### PR TITLE
Add strlog_json JSON timestamp test

### DIFF
--- a/streams_log.py
+++ b/streams_log.py
@@ -20,8 +20,9 @@ def strlog_json(level: str, message: str, **fields) -> None:
     **fields:
         Additional keyword arguments are included in the output record.
     """
+    iso_ts = datetime.now(UTC).isoformat(timespec="seconds")
     record = {
-        "ts": datetime.now(UTC).isoformat(timespec="seconds"),
+        "ts": iso_ts.replace("+00:00", "Z"),
         "level": level,
         "msg": message,
     }

--- a/tests/test_streams_log.py
+++ b/tests/test_streams_log.py
@@ -1,0 +1,19 @@
+import pathlib
+import sys
+import json
+import re
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from streams_log import strlog_json
+
+
+def test_strlog_json_timestamp_format(capsys):
+    strlog_json("info", "hello", foo="bar")
+    captured = capsys.readouterr().err.strip()
+    record = json.loads(captured)
+    assert record["level"] == "info"
+    assert record["msg"] == "hello"
+    assert record["foo"] == "bar"
+    assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", record["ts"])


### PR DESCRIPTION
## Summary
- test `strlog_json` output
- ensure timestamp ends with `Z`
- adjust `strlog_json` implementation to emit `Z` suffix

## Testing
- `pytest tests/test_streams_log.py::test_strlog_json_timestamp_format -q`