### PR TITLE
Add clang-tidy-cpp17 config

### DIFF
--- a/.clang-tidy-cpp17
+++ b/.clang-tidy-cpp17
@@ -1,0 +1,4 @@
+Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
+WarningsAsErrors: ''
+HeaderFilterRegex: '.*'
+FormatStyle: file


### PR DESCRIPTION
## Summary
- add `.clang-tidy-cpp17` identical to the C++23 config

## Testing
- `pytest -q` *(fails: SyntaxError during test collection)*