### PR TITLE
Update C standard setting

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ QEMU := $(shell which qemu-system-aarch64 2>/dev/null || \
 endif
 
 ARCH ?= x86_64
-CSTD ?= gnu2x
+CSTD ?= c23
 CLANG_TIDY ?= clang-tidy
 TIDY_SRCS := $(wildcard $(KERNEL_DIR)/*.c $(ULAND_DIR)/*.c $(LIBOS_DIR)/*.c)
 


### PR DESCRIPTION
## Summary
- switch Makefile's C standard from gnu2x to c23

## Testing
- `make ARCH=x86_64 TOOLPREFIX=x86_64-linux-gnu-` *(fails: unrecognized `-std=c23`)*
- `make ARCH=aarch64 TOOLPREFIX=aarch64-linux-gnu-` *(fails: missing `aarch64-linux-gnu-gcc`)*