### PR TITLE
Configure Python hooks for linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,12 +26,14 @@ repos:
     - id: black
       name: black
       entry: black --check --diff
-      language: system
+      language: python
+      additional_dependencies: [black==25.1.0]
       types: [python]
     - id: flake8
       name: flake8
       entry: flake8
-      language: system
+      language: python
+      additional_dependencies: [flake8==6.1.0]
       types: [python]
 
 - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
## Summary
- run `black` and `flake8` via pre-commit's Python environment
- pin versions for both tools

## Testing
- `pre-commit run --files .pre-commit-config.yaml README` *(fails: `pre-commit: command not found`)*