### PR TITLE
Implement CPUID-based spinlock alignment

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -172,6 +172,7 @@ void popcli(void);
 void qspin_lock(struct spinlock *);
 void qspin_unlock(struct spinlock *);
 int qspin_trylock(struct spinlock *);
+size_t detect_cache_line_size(void);
 
 // sleeplock.c
 void acquiresleep(struct sleeplock *);

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -19,4 +19,18 @@ struct spinlock {
 static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }
+#ifdef SPINLOCK_NO_STUBS
+static inline size_t spinlock_optimal_alignment(void) {
+#if defined(__i386__) || defined(__x86_64__)
+    unsigned int eax = 1, ebx, ecx, edx;
+    __asm__ volatile("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(eax));
+    size_t sz = ((ebx >> 8) & 0xff) * 8u;
+#else
+    size_t sz = 0;
+#endif
+    size_t base = __alignof__(struct spinlock);
+    return sz > base ? sz : base;
+}
+#else
 static inline size_t spinlock_optimal_alignment(void) { return __alignof__(struct spinlock); }
+#endif

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -9,6 +9,7 @@
 #include "x86.h"
 #include "exo_stream.h"
 #include "exo_ipc.h"
+#include "spinlock.h"
 
 static void startothers(void);
 static void mpmain(void) __attribute__((noreturn));
@@ -25,6 +26,7 @@ extern char end[]; // first address after kernel loaded from ELF file
 int main(void) {
   kinit1(end, P2V(4 * 1024 * 1024)); // phys page allocator
   kvmalloc();                        // kernel page table
+  spinlock_cache_line_size = detect_cache_line_size();
   mpinit();                          // detect other processors
   lapicinit();                       // interrupt controller
   seginit();                         // segment descriptors

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -4,13 +4,35 @@ import pathlib
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
-C_CODE = """
+STUB_CODE = """
 #include <stddef.h>
 #include <stdint.h>
-#include "types.h"
-#include "spinlock.h"
+#include \"types.h\"
+#include \"spinlock.h\"
 int main(void){
     return _Alignof(struct spinlock) == spinlock_optimal_alignment() ? 0 : 1;
+}
+"""
+
+REAL_CODE = """
+#include <stddef.h>
+#include <stdint.h>
+#include \"types.h\"
+#include \"spinlock.h\"
+static size_t detect(void){
+#if defined(__i386__) || defined(__x86_64__)
+    unsigned int eax = 1, ebx, ecx, edx;
+    __asm__ volatile("cpuid" : "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) : "a"(eax));
+    return ((ebx >> 8) & 0xff) * 8u;
+#else
+    return 0;
+#endif
+}
+int main(void){
+    size_t cl = detect();
+    size_t base = _Alignof(struct spinlock);
+    size_t expected = cl > base ? cl : base;
+    return expected == spinlock_optimal_alignment() ? 0 : 1;
 }
 """
 
@@ -18,7 +40,7 @@ def compile_and_run(use_stub):
     with tempfile.TemporaryDirectory() as td:
         src = pathlib.Path(td)/"test.c"
         exe = pathlib.Path(td)/"test"
-        src.write_text(C_CODE)
+        src.write_text(STUB_CODE if use_stub else REAL_CODE)
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
         cmd = [


### PR DESCRIPTION
## Summary
- add a `detect_cache_line_size()` helper that issues CPUID
- store result during kernel boot and expose via `spinlock_optimal_alignment()`
- fall back to inline CPUID detection when `SPINLOCK_NO_STUBS` is used
- update user-space header and tests to verify CPUID derived value

## Testing
- `pytest -q`