### PR TITLE
Fix includes for exo headers

### DIFF
--- a/src-headers/exo_cpu.h
+++ b/src-headers/exo_cpu.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "exo_mem.h"
-#include "../../exo.h"
+#include "exo.h"
 
 int exo_yield_to(exo_cap target);

--- a/src-headers/exo_disk.h
+++ b/src-headers/exo_disk.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include "exo_mem.h"
-#include "../../exo.h"
+#include "exo.h"
 #include <stdint.h>
 
 int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 #include "exo_mem.h"
-#include "../../exo.h"
+#include "exo.h"
 
 struct exo_ipc_ops {
   int (*send)(exo_cap dest, const void *buf, uint64_t len);

--- a/src-headers/exo_mem.h
+++ b/src-headers/exo_mem.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "../../exo.h"
+#include "exo.h"
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap cap);

--- a/src-headers/stdint.h
+++ b/src-headers/stdint.h
@@ -1,2 +1,2 @@
 #pragma once
-#include <stdint.h>
+#include_next <stdint.h>


### PR DESCRIPTION
## Summary
- include `exo.h` from `exo_*` headers with shorter path
- use `include_next` in `src-headers/stdint.h` so that the system header is found

## Testing
- `gcc -I src-headers -I . -c /tmp/test.c -o /tmp/test.o && echo "compiled"`