### PR TITLE
Improve apt_pin_install offline check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,10 @@ pip_install(){
 }
 apt_pin_install(){
   pkg="$1"
+  if [ "$NETWORK_AVAILABLE" != true ]; then
+    echo "Skipping apt-get install of $pkg due to offline mode" >&2
+    return 0
+  fi
   ver=$(apt-cache show "$pkg" 2>/dev/null \
         | awk '/^Version:/{print $2; exit}' || true)
   if [ -n "$ver" ]; then


### PR DESCRIPTION
## Summary
- handle offline mode in `apt_pin_install` inside `setup.sh`

## Testing
- `bash -n setup.sh`
- `make check` *(fails: SyntaxError in tests)*