### PR TITLE
Fix duplicate epoch field in capability entry

### DIFF
--- a/src-headers/cap.h
+++ b/src-headers/cap.h
@@ -16,7 +16,6 @@ struct cap_entry {
     uint resource;
     uint rights;
     uint owner;
-    uint epoch;
 };
 
 extern uint global_epoch;


### PR DESCRIPTION
## Summary
- remove the extra `epoch` member from `struct cap_entry`

## Testing
- `make` *(fails: unrecognized command-line option `-std=c23`)*