### PR TITLE
Add asm_common header and macros

### DIFF
--- a/src-kernel/arch/asm_common.h
+++ b/src-kernel/arch/asm_common.h
@@ -1,0 +1,30 @@
+#pragma once
+
+// Common assembly macros for boot/entry code
+
+// Enable the A20 line so the CPU can access >1MB memory
+#define ENABLE_A20 \
+1: inb $0x64, %al; testb $0x2, %al; jnz 1b; \
+   movb $0xd1, %al; outb %al, $0x64; \
+2: inb $0x64, %al; testb $0x2, %al; jnz 2b; \
+   movb $0xdf, %al; outb %al, $0x60
+
+// Load GDT and enable protected mode, then jump to the given label
+#define SETUP_PROT_MODE(gdt, sel, label) \
+    lgdt gdt; \
+    movl %cr0, %eax; \
+    orl $CR0_PE, %eax; \
+    movl %eax, %cr0; \
+    ljmp $(sel), $label
+
+// Initialize data segment registers after entering protected mode
+#define INIT_PROT_MODE_DATA(sel) \
+    movw $(sel), %ax; \
+    movw %ax, %ds; \
+    movw %ax, %es; \
+    movw %ax, %ss; \
+    movw $0, %ax; \
+    movw %ax, %fs; \
+    movw %ax, %gs
+
+

--- a/src-kernel/arch/x64/bootasm64.S
+++ b/src-kernel/arch/x64/bootasm64.S
@@ -1,6 +1,7 @@
 #include "asm.h"
 #include "memlayout.h"
 #include "mmu.h"
+#include "../asm_common.h"
 
 #define CR4_PAE 0x00000020
 
@@ -17,35 +18,14 @@ start:
     movw %ax,%es
     movw %ax,%ss
 
-# Enable A20
-seta20.1:
-    inb $0x64,%al
-    testb $0x2,%al
-    jnz seta20.1
-    movb $0xd1,%al
-    outb %al,$0x64
-seta20.2:
-    inb $0x64,%al
-    testb $0x2,%al
-    jnz seta20.2
-    movb $0xdf,%al
-    outb %al,$0x60
+    # Enable access to memory above 1MB
+    ENABLE_A20
 
-    lgdt gdtdesc32
-    movl %cr0,%eax
-    orl $CR0_PE,%eax
-    movl %eax,%cr0
-    ljmp $(1<<3), $prot32
+    SETUP_PROT_MODE(gdtdesc32, 1<<3, prot32)
 
 .code32
 prot32:
-    movw $(2<<3), %ax
-    movw %ax,%ds
-    movw %ax,%es
-    movw %ax,%ss
-    movw $0,%ax
-    movw %ax,%fs
-    movw %ax,%gs
+    INIT_PROT_MODE_DATA(2<<3)
 
     lgdt gdtdesc64
 

--- a/src-kernel/arch/x64/entryother64.S
+++ b/src-kernel/arch/x64/entryother64.S
@@ -2,6 +2,7 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "param.h"
+#include "../asm_common.h"
 
 #define CR4_PAE 0x00000020
 
@@ -16,21 +17,11 @@ start:
     movw %ax,%es
     movw %ax,%ss
 
-    lgdt gdtdesc32
-    movl %cr0,%eax
-    orl $CR0_PE,%eax
-    movl %eax,%cr0
-    ljmp $(1<<3), $prot32
+    SETUP_PROT_MODE(gdtdesc32, 1<<3, prot32)
 
 .code32
 prot32:
-    movw $(2<<3), %ax
-    movw %ax,%ds
-    movw %ax,%es
-    movw %ax,%ss
-    movw $0,%ax
-    movw %ax,%fs
-    movw %ax,%gs
+    INIT_PROT_MODE_DATA(2<<3)
 
     lgdt gdtdesc64
 
@@ -57,12 +48,7 @@ longmode:
     mov (start-8), %rax
     mov %rax,%rsp
     lgdt gdtdesc64
-    movw $(2<<3), %ax
-    movw %ax,%ds
-    movw %ax,%es
-    movw %ax,%ss
-    movw %ax,%fs
-    movw %ax,%gs
+    INIT_PROT_MODE_DATA(2<<3)
     mov (start-16), %rax
     jmp *%rax
 

--- a/src-kernel/bootasm.S
+++ b/src-kernel/bootasm.S
@@ -1,6 +1,7 @@
 #include "asm.h"
 #include "memlayout.h"
 #include "mmu.h"
+#include "arch/asm_common.h"
 
 # Start the first CPU: switch to 32-bit protected mode, jump into C.
 # The BIOS loads this code from the first sector of the hard disk into
