### PR TITLE
Add configurable spinlock type

### DIFF
--- a/doc/qspinlock.md
+++ b/doc/qspinlock.md
@@ -34,3 +34,14 @@ can adopt qspinlocks without structural changes.
 Use `spinlock_optimal_alignment()` to query the recommended byte
 alignment for `struct spinlock` instances. Aligning locks to this value
 helps avoid cache line sharing between CPUs.
+
+### Selection Mechanism
+
+The active spinlock implementation is chosen at compile time through
+`spinlock_config.h`.  Define the macro `SPINLOCK_TYPE` to either
+`SPINLOCK_TICKET` (the default) or `SPINLOCK_QSPIN`.
+
+When `SPINLOCK_TYPE` is set to `SPINLOCK_QSPIN`, the kernel's
+`acquire()` routine dispatches to `qspin_lock` and the libos header does
+the same when `SPINLOCK_NO_STUBS` is defined.  Leaving `SPINLOCK_TYPE`
+undefined selects the traditional ticket lock implementation.

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -2,6 +2,7 @@
 
 
 #include <stddef.h>
+#include "../spinlock_config.h"
 
 struct ticketlock {
   _Atomic unsigned short head;
@@ -16,7 +17,20 @@ struct spinlock {
   struct cpu *cpu;
   unsigned int pcs[10];
 };
+
+#ifdef SPINLOCK_NO_STUBS
+void initlock(struct spinlock *l, const char *name);
+#if SPINLOCK_TYPE == SPINLOCK_QSPIN
+#include "../qspinlock.h"
+static inline void acquire(struct spinlock *l) { qspin_lock(l); }
+static inline void release(struct spinlock *l) { qspin_unlock(l); }
+#else
+void acquire(struct spinlock *l);
+void release(struct spinlock *l);
+#endif
+#else
 static inline void initlock(struct spinlock *l, const char *name) { (void)l; (void)name; }
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }
+#endif
 static inline size_t spinlock_optimal_alignment(void) { return __alignof__(struct spinlock); }

--- a/src-headers/spinlock_config.h
+++ b/src-headers/spinlock_config.h
@@ -1,0 +1,15 @@
+#pragma once
+
+// Configuration for spinlock implementation.
+// Define SPINLOCK_TYPE to select between ticket locks and qspinlocks.
+// Values:
+//   SPINLOCK_TICKET - traditional ticket lock
+//   SPINLOCK_QSPIN  - randomized back-off qspinlock
+
+#define SPINLOCK_TICKET 0
+#define SPINLOCK_QSPIN  1
+
+#ifndef SPINLOCK_TYPE
+#define SPINLOCK_TYPE SPINLOCK_TICKET
+#endif
+

--- a/src-kernel/spinlock.c
+++ b/src-kernel/spinlock.c
@@ -8,6 +8,10 @@
 #include "mmu.h"
 #include "proc.h"
 #include "spinlock.h"
+#include "spinlock_config.h"
+#if SPINLOCK_TYPE == SPINLOCK_QSPIN
+#include "qspinlock.h"
+#endif
 
 void
 initlock(struct spinlock *lk, char *name)
@@ -25,6 +29,9 @@ initlock(struct spinlock *lk, char *name)
 void
 acquire(struct spinlock *lk)
 {
+#if SPINLOCK_TYPE == SPINLOCK_QSPIN
+  qspin_lock(lk);
+#else
   pushcli(); // disable interrupts to avoid deadlock.
   if(holding(lk))
     panic("acquire");
@@ -41,6 +48,7 @@ acquire(struct spinlock *lk)
   // Record info about lock acquisition for debugging.
   lk->cpu = mycpu();
   getcallerpcs(&lk, lk->pcs);
+#endif
 }
 
 // Release the lock.


### PR DESCRIPTION
## Summary
- make spinlock implementation selectable with `SPINLOCK_TYPE`
- dispatch `acquire()` to `qspin_lock()` when `SPINLOCK_TYPE` is `SPINLOCK_QSPIN`
- update libos spinlock stubs to honor this configuration when stubs are disabled
- document configuration in `qspinlock.md`

## Testing
- `make check`