### PR TITLE
Add CONFIG_SMP toggle for spinlocks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 KERNEL_DIR := src-kernel
 ULAND_DIR  := src-uland
 LIBOS_DIR  := libos
+CONFIG_SMP ?= 1
 
 OBJS = \
     $(KERNEL_DIR)/bio.o \
@@ -21,9 +22,6 @@ OBJS = \
     $(KERNEL_DIR)/pipe.o \
     $(KERNEL_DIR)/proc.o \
     $(KERNEL_DIR)/sleeplock.o \
-    $(KERNEL_DIR)/spinlock.o \
-    $(KERNEL_DIR)/qspinlock.o \
-    $(KERNEL_DIR)/rspinlock.o \
     $(KERNEL_DIR)/rcu.o \
     $(KERNEL_DIR)/string.o \
     $(KERNEL_DIR)/syscall.o \
@@ -48,6 +46,12 @@ OBJS = \
     $(KERNEL_DIR)/beatty_sched.o \
     $(KERNEL_DIR)/beatty_dag_stream.o \
     $(KERNEL_DIR)/zone.o
+
+ifeq ($(CONFIG_SMP),1)
+OBJS += $(KERNEL_DIR)/spinlock.o \
+       $(KERNEL_DIR)/qspinlock.o \
+       $(KERNEL_DIR)/rspinlock.o
+endif
 
 ifeq ($(ARCH),x86_64)
 OBJS += $(KERNEL_DIR)/mmu64.o
@@ -245,7 +249,7 @@ SIGNBOOT := 0
 endif
 
 
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(KERNEL_DIR)/include -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(KERNEL_DIR)/include -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto -DCONFIG_SMP=$(CONFIG_SMP)
 CFLAGS += $(if $(filter ia16,$(ARCH)),-I$(KERNEL_DIR)/arch/ia16,)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 # Optional CPU optimization flags

--- a/README
+++ b/README
@@ -173,6 +173,10 @@ cross-compiling a 64-bit version is available. Set
 ``ARCH=x86_64`` when invoking make to enable 64-bit builds and adjust
 ``CSTD`` to use a different C standard if desired.
 
+By default the kernel builds with symmetric multiprocessing (SMP) locks
+enabled. Set ``CONFIG_SMP=0`` when invoking ``make`` to omit the
+spinlock implementations and compile a uniprocessor configuration.
+
 
 When building with ``ARCH=x86_64`` the resulting artifacts will be named
 ``kernel64``, ``fs64.img``, ``xv6-64.img`` and ``xv6memfs-64.img``.

--- a/doc/qspinlock.md
+++ b/doc/qspinlock.md
@@ -34,3 +34,11 @@ can adopt qspinlocks without structural changes.
 Use `spinlock_optimal_alignment()` to query the recommended byte
 alignment for `struct spinlock` instances. Aligning locks to this value
 helps avoid cache line sharing between CPUs.
+
+### SMP Option
+
+Spinlock operations are compiled only when `CONFIG_SMP` is non-zero.
+Defining this option to `0` removes the real locking code and replaces
+`acquire`/`release` with no-op inline functions. This is useful when
+building a uniprocessor configuration where interrupts alone suffice
+for mutual exclusion.

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,7 @@
 project('xv6', 'c', default_options: ['c_std=c23'])
 
+option('config_smp', type: 'boolean', value: true, description: 'enable SMP spinlocks')
+
 clang_tidy = find_program('clang-tidy', required: false)
 
 src_dirs = ['src-kernel', 'src-uland', 'libos']
@@ -9,7 +11,14 @@ foreach d : src_dirs
   sources += files(d + '/*.c')
 endforeach
 
+if not get_option('config_smp')
+  sources -= files('src-kernel/spinlock.c',
+                   'src-kernel/qspinlock.c',
+                   'src-kernel/rspinlock.c')
+endif
+
 executable('kernel', sources,
+           c_args: ['-DCONFIG_SMP=' + (get_option('config_smp') ? '1' : '0')],
            include_directories: include_directories('.',
                                             'src-headers',
                                             'src-kernel/include',

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -2,6 +2,7 @@
 
 
 #include <stddef.h>
+#include <smp_lock.h>
 
 struct ticketlock {
   _Atomic unsigned short head;
@@ -16,7 +17,14 @@ struct spinlock {
   struct cpu *cpu;
   unsigned int pcs[10];
 };
+
+#if CONFIG_SMP
+void initlock(struct spinlock *l, const char *name);
+void acquire(struct spinlock *l);
+void release(struct spinlock *l);
+#else
 static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }
+#endif
 static inline size_t spinlock_optimal_alignment(void) { return __alignof__(struct spinlock); }

--- a/src-headers/smp_lock.h
+++ b/src-headers/smp_lock.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef CONFIG_SMP
+#define CONFIG_SMP 1
+#endif

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <smp_lock.h>
 
 // Ticket-based mutual exclusion lock.
 struct ticketlock {
@@ -24,4 +25,11 @@ spinlock_optimal_alignment(void)
 {
   return __alignof__(struct spinlock);
 }
+
+#if !CONFIG_SMP
+static inline void initlock(struct spinlock *lk, char *name) { (void)lk; (void)name; }
+static inline void acquire(struct spinlock *lk) { (void)lk; }
+static inline void release(struct spinlock *lk) { (void)lk; }
+static inline int holding(struct spinlock *lk) { (void)lk; return 1; }
+#endif
 

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -21,6 +21,7 @@ def compile_and_run(use_stub):
         src.write_text(C_CODE)
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
+            (pathlib.Path(td)/"smp_lock.h").write_text('#define CONFIG_SMP 0\n')
         cmd = [
             "gcc","-std=c11",
             "-I", str(td),

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -51,6 +51,7 @@ def compile_and_run(body):
         # headers expected by zone.c
         (pathlib.Path(td)/"spinlock.h").write_text(
             '#include "src-headers/libos/spinlock.h"\n')
+        (pathlib.Path(td)/"smp_lock.h").write_text('#define CONFIG_SMP 0\n')
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text('#include "src-headers/types.h"\n#include "src-headers/mmu.h"\n')
         (pathlib.Path(td)/"memlayout.h").write_text('#include "src-headers/memlayout.h"\n')


### PR DESCRIPTION
## Summary
- add `CONFIG_SMP` definition header
- compile spinlock code only when SMP is enabled
- provide no-op versions of spinlock routines when `CONFIG_SMP=0`
- document the new option

## Testing
- `make check`