### PR TITLE
Switch to CMake/Clang build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.16)
+project(exov6 C)
+
+# Force clang
+if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+    message(FATAL_ERROR "GCC is not supported; please use clang")
+endif()
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+
+find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+if(CLANG_TIDY_EXE)
+    set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
+endif()
+
+add_subdirectory(libnstr_graph)
+# TODO: add kernel and userland targets

--- a/README
+++ b/README
@@ -58,31 +58,26 @@ We don't process error reports (see note on top of this file).
 
 BUILDING AND RUNNING XV6
 
-To build xv6 on an x86 ELF machine (like Linux or FreeBSD), run
-"make". On non-x86 or non-ELF machines (like OS X, even on x86), you
-will need to install a cross-compiler gcc suite capable of producing
-x86 ELF binaries (see https://pdos.csail.mit.edu/6.828/).
-A cross-compiler may not be necessary on a 64-bit Linux host since the
-toolchain can produce 32-bit binaries, but on other systems install a
-cross-compiler suite and invoke ``make TOOLPREFIX=i386-jos-elf-``.
+Building the project now relies on **CMake** and the **Clang** toolchain.
+GCC is currently unsupported.  After installing the required packages
+via ``setup.sh`` configure a build directory and compile with::
 
-Step-by-step build and run commands::
+    cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+    cmake --build build
 
-    make            # build the kernel and all user programs
-    make qemu       # boot the generated image under QEMU
-    make bochs      # alternatively boot using Bochs
+Use ``ninja`` or ``make`` as your generator of choice.  ``clang-tidy``
+integrates automatically when available and will run during the build.
 
 When adding new user-space utilities place the sources under
-``src-uland/user`` and append the corresponding ``_prog`` name to
-``UPROGS`` in ``Makefile``.  Running plain ``make`` then rebuilds
-``fs.img`` with the new binaries.
+``src-uland/user`` and update the corresponding CMake target.
 
 The QEMU PC simulator is installed automatically by ``setup.sh``.
-Bochs is optional but also supported via ``make bochs``.
+Bochs is optional but the CMake build still produces a bootable image
+usable with the existing run scripts.
 
 A few headers used solely by the kernel have been moved under
 ``src-kernel/include``.  Files like ``spinlock.h`` and ``sleeplock.h``
-reside here instead of ``src-headers``.  The Makefile and Meson build
+reside here instead of ``src-headers``.  CMake adds this directory to
 add this directory to the compiler's include path automatically.
 
 BOCHS
@@ -224,32 +219,9 @@ CROSS-COMPILING
 ---------------
 The ``setup.sh`` script installs cross-compilers for several
 architectures such as ARMv7, AArch64, PowerPC and PowerPC64 (both
-big-endian and little-endian).  Use the ``ARCH`` variable when invoking
-``make`` to select the desired target.  The current Makefile implements
-``ARCH=aarch64`` in addition to ``x86`` and ``x86_64``.
-
-Build and run an AArch64 image with::
-
-    make ARCH=aarch64
-    ./qemu-aarch64.sh
-
-Other cross-compilers are ready for experimentation.  Example commands
-for architectures that do not yet have dedicated run scripts are::
-
-    make ARCH=arm        # ARMv7
-    qemu-system-arm -M virt -nographic -kernel kernel-arm
-
-    make ARCH=powerpc    # 32-bit PowerPC
-    qemu-system-ppc -M g3beige -nographic -kernel kernel-powerpc
-
-    make ARCH=ppc64      # PowerPC64 big-endian
-    qemu-system-ppc64 -M pseries -nographic -kernel kernel-ppc64
-
-    make ARCH=ppc64le    # PowerPC64 little-endian
-    qemu-system-ppc64 -M pseries -cpu POWER8 -nographic -kernel kernel-ppc64le
-
-When additional ``ARCH`` values are implemented in the Makefile these
-commands will build and boot the corresponding images.
+big-endian and little-endian).  Future versions of the CMake build will
+expose an ``ARCH`` option for cross-compilation, but only the host
+architecture is currently supported.
 
 
 BOCHS
@@ -267,14 +239,13 @@ The above configuration reports panics from the CD-ROM while leaving
 other devices interactive, ignores non-critical CD-ROM errors and still
 prints its debug messages.
 
-MESON BUILD
+CMAKE BUILD
 -----------
-The repository also includes a simple Meson setup.  After running
-``setup.sh`` the ``meson`` and ``ninja`` tools are installed.  Configure a
-build directory and compile with::
+The preferred build system is now CMake. After running `setup.sh` configure a
+build directory with::
 
-    meson setup build
-    ninja -C build
+    cmake -S . -B build
+    cmake --build build
 
 CODE FORMATTING
 ---------------

--- a/libnstr_graph/CMakeLists.txt
+++ b/libnstr_graph/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_library(nstr_graph STATIC nstr_graph.c)
+
+# Provide the include directory to consumers
+target_include_directories(nstr_graph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/setup.sh
+++ b/setup.sh
@@ -69,6 +69,7 @@ else
 fi
 
 #— core build tools, formatters, analysis, science libs
+echo "CMake build requires clang; GCC is not supported" >&2
 for pkg in \
   build-essential gcc g++ g++-13 clang clang-16 lld llvm \
   clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig shellcheck pre-commit \

--- a/src-headers/proc.h
+++ b/src-headers/proc.h
@@ -4,6 +4,7 @@
 #include "mmu.h"
 #include "x86.h"
 #include "spinlock.h"
+#include <stddef.h>
 
 // Context used for kernel context switches.
 #if defined(__x86_64__) || defined(__aarch64__)

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -1,5 +1,5 @@
 #pragma once
-
+#include <stdint.h>
 
 // Ticket-based mutual exclusion lock.
 struct ticketlock {


### PR DESCRIPTION
## Summary
- replace Meson/Makefile instructions with CMake and clang
- add basic CMakeLists with clang-tidy integration
- update setup script with clang-only note
- fix missing includes for clang builds

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `pytest -q`