### PR TITLE
Improve spinlock headers and add alignment test

### DIFF
--- a/doc/qspinlock.md
+++ b/doc/qspinlock.md
@@ -28,3 +28,9 @@ QSpinlocks are useful when many cores contend for the same lock. They can
 reduce contention spikes in scheduler queues, I/O paths or other hot
 structures. Because they share the same `struct spinlock`, existing code
 can adopt qspinlocks without structural changes.
+
+### Optimal Alignment
+
+Use `spinlock_optimal_alignment()` to query the recommended byte
+alignment for `struct spinlock` instances. Aligning locks to this value
+helps avoid cache line sharing between CPUs.

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -1,11 +1,22 @@
 #pragma once
 
 
+#include <stddef.h>
+
 struct ticketlock {
   _Atomic unsigned short head;
   _Atomic unsigned short tail;
 };
-struct spinlock { struct ticketlock ticket; };
+
+struct cpu; // forward declaration
+
+struct spinlock {
+  struct ticketlock ticket;
+  char *name;
+  struct cpu *cpu;
+  unsigned int pcs[10];
+};
 static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }
+static inline size_t spinlock_optimal_alignment(void) { return __alignof__(struct spinlock); }

--- a/src-headers/qspinlock.h
+++ b/src-headers/qspinlock.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "spinlock.h"
+#include <spinlock.h>
 
 void qspin_lock(struct spinlock *lk);
 void qspin_unlock(struct spinlock *lk);

--- a/src-headers/rspinlock.h
+++ b/src-headers/rspinlock.h
@@ -1,5 +1,5 @@
 #pragma once
-#include "spinlock.h"
+#include <spinlock.h>
 
 struct rspinlock {
   struct spinlock lk;  // underlying spinlock

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stddef.h>
 
 // Ticket-based mutual exclusion lock.
 struct ticketlock {
@@ -16,4 +17,11 @@ struct spinlock {
   uint pcs[10];      // The call stack (an array of program counters)
                      // that locked the lock.
 };
+
+// Returns the recommended alignment for instances of struct spinlock.
+static inline size_t
+spinlock_optimal_alignment(void)
+{
+  return __alignof__(struct spinlock);
+}
 

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -1,0 +1,42 @@
+import subprocess
+import tempfile
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = """
+#include <stddef.h>
+#include <stdint.h>
+#include "types.h"
+#include "spinlock.h"
+int main(void){
+    return _Alignof(struct spinlock) == spinlock_optimal_alignment() ? 0 : 1;
+}
+"""
+
+def compile_and_run(use_stub):
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE)
+        if use_stub:
+            (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
+        cmd = [
+            "gcc","-std=c11",
+            "-I", str(td),
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            "-I", str(ROOT/"src-kernel/include"),
+            str(src),
+            "-o", str(exe)
+        ]
+        if not use_stub:
+            cmd.insert(2, "-DSPINLOCK_NO_STUBS")
+        subprocess.check_call(cmd)
+        return subprocess.run([str(exe)]).returncode
+
+def test_alignment_stub():
+    assert compile_and_run(True) == 0
+
+def test_alignment_real():
+    assert compile_and_run(False) == 0


### PR DESCRIPTION
## Summary
- define `spinlock_optimal_alignment` helper
- clean include paths in qspinlock/rspinlock headers
- expand stub spinlock header for zone tests
- document alignment helper
- add regression test for spinlock alignment

## Testing
- `pytest -q`