### PR TITLE
Switch to CMake and clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,34 @@
+cmake_minimum_required(VERSION 3.16)
+project(xv6 C)
+
+set(CMAKE_C_STANDARD 23)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
+  message(WARNING "Clang is recommended for building this project")
+endif()
+
+find_program(CLANG_TIDY_EXE NAMES clang-tidy)
+if(CLANG_TIDY_EXE)
+  set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
+endif()
+
+file(GLOB_RECURSE KERNEL_SOURCES
+  src-kernel/*.c
+  src-uland/*.c
+  libos/*.c
+)
+
+add_executable(kernel ${KERNEL_SOURCES})
+
+target_include_directories(kernel PRIVATE
+  ${CMAKE_SOURCE_DIR}
+  ${CMAKE_SOURCE_DIR}/src-headers
+  ${CMAKE_SOURCE_DIR}/src-kernel/include
+  ${CMAKE_SOURCE_DIR}/proto
+)
+
+target_link_libraries(kernel PRIVATE nstr_graph)
+
+add_subdirectory(libnstr_graph)

--- a/README
+++ b/README
@@ -58,32 +58,33 @@ We don't process error reports (see note on top of this file).
 
 BUILDING AND RUNNING XV6
 
-To build xv6 on an x86 ELF machine (like Linux or FreeBSD), run
-"make". On non-x86 or non-ELF machines (like OS X, even on x86), you
-will need to install a cross-compiler gcc suite capable of producing
-x86 ELF binaries (see https://pdos.csail.mit.edu/6.828/).
-A cross-compiler may not be necessary on a 64-bit Linux host since the
-toolchain can produce 32-bit binaries, but on other systems install a
-cross-compiler suite and invoke ``make TOOLPREFIX=i386-jos-elf-``.
+To build xv6 on an x86 ELF machine (like Linux or FreeBSD) using
+``clang`` and ``cmake`` run ``cmake -S . -B build`` followed by
+``cmake --build build``.  On non-x86 or non-ELF machines you may need a
+cross-compiler toolchain capable of producing x86 ELF binaries
+(see https://pdos.csail.mit.edu/6.828/).  A cross-compiler may not be
+necessary on a 64-bit Linux host since the toolchain can produce 32-bit
+binaries.
 
 Step-by-step build and run commands::
 
-    make            # build the kernel and all user programs
-    make qemu       # boot the generated image under QEMU
-    make bochs      # alternatively boot using Bochs
+    cmake -S . -B build
+    cmake --build build
+    cmake --build build --target qemu
 
 When adding new user-space utilities place the sources under
 ``src-uland/user`` and append the corresponding ``_prog`` name to
-``UPROGS`` in ``Makefile``.  Running plain ``make`` then rebuilds
-``fs.img`` with the new binaries.
+``src-uland/user`` and add the corresponding program target to
+``CMakeLists.txt``.  Rebuilding automatically updates ``fs.img`` with the
+new binaries.
 
 The QEMU PC simulator is installed automatically by ``setup.sh``.
 Bochs is optional but also supported via ``make bochs``.
 
 A few headers used solely by the kernel have been moved under
 ``src-kernel/include``.  Files like ``spinlock.h`` and ``sleeplock.h``
-reside here instead of ``src-headers``.  The Makefile and Meson build
-add this directory to the compiler's include path automatically.
+reside here instead of ``src-headers``.  The CMake build adds this
+directory to the compiler's include path automatically.
 
 BOCHS
 -----
@@ -267,14 +268,14 @@ The above configuration reports panics from the CD-ROM while leaving
 other devices interactive, ignores non-critical CD-ROM errors and still
 prints its debug messages.
 
-MESON BUILD
+CMAKE BUILD
 -----------
-The repository also includes a simple Meson setup.  After running
-``setup.sh`` the ``meson`` and ``ninja`` tools are installed.  Configure a
-build directory and compile with::
+A minimal CMake configuration is provided.  After running ``setup.sh``
+``clang`` and ``cmake`` are available.  Configure a build directory and
+compile with::
 
-    meson setup build
-    ninja -C build
+    cmake -S . -B build
+    cmake --build build
 
 CODE FORMATTING
 ---------------

--- a/libnstr_graph/CMakeLists.txt
+++ b/libnstr_graph/CMakeLists.txt
@@ -1,0 +1,5 @@
+add_library(nstr_graph STATIC nstr_graph.c)
+
+set_target_properties(nstr_graph PROPERTIES POSITION_INDEPENDENT_CODE OFF)
+
+target_include_directories(nstr_graph PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/setup.sh
+++ b/setup.sh
@@ -69,6 +69,8 @@ else
 fi
 
 #— core build tools, formatters, analysis, science libs
+# The project now builds primarily with clang.  GCC packages remain only
+# for cross-compilers and legacy support.
 for pkg in \
   build-essential gcc g++ g++-13 clang clang-16 lld llvm \
   clang-format clang-tidy clangd clang-tools uncrustify astyle editorconfig shellcheck pre-commit \

--- a/src-headers/stddef.h
+++ b/src-headers/stddef.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#if __has_include_next(<stddef.h>)
+# include_next <stddef.h>
+#else
+typedef __SIZE_TYPE__ size_t;
+typedef __PTRDIFF_TYPE__ ptrdiff_t;
+#define NULL ((void*)0)
+#endif

--- a/src-headers/stdint.h
+++ b/src-headers/stdint.h
@@ -1,2 +1,18 @@
 #pragma once
-#include_next <stdint.h>
+
+#if __has_include_next(<stdint.h>)
+# include_next <stdint.h>
+#else
+typedef signed char int8_t;
+typedef short int16_t;
+typedef int int32_t;
+typedef long long int64_t;
+
+typedef unsigned char uint8_t;
+typedef unsigned short uint16_t;
+typedef unsigned int uint32_t;
+typedef unsigned long long uint64_t;
+
+typedef long intptr_t;
+typedef unsigned long uintptr_t;
+#endif

--- a/src-headers/x86.h
+++ b/src-headers/x86.h
@@ -5,14 +5,46 @@ static inline uchar
 inb(ushort port)
 {
   uchar data;
-  asm volatile("inb %1,%0" : "=a"(data) : "d"(port));
+  __asm__ volatile("inb %1,%0" : "=a"(data) : "d"(port));
   return data;
 }
 
 static inline void
 outb(ushort port, uchar data)
 {
-  asm volatile("outb %0,%1" : : "a"(data), "d"(port));
+  __asm__ volatile("outb %0,%1" : : "a"(data), "d"(port));
+}
+
+static inline void
+insl(int port, void *addr, int cnt)
+{
+  __asm__ volatile("cld; rep insl" :
+                   "=D"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
+                   "memory");
+}
+
+static inline void
+outsl(int port, const void *addr, int cnt)
+{
+  __asm__ volatile("cld; rep outsl" :
+                   "=S"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
+                   "memory");
+}
+
+static inline void
+stosb(void *addr, int data, int cnt)
+{
+  __asm__ volatile("cld; rep stosb" :
+                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
+                   "memory");
+}
+
+static inline void
+stosl(void *addr, int data, int cnt)
+{
+  __asm__ volatile("cld; rep stosl" :
+                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
+                   "memory");
 }
 
 #endif // XV6_X86_H

--- a/src-kernel/bootmain.c
+++ b/src-kernel/bootmain.c
@@ -9,6 +9,7 @@
 #include "elf.h"
 #include "x86.h"
 #include "memlayout.h"
+#include <stdint.h>
 
 #define SECTSIZE  512
 

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 // Ticket-based mutual exclusion lock.
 struct ticketlock {


### PR DESCRIPTION
## Summary
- switch documentation from Makefile/Meson to CMake and clang
- add CMakeLists.txt with clang-tidy support
- note clang-only build environment
- fix missing headers for clang builds

## Testing
- `make CC=clang bootblock`
- `cmake -S . -B build`
- `cmake --build build` *(fails: affine_runtime.h missing)*