@@ -18,48 +19,20 @@ start:
   movw    %ax,%es             # -> Extra Segment
   movw    %ax,%ss             # -> Stack Segment
 
-  # Physical address line A20 is tied to zero so that the first PCs 
-  # with 2 MB would run software that assumed 1 MB.  Undo that.
-seta20.1:
-  inb     $0x64,%al               # Wait for not busy
-  testb   $0x2,%al
-  jnz     seta20.1
-
-  movb    $0xd1,%al               # 0xd1 -> port 0x64
-  outb    %al,$0x64
-
-seta20.2:
-  inb     $0x64,%al               # Wait for not busy
-  testb   $0x2,%al
-  jnz     seta20.2
-
-  movb    $0xdf,%al               # 0xdf -> port 0x60
-  outb    %al,$0x60
+  # Enable access to memory above 1MB
+  ENABLE_A20
 
   # Switch from real to protected mode.  Use a bootstrap GDT that makes
   # virtual addresses map directly to physical addresses so that the
   # effective memory map doesn't change during the transition.
-  lgdt    gdtdesc
-  movl    %cr0, %eax
-  orl     $CR0_PE, %eax
-  movl    %eax, %cr0
+  SETUP_PROT_MODE(gdtdesc, SEG_KCODE<<3, start32)
 
 //PAGEBREAK!
-  # Complete the transition to 32-bit protected mode by using a long jmp
-  # to reload %cs and %eip.  The segment descriptors are set up with no
-  # translation, so that the mapping is still the identity mapping.
-  ljmp    $(SEG_KCODE<<3), $start32
 
 .code32  # Tell assembler to generate 32-bit code now.
 start32:
   # Set up the protected-mode data segment registers
-  movw    $(SEG_KDATA<<3), %ax    # Our data segment selector
-  movw    %ax, %ds                # -> DS: Data Segment
-  movw    %ax, %es                # -> ES: Extra Segment
-  movw    %ax, %ss                # -> SS: Stack Segment
-  movw    $0, %ax                 # Zero segments not ready for use
-  movw    %ax, %fs                # -> FS
-  movw    %ax, %gs                # -> GS
+  INIT_PROT_MODE_DATA(SEG_KDATA<<3)
 
   # Set up the stack pointer and call into C.
   movl    $start, %esp

--- a/src-kernel/entryother.S
+++ b/src-kernel/entryother.S
@@ -1,6 +1,7 @@
 #include "asm.h"
 #include "memlayout.h"
 #include "mmu.h"
+#include "arch/asm_common.h"
 	
 # Each non-boot CPU ("AP") is started up in response to a STARTUP
 # IPI from the boot CPU.  Section B.4.2 of the Multi-Processor
@@ -30,30 +31,14 @@ start:
   movw    %ax,%es
   movw    %ax,%ss
 
-  # Switch from real to protected mode.  Use a bootstrap GDT that makes
-  # virtual addresses map directly to physical addresses so that the
-  # effective memory map doesn't change during the transition.
-  lgdt    gdtdesc
-  movl    %cr0, %eax
-  orl     $CR0_PE, %eax
-  movl    %eax, %cr0
-
-  # Complete the transition to 32-bit protected mode by using a long jmp
-  # to reload %cs and %eip.  The segment descriptors are set up with no
-  # translation, so that the mapping is still the identity mapping.
-  ljmpl    $(SEG_KCODE<<3), $(start32)
+  # Switch from real to protected mode.
+  SETUP_PROT_MODE(gdtdesc, SEG_KCODE<<3, start32)
 
 //PAGEBREAK!
 .code32  # Tell assembler to generate 32-bit code now.
 start32:
   # Set up the protected-mode data segment registers
-  movw    $(SEG_KDATA<<3), %ax    # Our data segment selector
-  movw    %ax, %ds                # -> DS: Data Segment
-  movw    %ax, %es                # -> ES: Extra Segment
-  movw    %ax, %ss                # -> SS: Stack Segment
-  movw    $0, %ax                 # Zero segments not ready for use
-  movw    %ax, %fs                # -> FS
-  movw    %ax, %gs                # -> GS
+  INIT_PROT_MODE_DATA(SEG_KDATA<<3)
 
   # Turn on page size extension for 4Mbyte pages
   movl    %cr4, %eax


### PR DESCRIPTION
## Summary
- add `asm_common.h` with helper macros for A20 and protected mode setup
- use these macros in boot and entry assembly
- update x86_64 boot/entry assembly accordingly

## Testing
- `make ARCH=x86_64` *(fails: implicit declarations in bootmain.c)*
- `make ARCH=aarch64` *(fails: unsupported -march=armv8-a)*