### PR TITLE
Fix duplicate test name

### DIFF
--- a/tests/test_simulate.py
+++ b/tests/test_simulate.py
@@ -19,7 +19,7 @@ def test_simulate_harness_completes():
     ):
         pytest.skip("QEMU not installed")
 
-def test_simulate_harness_completes(monkeypatch):
+def test_simulate_harness_runs(monkeypatch):
     monkeypatch.setenv("QEMU", "/bin/true")
 
     assert simulate.main() == 0


### PR DESCRIPTION
## Summary
- rename second test in `tests/test_simulate.py` so each test has a unique name

## Testing
- `pre-commit` *(fails: command not found)*
- `pytest -k test_simulate` *(fails: SyntaxError in unrelated test files)*