### PR TITLE
Fix corrupted tests

### DIFF
--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -1,10 +1,12 @@
-import subprocess, tempfile, pathlib, textwrap
-
+import subprocess
+import tempfile
+import pathlib
+import textwrap
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-C_CODE = textwrap.dedent("""
-
+C_CODE = textwrap.dedent(
+    """
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
@@ -33,15 +35,9 @@ int main(void){
     assert(cap_revoke(id) == -1);
     return 0;
 }
-""")
+"""
+)
 
-
-#include <stdint.h>
-typedef unsigned short uint16_t;
-#include "src-headers/caplib.h"
-int cap_revoke(void){ return 0; }
-int main(void){ return cap_revoke(); }
-""")
 
 def compile_and_run():
     with tempfile.TemporaryDirectory() as td:
@@ -50,11 +46,14 @@ def compile_and_run():
         (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock{int d;};")
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text("typedef unsigned int uint;\n"\
-                                               "typedef unsigned short ushort;\n"\
-                                               "typedef unsigned char uchar;\n")
+        (pathlib.Path(td)/"types.h").write_text(
+            "typedef unsigned int uint;\n"
+            "typedef unsigned short ushort;\n"
+            "typedef unsigned char uchar;\n"
+        )
         (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif")
+            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
+        )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
             "gcc","-std=c11",
@@ -69,17 +68,6 @@ def compile_and_run():
 
 def test_cap_epoch_wrap():
     assert compile_and_run() == 0
-        (pathlib.Path(td)/"include").mkdir()
-        (pathlib.Path(td)/"include"/"exokernel.h").write_text("\n")
-        exe = pathlib.Path(td)/"test"
-        subprocess.check_call([
-            "gcc","-std=c11",
-            "-I", str(ROOT),
-            "-I", str(ROOT/"src-headers"),
-            "-I", str(td),
-            str(src), "-o", str(exe)
-        ])
-        subprocess.check_call([str(exe)])
 
 
 def test_cap_revoke_call():

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -1,4 +1,7 @@
-import pathlib, subprocess, tempfile, textwrap
+import pathlib
+import subprocess
+import tempfile
+import textwrap
 
 C_CODE = textwrap.dedent(
     """
@@ -37,49 +40,7 @@ int main(void) {
   assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
   return 0;
 }
-import pathlib
-import subprocess
-import tempfile
-import textwrap
-
-C_CODE = textwrap.dedent(
-    """
-    #include <assert.h>
-    #include <stddef.h>
-
-    typedef struct { unsigned int id; } exo_cap;
-    typedef struct {
-      size_t msg_size;
-    } msg_type_desc;
-    typedef struct {
-      size_t msg_size;
-      const msg_type_desc *desc;
-    } chan_t;
-
-    int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-      (void)dest;
-      if (!c || len != c->msg_size)
-        return -1;
-      return 0;
-    }
-    int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-      (void)src;
-      (void)msg;
-      if (!c || len != c->msg_size)
-        return -1;
-      return 0;
-    }
-
-    int main(void) {
-      msg_type_desc d = {sizeof(int)};
-      chan_t c = {d.msg_size, &d};
-      int m = 5;
-      assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
-      unsigned char bad = 0;
-      assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
-      return 0;
-    }
-    """
+"""
 )
 
 


### PR DESCRIPTION
## Summary
- deduplicate the channel endpoint test and close its C snippet
- remove stray snippet in `test_cap_revoke.py`
- keep one helper and two cap revoke tests

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError in several tests)*