### PR TITLE
Fix datetime usage in streams_log

### DIFF
--- a/streams_log.py
+++ b/streams_log.py
@@ -1,6 +1,6 @@
 import json
 import sys
-from datetime import datetime
+from datetime import datetime, UTC
 
 
 def strlog(message: str) -> None:
@@ -21,7 +21,7 @@ def strlog_json(level: str, message: str, **fields) -> None:
         Additional keyword arguments are included in the output record.
     """
     record = {
-        "ts": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
         "level": level,
         "msg": message,
     }


### PR DESCRIPTION
## Summary
- use timezone-aware `datetime.now(datetime.UTC)`
- adjust import to bring in `UTC`

## Testing
- `pytest tests/test_encrypt_mod.py -q -W error`
- `pytest tests/test_flow_pid.py -q`
- `pytest -q | head` *(fails: CalledProcessError: command '[gcc', '-std=c11'`*