### PR TITLE
Implement JSON logging helper

### DIFF
--- a/README
+++ b/README
@@ -468,3 +468,16 @@ constant. The ``flow_pid.py`` helpers ``set_kp()``, ``set_ki()`` and
 
 For testing the base directory can be overridden with the environment
 variable ``FLOW_PID_DIR``.
+
+STREAMS LOGGING
+---------------
+Python STREAMS modules log messages using ``strlog_json()`` from
+``streams_log.py``.  The helper outputs a JSON object containing the
+timestamp, log level and message.  Extra keyword arguments become
+fields in the record.  ``strlog()`` continues to print plain text for
+older modules.
+
+Example::
+
+    from streams_log import strlog_json
+    strlog_json("info", "module loaded", name="xor_encrypt")

--- a/encrypt_mod.py
+++ b/encrypt_mod.py
@@ -1,4 +1,6 @@
 from stream_module import mblk_t
+from streams_log import strlog_json
+
 
 class XorEncryptModule:
     """Simple XOR encryption/decryption module."""
@@ -7,5 +9,14 @@ class XorEncryptModule:
         self.key = key & 0xFF
 
     def __call__(self, mblk: mblk_t) -> mblk_t:
+        """XOR each byte of the message and emit a log entry."""
+        before = bytes(mblk.data)
         mblk.data = bytearray(b ^ self.key for b in mblk.data)
+        strlog_json(
+            "debug",
+            "xor_encrypt",
+            key=self.key,
+            before=before.hex(),
+            after=bytes(mblk.data).hex(),
+        )
         return mblk

--- a/streams_log.py
+++ b/streams_log.py
@@ -1,0 +1,28 @@
+import json
+from datetime import datetime
+
+
+def strlog(message: str) -> None:
+    """Output a plain text log message."""
+    print(message)
+
+
+def strlog_json(level: str, message: str, **fields) -> None:
+    """Emit a structured log entry as JSON.
+
+    Parameters
+    ----------
+    level:
+        Severity of the message (e.g. "info", "error").
+    message:
+        Human readable log message.
+    **fields:
+        Additional keyword arguments are included in the output record.
+    """
+    record = {
+        "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "level": level,
+        "msg": message,
+    }
+    record.update(fields)
+    print(json.dumps(record))


### PR DESCRIPTION
## Summary
- add `streams_log.py` with `strlog_json`
- log encrypt module operations with structured JSON
- document STREAMS logging in README

## Testing
- `black --check --diff encrypt_mod.py streams_log.py`
- `flake8` *(fails: command not found)*