### PR TITLE
Improve typed channel docs and add runtime checks

### DIFF
--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -144,7 +144,20 @@ whenever the current task yields or no runnable work remains.
   structure defined in `ipc.h`.
 
 Typed channels built with the `CHAN_DECLARE` macro wrap these primitives
-and automatically serialize Cap'n Proto messages.
+and automatically serialize Cap'n Proto messages.  Each channel is
+backed by a `msg_type_desc` describing the size of the Cap'n Proto
+structure it transports.
+
+Schemas written in `.capnp` format are compiled with `capnp` to generate
+`<name>.capnp.h`.  The resulting header defines `type_MESSAGE_SIZE` as
+well as `type_encode()` and `type_decode()` helpers that translate
+between the C struct and its serialized form.
+
+The generic helpers `chan_endpoint_send()` and `chan_endpoint_recv()`
+verify that the buffer length matches the descriptor before invoking the
+underlying capability syscalls.  A mismatch causes the helpers to return
+`-1` (and the kernel variant prints a diagnostic), ensuring that only
+properly sized messages traverse the channel.
 
 The libOS builds higher level abstractions such as processes and files
 by combining these primitives.

--- a/src-kernel/chan.c
+++ b/src-kernel/chan.c
@@ -3,14 +3,28 @@
 
 // Kernel variant of chan_endpoint_send validating the message size
 int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-  if (!c || len != msg_desc_size(c->desc))
+  if (!c) {
+    cprintf("chan_endpoint_send: null channel\n");
     return -1;
+  }
+  size_t expected = msg_desc_size(c->desc);
+  if (len != expected) {
+    cprintf("chan_endpoint_send: size %d != %d\n", (int)len, (int)expected);
+    return -1;
+  }
   return exo_send(dest, msg, len);
 }
 
 // Kernel variant of chan_endpoint_recv validating the message size
 int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-  if (!c || len != msg_desc_size(c->desc))
+  if (!c) {
+    cprintf("chan_endpoint_recv: null channel\n");
     return -1;
+  }
+  size_t expected = msg_desc_size(c->desc);
+  if (len != expected) {
+    cprintf("chan_endpoint_recv: size %d != %d\n", (int)len, (int)expected);
+    return -1;
+  }
   return exo_recv(src, msg, len);
 }

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -22,16 +22,22 @@ chan_destroy(chan_t *c)
 int
 chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len)
 {
-    if(len != c->msg_size)
+    if(len != c->msg_size){
+        printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
+               (int)c->msg_size);
         return -1;
+    }
     return cap_send(dest, msg, c->msg_size);
 }
 
 int
 chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len)
 {
-    if(len != c->msg_size)
+    if(len != c->msg_size){
+        printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
+               (int)c->msg_size);
         return -1;
+    }
     return cap_recv(src, msg, c->msg_size);
 }
 

--- a/src-uland/user/typed_chan_demo.c
+++ b/src-uland/user/typed_chan_demo.c
@@ -17,10 +17,18 @@ main(int argc, char *argv[])
     ping_chan_recv(c, cap, &out);
     printf(1, "typed channel message %d\n", out.value);
 
-    // Demonstrate size validation by calling the generic endpoint helpers
+    // Demonstrate failure when message sizes do not match
     char bad[1] = {0};
     int r = chan_endpoint_send(&c->base, cap, bad, sizeof(bad));
     printf(1, "bad send result %d\n", r);
+    r = chan_endpoint_recv(&c->base, cap, bad, sizeof(bad));
+    printf(1, "bad recv result %d\n", r);
+
+    // Correct usage again
+    ping_chan_send(c, cap, &msg);
+    memset(&out, 0, sizeof(out));
+    ping_chan_recv(c, cap, &out);
+    printf(1, "typed channel message %d\n", out.value);
     ping_chan_destroy(c);
     exit();
 }


### PR DESCRIPTION
## Summary
- document typed channel workflow
- fail noisily when messages are the wrong size
- show typed channel failure and success in demo

## Testing
- `make check` *(fails: SyntaxError in simulate.py)*