### PR TITLE
Copy newline named headers to normal names

### DIFF
--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -1,1 +1,6 @@
-../libos/driver.h
+#pragma once
+#include "types.h"
+#include "caplib.h"
+
+int driver_spawn(const char *path, char *const argv[]);
+int driver_connect(int pid, exo_cap ep);

--- a/src-headers/libos/file.h
+++ b/src-headers/libos/file.h
@@ -1,1 +1,39 @@
-../libos/file.h
+#pragma once
+
+#include "include/exokernel.h"
+
+struct file {
+  enum { FD_NONE, FD_CAP } type;
+  size_t ref; // reference count
+  char readable;
+  char writable;
+  struct exo_blockcap cap; // backing storage capability
+  size_t off;
+};
+
+// in-memory copy of an inode
+struct inode {
+  uint dev;              // Device number
+  uint inum;             // Inode number
+  size_t ref;            // Reference count
+  struct sleeplock lock; // protects everything below here
+  int valid;             // inode has been read from disk?
+
+  short type; // copy of disk inode
+  short major;
+  short minor;
+  short nlink;
+  size_t size;
+  uint addrs[NDIRECT + 1];
+};
+
+// table mapping major device number to
+// device functions
+struct devsw {
+  int (*read)(struct inode *, char *, size_t);
+  int (*write)(struct inode *, char *, size_t);
+};
+
+extern struct devsw devsw[];
+
+#define CONSOLE 1

--- a/src-headers/libos/fs.h
+++ b/src-headers/libos/fs.h
@@ -1,1 +1,59 @@
-../libos/fs.h
+#pragma once
+
+// On-disk file system format.
+// Both the kernel and user programs use this header file.
+
+
+#define ROOTINO 1  // root i-number
+#define BSIZE 512  // block size
+
+// Disk layout:
+// [ boot block | super block | log | inode blocks |
+//                                          free bit map | data blocks]
+//
+// mkfs computes the super block and builds an initial file system. The
+// super block describes the disk layout:
+struct superblock {
+  uint size;         // Size of file system image (blocks)
+  uint nblocks;      // Number of data blocks
+  uint ninodes;      // Number of inodes.
+  uint nlog;         // Number of log blocks
+  uint logstart;     // Block number of first log block
+  uint inodestart;   // Block number of first inode block
+  uint bmapstart;    // Block number of first free map block
+};
+
+#define NDIRECT 12
+#define NINDIRECT (BSIZE / sizeof(uint))
+#define MAXFILE (NDIRECT + NINDIRECT*1024)
+
+// On-disk inode structure
+struct dinode {
+  short type;           // File type
+  short major;          // Major device number (T_DEV only)
+  short minor;          // Minor device number (T_DEV only)
+  short nlink;          // Number of links to inode in file system
+  uint size;            // Size of file (bytes)
+  uint addrs[NDIRECT+1];   // Data block addresses
+};
+
+// Inodes per block.
+#define IPB           (BSIZE / sizeof(struct dinode))
+
+// Block containing inode i
+#define IBLOCK(i, sb)     ((i) / IPB + sb.inodestart)
+
+// Bitmap bits per block
+#define BPB           (BSIZE*8)
+
+// Block of free map containing bit for block b
+#define BBLOCK(b, sb) (b/BPB + sb.bmapstart)
+
+// Directory is a file containing a sequence of dirent structures.
+#define DIRSIZ 14
+
+struct dirent {
+  ushort inum;
+  char name[DIRSIZ];
+};
+

--- a/src-headers/libos/libfs.h
+++ b/src-headers/libos/libfs.h
@@ -1,1 +1,9 @@
-../libos/libfs.h
+#pragma once
+#include "file.h"
+#include "fs.h"
+#include "include/exokernel.h"
+
+int fs_read_block(struct exo_blockcap cap, void *dst);
+int fs_write_block(struct exo_blockcap cap, const void *src);
+int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
+int fs_bind_block(struct exo_blockcap *cap, void *data, int write);

--- a/src-headers/libos/sched.h
+++ b/src-headers/libos/sched.h
@@ -1,1 +1,8 @@
-../libos/sched.h
+#pragma once
+#include "dag.h"
+
+static inline void dag_node_set_priority(struct dag_node *n, int priority) {
+  n->priority = priority;
+}
+
+void libos_setup_beatty_dag(void);

--- a/src-headers/libos/sleeplock.h
+++ b/src-headers/libos/sleeplock.h
@@ -1,1 +1,6 @@
-../libos/sleeplock.h
+#pragma once
+#include "spinlock.h"
+struct sleeplock { int locked; struct spinlock lk; };
+static inline void initsleeplock(struct sleeplock *lk, const char *name) { (void)lk; (void)name; }
+static inline void acquiresleep(struct sleeplock *lk) { (void)lk; }
+static inline void releasesleep(struct sleeplock *lk) { (void)lk; }

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -1,1 +1,11 @@
-../libos/spinlock.h
+#pragma once
+
+
+struct ticketlock {
+  _Atomic unsigned short head;
+  _Atomic unsigned short tail;
+};
+struct spinlock { struct ticketlock ticket; };
+static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
+static inline void acquire(struct spinlock *l) { (void)l; }
+static inline void release(struct spinlock *l) { (void)l; }


### PR DESCRIPTION
## Summary
- turn newline-suffixed header symlinks into regular files
- copy content from newline filename variants to files without newlines

## Testing
- `git status --short`