### PR TITLE
Add basic IOMMU support

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -278,5 +278,11 @@ void rcu_read_lock(void);
 void rcu_read_unlock(void);
 void rcu_synchronize(void);
 
+// iommu.c
+int iommu_map(struct iommu_dom *, uintptr_t, uintptr_t, size_t, int);
+int iommu_unmap(struct iommu_dom *, uintptr_t, size_t);
+void iommu_sync(struct iommu_dom *);
+void iommu_revoke(struct iommu_dom *);
+
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))

--- a/src-headers/iommu.h
+++ b/src-headers/iommu.h
@@ -1,0 +1,33 @@
+#pragma once
+#include <stddef.h>
+#include <stdint.h>
+#define IOMMU_PTE_P 0x1
+
+typedef uint64_t iommu_pte_t;
+
+struct iommu_dom {
+    iommu_pte_t *pt;
+    size_t npages;
+};
+
+#define IOMMU_OP_MAP    0xA0
+#define IOMMU_OP_UNMAP  0xA1
+#define IOMMU_OP_REVOKE 0xA2
+
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa,
+              size_t len, int perm);
+int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len);
+void iommu_sync(struct iommu_dom *dom);
+void iommu_revoke(struct iommu_dom *dom);
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int iommu_map_call(uintptr_t iova, uintptr_t pa, size_t len);
+int iommu_unmap_call(uintptr_t iova, size_t len);
+int iommu_revoke_call(void);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-kernel/iommu.c
+++ b/src-kernel/iommu.c
@@ -1,0 +1,58 @@
+#include "iommu.h"
+#include "defs.h"
+#include "mmu.h"
+#include <stdint.h>
+#include <string.h>
+
+int
+iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa,
+          size_t len, int perm)
+{
+    if(!dom || !dom->pt || (iova % PGSIZE) || (pa % PGSIZE) ||
+       (len % PGSIZE))
+        return -1;
+    size_t pages = len / PGSIZE;
+    for(size_t i = 0; i < pages; i++){
+        size_t idx = (iova / PGSIZE) + i;
+        if(idx >= dom->npages)
+            return -1;
+        if(dom->pt[idx] & IOMMU_PTE_P)
+            return -1;
+        dom->pt[idx] = (pa + i*PGSIZE) | perm | IOMMU_PTE_P;
+    }
+    iommu_sync(dom);
+    return 0;
+}
+
+int
+iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len)
+{
+    if(!dom || !dom->pt || (iova % PGSIZE) || (len % PGSIZE))
+        return -1;
+    size_t pages = len / PGSIZE;
+    for(size_t i = 0; i < pages; i++){
+        size_t idx = (iova / PGSIZE) + i;
+        if(idx >= dom->npages || !(dom->pt[idx] & IOMMU_PTE_P))
+            return -1;
+        dom->pt[idx] = 0;
+    }
+    iommu_sync(dom);
+    return 0;
+}
+
+void
+iommu_sync(struct iommu_dom *dom)
+{
+    (void)dom;
+    // In hardware this would flush IOTLB; no-op in mock implementation.
+}
+
+void
+iommu_revoke(struct iommu_dom *dom)
+{
+    if(!dom || !dom->pt)
+        return;
+    for(size_t i = 0; i < dom->npages; i++)
+        dom->pt[i] = 0;
+    iommu_sync(dom);
+}

--- a/src-uland/iommu.c
+++ b/src-uland/iommu.c
@@ -1,0 +1,34 @@
+#include "iommu.h"
+#include "ipc.h"
+
+int
+iommu_map_call(uintptr_t iova, uintptr_t pa, size_t len)
+{
+    zipc_msg_t m = {0};
+    m.w0 = IOMMU_OP_MAP;
+    m.w1 = iova;
+    m.w2 = pa;
+    m.w3 = len;
+    zipc_call(&m);
+    return (int)m.w0;
+}
+
+int
+iommu_unmap_call(uintptr_t iova, size_t len)
+{
+    zipc_msg_t m = {0};
+    m.w0 = IOMMU_OP_UNMAP;
+    m.w1 = iova;
+    m.w2 = len;
+    zipc_call(&m);
+    return (int)m.w0;
+}
+
+int
+iommu_revoke_call(void)
+{
+    zipc_msg_t m = {0};
+    m.w0 = IOMMU_OP_REVOKE;
+    zipc_call(&m);
+    return (int)m.w0;
+}

--- a/tests/test_iommu.py
+++ b/tests/test_iommu.py
@@ -1,0 +1,65 @@
+import subprocess, tempfile, pathlib, textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent("""
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+
+#define PGSIZE 4096
+#include "src-headers/iommu.h"
+
+struct spinlock { int dummy; };
+struct cpu; static struct cpu* mycpu(void){ return 0; }
+static void initlock(struct spinlock *l, char *n){ (void)l;(void)n; }
+static void acquire(struct spinlock *l){ (void)l; }
+static void release(struct spinlock *l){ (void)l; }
+static int holding(struct spinlock *l){ (void)l; return 0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; assert(0); }
+static void cprintf(const char *f, ...){ (void)f; }
+#include "src-kernel/iommu.c"
+
+int main(void){
+    uint64_t tbl[8];
+    struct iommu_dom d = { tbl, 8 };
+    memset(tbl,0,sizeof(tbl));
+    assert(iommu_map(&d, 0, 0x1000, PGSIZE, 0) == 0);
+    assert(tbl[0] == (0x1000 | IOMMU_PTE_P));
+    assert(iommu_unmap(&d, 0, PGSIZE) == 0);
+    assert(tbl[0] == 0);
+    iommu_map(&d, 0, 0x2000, PGSIZE, 0);
+    iommu_revoke(&d);
+    for(int i=0;i<8;i++) assert(tbl[i]==0);
+    return 0;
+}
+""")
+
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        src.write_text(C_CODE)
+        # stub headers expected by iommu.c
+        (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock{int d;};")
+        (pathlib.Path(td)/"defs.h").write_text("")
+        (pathlib.Path(td)/"mmu.h").write_text("#define PGSIZE 4096")
+        (pathlib.Path(td)/"memlayout.h").write_text("")
+        (pathlib.Path(td)/"types.h").write_text("typedef unsigned int uint;\ntypedef unsigned short ushort;\ntypedef unsigned char uchar;\ntypedef unsigned long long uint64;")
+        (pathlib.Path(td)/"stdint.h").write_text(
+            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif")
+        exe = pathlib.Path(td)/"test"
+        subprocess.check_call([
+            "gcc","-std=c11",
+            "-I", str(td),
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_iommu_basic():
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- introduce `iommu.h` with simple domain structure and opcodes
- implement `iommu_map`, `iommu_unmap`, `iommu_sync` and `iommu_revoke`
- add user-level wrappers for IOMMU opcodes
- expose IOMMU API via `defs.h`
- test mapping, unmapping and revoke behaviour

## Testing
- `pytest tests/test_iommu.py -q`