### PR TITLE
Fix simulation harness and unit test

### DIFF
--- a/simulate.py
+++ b/simulate.py
@@ -1,30 +1,8 @@
 """Simulation harness for xv6 testing.
 
-
-
-The harness boots xv6 under QEMU and executes a short command
-sequence so automated tests can verify that the kernel image boots
-successfully.  The QEMU binary and image paths may be overridden via
-environment variables.  When tests run they set ``QEMU=/bin/true`` so
-the harness exits immediately without launching an emulator.
 Boot xv6 under QEMU and return the emulator's exit status. The QEMU
 binary and disk image paths can be overridden via environment
 variables. The harness is primarily used by the automated test suite.
-
-
-The original placeholder merely returned success. The harness now
-invokes QEMU to boot the xv6 kernel and issues a trivial command
-sequence to ensure the guest is operational. The exit status from
-QEMU is propagated so CI runs can detect boot failures.
-
-This module's :func:`main` entry point boots xv6 under QEMU, runs a
-short command sequence and returns the emulator's exit status. It is
-intentionally minimal and primarily used by the automated test suite.
-The QEMU binary and image paths can be overridden through environment
-variables. When running under the tests the ``QEMU`` variable is set
-to ``/bin/true`` so the harness completes instantly without launching
-an emulator.
-
 """
 
 from __future__ import annotations
@@ -39,6 +17,7 @@ SCRIPT = "echo booted;\n\x01x"
 DEFAULT_DISK = "xv6-64.img"
 DEFAULT_FS = "fs64.img"
 
+
 def _find_qemu() -> Optional[str]:
     """Return the first available QEMU binary or ``None``."""
     for binary in ("qemu-system-x86_64", "qemu-system-i386", "qemu"):
@@ -48,30 +27,14 @@ def _find_qemu() -> Optional[str]:
     return None
 
 
-import os
-import subprocess
-from pathlib import Path
-
-DEFAULT_QEMU = "qemu-system-x86_64"
-DEFAULT_DISK = "xv6-64.img"
-DEFAULT_FS = "fs64.img"
-
-SCRIPT = "echo booted;\n\x01x"
-
-def main() -> int:
-    """Boot xv6 under QEMU and return the emulator's exit status."""
-
-    qemu = os.environ.get("QEMU", DEFAULT_QEMU)=======
 def main() -> int:
     """Boot xv6 under QEMU and return the emulator's exit status."""
 
     qemu = os.environ.get("QEMU") or _find_qemu()
     if not qemu:
-        pr of int("QEMU not found; cannot run simulation")
+        print("QEMU not found; cannot run simulation")
         return 1
 
-
-      
     disk = Path(os.environ.get("XV6_IMG", DEFAULT_DISK))
     fsimg = Path(os.environ.get("FS_IMG", DEFAULT_FS))
 

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -1,56 +1,57 @@
-import pathlib import subprocess import tempfile import textwrap
+import pathlib
+import subprocess
+import tempfile
+import textwrap
 
-    C_CODE = textwrap.dedent(""
-                             "
-#include <assert.h>
-#include <stddef.h>
+C_CODE = textwrap.dedent(
+    """
+    #include <assert.h>
+    #include <stddef.h>
 
-                             typedef struct {unsigned int id;
-}
-exo_cap;
-typedef struct {
-  size_t msg_size;
-} msg_type_desc;
-typedef struct {
-  size_t msg_size;
-  const msg_type_desc *desc;
-} chan_t;
+    typedef struct { unsigned int id; } exo_cap;
+    typedef struct {
+      size_t msg_size;
+    } msg_type_desc;
+    typedef struct {
+      size_t msg_size;
+      const msg_type_desc *desc;
+    } chan_t;
 
-int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-  (void)dest;
-  if (!c || len != c->msg_size)
-    return -1;
-  return 0;
-}
-int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-  (void)src;
-  (void)msg;
-  if (!c || len != c->msg_size)
-    return -1;
-  return 0;
-}
+    int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
+      (void)dest;
+      if (!c || len != c->msg_size)
+        return -1;
+      return 0;
+    }
+    int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
+      (void)src;
+      (void)msg;
+      if (!c || len != c->msg_size)
+        return -1;
+      return 0;
+    }
 
-int main(void) {
-  msg_type_desc d = {sizeof(int)};
-  chan_t c = {d.msg_size, &d};
-  int m = 5;
-  assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
-  unsigned char bad = 0;
-  assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
-  return 0;
-}
+    int main(void) {
+      msg_type_desc d = {sizeof(int)};
+      chan_t c = {d.msg_size, &d};
+      int m = 5;
+      assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
+      unsigned char bad = 0;
+      assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
+      return 0;
+    }
     """
 )
 
 
-def compile_and_run():
+def compile_and_run() -> None:
     with tempfile.TemporaryDirectory() as td:
-        src = pathlib.Path(td)/"test.c"
-        exe = pathlib.Path(td)/"test"
+        src = pathlib.Path(td) / "test.c"
+        exe = pathlib.Path(td) / "test"
         src.write_text(C_CODE)
         subprocess.check_call(["gcc", "-std=c11", str(src), "-o", str(exe)])
         subprocess.check_call([str(exe)])
 
 
-def test_chan_endpoint_validation():
+def test_chan_endpoint_validation() -> None:
     compile_and_run()


### PR DESCRIPTION
## Summary
- clean up `simulate.py` harness implementation
- rebuild `tests/test_chan_endpoint.py` to valid Python

## Testing
- `make check` *(fails: subprocess.CalledProcessError in tests)*