### PR TITLE
Fix indentation in revoke test

### DIFF
--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -71,4 +71,4 @@ def test_cap_epoch_wrap():
 
 
 def test_cap_revoke_call():
-    compile_and_run()
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- fix indentation in `test_cap_revoke.py`
- end both tests with assertions

## Testing
- `make check` *(fails: SyntaxError in tests/test_chan_endpoint.py)*
- `pytest -q tests/test_cap_revoke.py` *(fails: gcc compilation error due to header issues)*