### PR TITLE
Set clang-tidy to C23/C++23

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,3 +2,4 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
+Standard: c23

--- a/.clang-tidy-cpp17
+++ b/.clang-tidy-cpp17
@@ -1,4 +1,0 @@
-Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
-WarningsAsErrors: ''
-HeaderFilterRegex: '.*'
-FormatStyle: file

--- a/.clang-tidy-cpp23
+++ b/.clang-tidy-cpp23
@@ -2,3 +2,4 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
+Standard: c++23

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,9 +12,9 @@ repos:
       language: system
       pass_filenames: true
       types: [c, h]
-    - id: clang-tidy-cpp17
-      name: clang-tidy (C++17)
-      entry: scripts/run-clang-tidy.sh --config-file=.clang-tidy-cpp17
+    - id: clang-tidy-cpp23
+      name: clang-tidy (C++23)
+      entry: scripts/run-clang-tidy.sh --config-file=.clang-tidy-cpp23
       language: system
       pass_filenames: true
       types: [cpp, cxx, cc, c++, hpp, hxx, hh]


### PR DESCRIPTION
## Summary
- set `.clang-tidy` to use C23
- rename C++ clang-tidy config to `.clang-tidy-cpp23`
- update config to use C++23
- adjust pre-commit hooks for the new config

## Testing
- `pre-commit run --files .clang-tidy .clang-tidy-cpp23 .pre-commit-config.yaml` *(fails: `pre-commit: command not found`)*