### PR TITLE
Fix apt pinning logic in setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ pip_install(){
 apt_pin_install(){
   pkg="$1"
   ver=$(apt-cache show "$pkg" 2>/dev/null \
-        | awk '/^Version:/{print $2; exit}')
+        | awk '/^Version:/{print $2; exit}' || true)
   if [ -n "$ver" ]; then
     if ! apt-get install -y "${pkg}=${ver}"; then
       echo "Warning: apt-get install ${pkg}=${ver} failed" >&2


### PR DESCRIPTION
## Summary
- avoid early failure in setup script when `apt-cache show` fails by ignoring the error

## Testing
- `make check` *(fails: SyntaxError in tests)*