### PR TITLE
Implement door IPC primitive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,6 +329,7 @@ LIBOS_OBJS = \
         $(ULAND_DIR)/swtch.o \
         $(ULAND_DIR)/caplib.o \
         $(ULAND_DIR)/chan.o \
+        $(ULAND_DIR)/door.o \
         proto/driver.capnp.o \
         $(ULAND_DIR)/math_core.o \
        $(ULAND_DIR)/libos/sched.o \

--- a/src-headers/door.h
+++ b/src-headers/door.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "ipc.h"
+#include "caplib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct door {
+    exo_cap dest;
+    void (*handler)(zipc_msg_t *msg);
+    int is_local;
+} door_t;
+
+door_t door_create_local(void (*handler)(zipc_msg_t *msg));
+door_t door_create_remote(exo_cap dest);
+int door_call(door_t *d, zipc_msg_t *msg);
+void door_server_loop(door_t *d);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-uland/door.c
+++ b/src-uland/door.c
@@ -1,0 +1,47 @@
+#include "door.h"
+#include <string.h>
+
+static void clear_cap(exo_cap *c) {
+    memset(c, 0, sizeof(*c));
+}
+
+door_t door_create_local(void (*handler)(zipc_msg_t *msg)) {
+    door_t d;
+    clear_cap(&d.dest);
+    d.handler = handler;
+    d.is_local = 1;
+    return d;
+}
+
+door_t door_create_remote(exo_cap dest) {
+    door_t d;
+    d.dest = dest;
+    d.handler = 0;
+    d.is_local = 0;
+    return d;
+}
+
+int door_call(door_t *d, zipc_msg_t *msg) {
+    if (!d)
+        return -1;
+    if (d->is_local) {
+        if (d->handler)
+            d->handler(msg);
+        return 0;
+    }
+    if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
+        return -1;
+    return cap_recv(d->dest, msg, sizeof(*msg));
+}
+
+void door_server_loop(door_t *d) {
+    if (!d || !d->handler)
+        return;
+    while (1) {
+        zipc_msg_t msg;
+        if (cap_recv(d->dest, &msg, sizeof(msg)) < 0)
+            continue;
+        d->handler(&msg);
+        cap_send(d->dest, &msg, sizeof(msg));
+    }
+}

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -8,75 +8,34 @@ C_CODE = textwrap.dedent(
 #include <assert.h>
 #include <stddef.h>
 
-typedef struct {unsigned int id;} exo_cap;
-typedef struct {
-  size_t msg_size;
-} msg_type_desc;
-typedef struct {
-  size_t msg_size;
-  const msg_type_desc *desc;
-} chan_t;
+typedef struct { unsigned int id; } exo_cap;
+typedef struct { size_t msg_size; } msg_type_desc;
+typedef struct { size_t msg_size; const msg_type_desc *desc; } chan_t;
 
 int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-  (void)dest;
-  if (!c || len != c->msg_size)
-    return -1;
-  return 0;
+    (void)dest;
+    if (!c || len != c->msg_size)
+        return -1;
+    return 0;
 }
 int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-  (void)src;
-  (void)msg;
-  if (!c || len != c->msg_size)
-    return -1;
-  return 0;
+    (void)src;
+    (void)msg;
+    if (!c || len != c->msg_size)
+        return -1;
+    return 0;
 }
 
 int main(void) {
-  msg_type_desc d = {sizeof(int)};
-  chan_t c = {d.msg_size, &d};
-  int m = 5;
-  assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
-  unsigned char bad = 0;
-  assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
-  return 0;
+    msg_type_desc d = {sizeof(int)};
+    chan_t c = {d.msg_size, &d};
+    int m = 5;
+    assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
+    unsigned char bad = 0;
+    assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
+    return 0;
 }
 """
-    #include <assert.h>
-    #include <stddef.h>
-
-    typedef struct { unsigned int id; } exo_cap;
-    typedef struct {
-        size_t msg_size;
-    } msg_type_desc;
-    typedef struct {
-        size_t msg_size;
-        const msg_type_desc *desc;
-    } chan_t;
-
-    int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-        (void)dest;
-        if (!c || len != c->msg_size)
-            return -1;
-        return 0;
-    }
-    int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-        (void)src;
-        (void)msg;
-        if (!c || len != c->msg_size)
-            return -1;
-        return 0;
-    }
-
-    int main(void) {
-        msg_type_desc d = {sizeof(int)};
-        chan_t c = {d.msg_size, &d};
-        int m = 5;
-        assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
-        unsigned char bad = 0;
-        assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
-        return 0;
-    }
-    """
 )
 
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -1,0 +1,57 @@
+import pathlib
+import subprocess
+import tempfile
+import textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent(
+    """
+#include <assert.h>
+#include <stdint.h>
+#include "src-headers/door.h"
+
+// minimal stub definitions for exo types and caplib helpers
+typedef struct { unsigned pa, id, rights, owner; unsigned long long tag[4]; } exo_cap;
+int cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return 0; }
+int cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return 0; }
+
+static int called = 0;
+static void handler(zipc_msg_t *m) { called++; m->w0++; }
+
+int main(void) {
+    door_t d = door_create_local(handler);
+    zipc_msg_t m = {0, 41, 0, 0, 0};
+    assert(door_call(&d, &m) == 0);
+    assert(called == 1);
+    assert(m.w0 == 42);
+    return 0;
+}
+"""
+)
+
+
+def compile_and_run() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td) / "test.c"
+        exe = pathlib.Path(td) / "test"
+        src.write_text(C_CODE)
+        subprocess.check_call(
+            [
+                "gcc",
+                "-std=c11",
+                "-I",
+                str(ROOT),
+                "-I",
+                str(ROOT / "src-headers"),
+                str(src),
+                str(ROOT / "src-uland/door.c"),
+                "-o",
+                str(exe),
+            ]
+        )
+        subprocess.check_call([str(exe)])
+
+
+def test_door_call() -> None:
+    compile_and_run()


### PR DESCRIPTION
## Summary
- add simple door IPC primitives in `door.h` and `door.c`
- compile new door library in libos build
- fix `test_chan_endpoint.py`
- add `test_door.py` exercising local door calls

## Testing
- `black tests/test_door.py tests/test_chan_endpoint.py`
- `pytest -q` *(fails: CalledProcessError, missing headers and compile errors)*