### PR TITLE
Implement zone allocator with ID verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,8 @@ OBJS = \
     $(KERNEL_DIR)/chan.o \
     $(KERNEL_DIR)/dag_sched.o \
     $(KERNEL_DIR)/beatty_sched.o \
-    $(KERNEL_DIR)/beatty_dag_stream.o
+    $(KERNEL_DIR)/beatty_dag_stream.o \
+    $(KERNEL_DIR)/zone.o
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -102,6 +102,13 @@ void kfree(char *);
 void kinit1(void *, void *);
 void kinit2(void *, void *);
 
+// zone.c
+typedef struct zone zone_t;
+void zone_init(zone_t *z, size_t obj_size, char *name);
+void *zalloc(zone_t *z);
+void zfree(zone_t *z, void *ptr);
+void zone_dump(zone_t *z);
+
 // kbd.c
 void kbdintr(void);
 

--- a/src-kernel/zone.c
+++ b/src-kernel/zone.c
@@ -1,0 +1,97 @@
+#include "zone.h"
+#include "defs.h"
+#include "mmu.h"
+#include "memlayout.h"
+
+static int next_zone_id = 1;
+
+void
+zone_init(zone_t *z, size_t obj_size, char *name)
+{
+  initlock(&z->lock, name);
+  z->obj_size = obj_size;
+  z->slabs = 0;
+  z->zone_id = __sync_fetch_and_add(&next_zone_id, 1);
+}
+
+static struct slab*
+new_slab(zone_t *z)
+{
+  struct slab *s = (struct slab*)kalloc();
+  if(!s)
+    return 0;
+  s->zone = z;
+  s->zone_id = z->zone_id;
+  s->inuse = 0;
+  s->next = z->slabs;
+  z->slabs = s;
+
+  s->free = 0;
+  size_t hdr = sizeof(struct slab);
+  size_t objsz = sizeof(struct zone_obj) + z->obj_size;
+  int n = (PGSIZE - hdr) / objsz;
+  char *p = (char*)s + hdr;
+  for(int i=0;i<n;i++){
+    struct zone_obj *o = (struct zone_obj*)p;
+    o->zone_id = z->zone_id;
+    o->next = s->free;
+    s->free = o;
+    p += objsz;
+  }
+  return s;
+}
+
+void *
+zalloc(zone_t *z)
+{
+  acquire(&z->lock);
+  struct slab *s;
+  for(s = z->slabs; s; s = s->next){
+    if(s->free)
+      break;
+  }
+  if(!s){
+    s = new_slab(z);
+    if(!s){
+      release(&z->lock);
+      return 0;
+    }
+  }
+  struct zone_obj *o = s->free;
+  s->free = o->next;
+  s->inuse++;
+  release(&z->lock);
+  o->zone_id = z->zone_id;
+  return (void*)(o + 1);
+}
+
+void
+zfree(zone_t *z, void *ptr)
+{
+  if(!ptr)
+    return;
+  struct zone_obj *o = ((struct zone_obj*)ptr) - 1;
+  struct slab *s = (struct slab*)((uintptr_t)o & ~(PGSIZE-1));
+  if(s->zone_id != z->zone_id || o->zone_id != z->zone_id){
+    zone_dump(z);
+    panic("zone_id mismatch");
+  }
+
+  acquire(&z->lock);
+  o->next = s->free;
+  s->free = o;
+  s->inuse--;
+  release(&z->lock);
+}
+
+void
+zone_dump(zone_t *z)
+{
+  cprintf("zone %d size %d\n", z->zone_id, (int)z->obj_size);
+  for(struct slab *s = z->slabs; s; s = s->next){
+    int free = 0;
+    for(struct zone_obj *o = s->free; o; o = o->next)
+      free++;
+    cprintf(" slab %p id %d inuse %d free %d\n", s, s->zone_id, s->inuse, free);
+  }
+}

--- a/src-kernel/zone.h
+++ b/src-kernel/zone.h
@@ -1,0 +1,35 @@
+#ifndef ZONE_H
+#define ZONE_H
+
+#include "spinlock.h"
+#include <stddef.h>
+
+struct zone;
+
+// Header stored before each allocated object
+struct zone_obj {
+  struct zone_obj *next;
+  int zone_id;
+};
+
+struct slab {
+  struct slab *next;
+  struct zone *zone;
+  int zone_id;
+  struct zone_obj *free;
+  int inuse;
+};
+
+typedef struct zone {
+  struct spinlock lock;
+  size_t obj_size;
+  int zone_id;
+  struct slab *slabs;
+} zone_t;
+
+void zone_init(zone_t *z, size_t obj_size, char *name);
+void *zalloc(zone_t *z);
+void zfree(zone_t *z, void *ptr);
+void zone_dump(zone_t *z);
+
+#endif // ZONE_H

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -1,0 +1,75 @@
+import subprocess
+import tempfile
+import pathlib
+import textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE_TEMPLATE = textwrap.dedent("""
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+// stub implementations expected by zone.c
+static void initlock(struct spinlock *lk, char *name){ (void)lk; (void)name; }
+static void acquire(struct spinlock *lk){ (void)lk; }
+static void release(struct spinlock *lk){ (void)lk; }
+static int holding(struct spinlock *lk){ (void)lk; return 0; }
+struct cpu; static struct cpu* mycpu(void){ return 0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; exit(1); }
+static void cprintf(const char *fmt, ...){ (void)fmt; }
+#define PGSIZE 4096
+static void *kalloc(void){ void *p; if(posix_memalign(&p, PGSIZE, PGSIZE)!=0) return NULL; return p; }
+static void kfree(char *p){ free(p); }
+
+#include "src-kernel/zone.c"
+
+int main(void) {
+%s
+}
+""")
+
+SUCCESS_BODY = """
+    zone_t z; zone_init(&z, sizeof(int), "z");
+    int *a = (int*)zalloc(&z);
+    *a = 123;
+    zfree(&z, a);
+    return 0;
+"""
+
+FAIL_BODY = """
+    zone_t a; zone_init(&a, sizeof(int), "a");
+    zone_t b; zone_init(&b, sizeof(int), "b");
+    int *x = (int*)zalloc(&a);
+    zfree(&b, x);
+    return 0;
+"""
+
+
+def compile_and_run(body):
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE_TEMPLATE % body)
+        # stub headers expected by zone.c
+        (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock {int dummy;};")
+        (pathlib.Path(td)/"defs.h").write_text("")
+        (pathlib.Path(td)/"mmu.h").write_text("#define PGSIZE 4096")
+        (pathlib.Path(td)/"memlayout.h").write_text("")
+        subprocess.check_call([
+            "gcc","-std=c11",
+            "-I", str(td),
+            "-I", str(ROOT),
+            str(src),
+            "-o", str(exe)
+        ])
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_zone_basic():
+    assert compile_and_run(SUCCESS_BODY) == 0
+
+
+def test_zone_mismatch():
+    assert compile_and_run(FAIL_BODY) != 0


### PR DESCRIPTION
## Summary
- add a slab-based zone allocator (`zone.c`, `zone.h`)
- expose zone APIs in `defs.h` and compile it in the kernel
- include the allocator in the build
- test zone allocation and mismatched frees

## Testing
- `pytest -q tests/test_zone.py`