### PR TITLE
Fix log output interfering with latency test

### DIFF
--- a/streams_log.py
+++ b/streams_log.py
@@ -1,4 +1,5 @@
 import json
+import sys
 from datetime import datetime
 
 
@@ -25,4 +26,4 @@ def strlog_json(level: str, message: str, **fields) -> None:
         "msg": message,
     }
     record.update(fields)
-    print(json.dumps(record))
+    print(json.dumps(record), file=sys.stderr)


### PR DESCRIPTION
## Summary
- emit JSON logs to stderr in `streams_log.strlog_json`

## Testing
- `pytest -q tests/test_scripts_simulate.py::test_latency_reported`