### PR TITLE
Update setup apt skip warning

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -26,7 +26,7 @@ pip_install(){
 apt_pin_install(){
   pkg="$1"
   if [ "$NETWORK_AVAILABLE" != true ]; then
-    echo "Skipping apt-get install of $pkg due to offline mode" >&2
+    echo "Warning: network unavailable, skipping apt-get install of $pkg" >&2
     return 0
   fi
   ver=$(apt-cache show "$pkg" 2>/dev/null \


### PR DESCRIPTION
## Summary
- tweak apt installer to warn when offline mode prevents apt install

## Testing
- `make check` *(fails: SyntaxError in tests/test_chan_endpoint.py)*
