### PR TITLE
Move Beatty and DAG schedulers to libOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,9 +44,6 @@ OBJS = \
     $(KERNEL_DIR)/fastipc.o \
     $(KERNEL_DIR)/endpoint.o \
     $(KERNEL_DIR)/chan.o \
-    $(KERNEL_DIR)/dag_sched.o \
-    $(KERNEL_DIR)/beatty_sched.o \
-    $(KERNEL_DIR)/beatty_dag_stream.o \
     $(KERNEL_DIR)/zone.o
 
 ifeq ($(ARCH),x86_64)
@@ -340,7 +337,11 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/file.o \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
-       $(LIBOS_DIR)/posix.o
+       $(LIBOS_DIR)/posix.o \
+       $(LIBOS_DIR)/sched/beatty_sched.o \
+       $(LIBOS_DIR)/sched/dag_sched.o \
+       $(LIBOS_DIR)/sched/beatty_dag_stream.o \
+       $(LIBOS_DIR)/sched_helpers.o
 
 
 libos: libos.a

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -32,11 +32,10 @@ that provides traditional services on top of the primitive capability interface.
             priority so heavier tasks execute first when several nodes are
             runnable.
 
-A **Beatty scheduler** now complements the DAG engine. It alternates among an arbitrary
-number of contexts using Beatty sequences with irrational weights. Call
-`beatty_sched_set_tasks` with an array of task capabilities and their corresponding
-weights to activate it. The scheduler is registered as an exo stream so user-level
-runtimes can select it on demand.
+A **Beatty scheduler** now complements the DAG engine. It alternates among an
+arbitrary number of contexts using Beatty sequences with irrational weights.
+The libOS exposes this scheduler; applications call `beatty_sched_set_tasks`
+and register the resulting exo stream entirely from user space.
 
 
 ## Capability System
@@ -399,9 +398,9 @@ main(void)
 
 ## Beatty Scheduler and Affine Runtime
 
-The kernel now ships with a Beatty scheduler implementing an affine runtime. It dispatches multiple cooperating contexts according to irrational weights. Enable it with `beatty_sched_set_tasks` after registering the Beatty exo stream. Typed channels can exchange messages whenever the scheduler yields.
+The libOS ships with a Beatty scheduler implementing an affine runtime. It dispatches multiple cooperating contexts according to irrational weights. Use `beatty_sched_set_tasks` after registering the Beatty exo stream to enable it entirely in user space. Typed channels can exchange messages whenever the scheduler yields.
 
-When `beatty_dag_stream_init()` is invoked during boot the Beatty scheduler is
+When `beatty_dag_stream_init()` is invoked from the libOS the Beatty scheduler is
 chained with the DAG scheduler through a single exo stream.  Beatty picks the
 next task family according to the weights passed to
 `beatty_sched_set_tasks`.  Each family receives time slices proportional to its

--- a/libos/sched/beatty_dag_stream.c
+++ b/libos/sched/beatty_dag_stream.c
@@ -1,6 +1,7 @@
 #include "types.h"
-#include "defs.h"
 #include "exo_stream.h"
+#include "libos/beatty_sched.h"
+#include "libos/dag.h"
 
 /* Initialize the combined Beatty+DAG stream. Call once during boot
  * after both schedulers are registered so Beatty can select which DAG

--- a/libos/sched/beatty_sched.c
+++ b/libos/sched/beatty_sched.c
@@ -1,6 +1,5 @@
 #include "types.h"
-#include "defs.h"
-#include "spinlock.h"
+#include "libos/spinlock.h"
 #include "exo_stream.h"
 #include "exo_cpu.h"
 #include "math_core.h"
@@ -54,3 +53,5 @@ void beatty_sched_init(void) {
   beatty_stream.head = &beatty_ops;
   exo_stream_register(&beatty_stream);
 }
+
+struct exo_sched_ops *beatty_sched_ops(void) { return &beatty_ops; }

--- a/libos/sched/dag_sched.c
+++ b/libos/sched/dag_sched.c
@@ -1,6 +1,6 @@
 #include "types.h"
-#include "defs.h"
-#include "spinlock.h"
+#include "libos/spinlock.h"
+#include <stdlib.h>
 #include "dag.h"
 #include "exo_stream.h"
 #include "exo_cpu.h"
@@ -28,7 +28,7 @@ dag_node_set_priority(struct dag_node *n, int priority)
 void
 dag_node_add_dep(struct dag_node *parent, struct dag_node *child)
 {
-  struct dag_node_list *l = (struct dag_node_list *)kalloc();
+  struct dag_node_list *l = (struct dag_node_list *)malloc(sizeof(*l));
   if(!l)
     return;
   l->node = child;
@@ -75,7 +75,7 @@ dag_mark_done(struct dag_node *n)
     struct dag_node *child = l->node;
     if(--child->pending == 0)
       enqueue_ready(child);
-    kfree((char *)l); /* free allocation from dag_node_add_dep */
+    free(l); /* free allocation from dag_node_add_dep */
     l = next;
   }
 }
@@ -115,3 +115,5 @@ dag_sched_init(void)
   dag_stream.head = &dag_ops;
   exo_stream_register(&dag_stream);
 }
+
+struct exo_sched_ops *dag_sched_ops(void) { return &dag_ops; }

--- a/libos/sched_helpers.c
+++ b/libos/sched_helpers.c
@@ -1,10 +1,11 @@
 #include "libos/sched.h"
-#include "dag.h"
+#include "libos/dag.h"
+#include "libos/beatty_sched.h"
 #include "user.h"
-#include "defs.h"
 
 void libos_setup_beatty_dag(void) {
-  // Initialize two schedulers already configured in the kernel
-  // and select the combined Beatty+DAG stream.
+  // Initialize user-space schedulers and select the combined stream.
+  dag_sched_init();
+  beatty_sched_init();
   beatty_dag_stream_init();
 }

--- a/src-headers/libos/beatty_sched.h
+++ b/src-headers/libos/beatty_sched.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "types.h"
+#include "exo.h"
+
+struct exo_sched_ops;
+void beatty_sched_set_tasks(exo_cap a, exo_cap b);
+void beatty_sched_init(void);
+struct exo_sched_ops *beatty_sched_ops(void);

--- a/src-headers/libos/dag.h
+++ b/src-headers/libos/dag.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "../dag.h"
+
+struct exo_sched_ops;
+void dag_sched_init(void);
+struct exo_sched_ops *dag_sched_ops(void);

--- a/src-headers/libos/sched.h
+++ b/src-headers/libos/sched.h
@@ -1,4 +1,5 @@
 #pragma once
-#include "../dag.h"
+#include "libos/dag.h"
+#include "libos/beatty_sched.h"
 
 void libos_setup_beatty_dag(void);

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -4,7 +4,6 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "proc.h"
-#include "dag.h"
 #include "cap.h"
 #include "x86.h"
 #include "exo_stream.h"
@@ -39,8 +38,6 @@ int main(void) {
   binit();                           // buffer cache
   fileinit();                        // file table
   ideinit();                         // disk
-  dag_sched_init();                  // initialize DAG scheduler
-  beatty_sched_init();               // initialize Beatty scheduler
   exo_ipc_register(&exo_ipc_queue_ops);
   startothers();                              // start other processors
   kinit2(P2V(4 * 1024 * 1024), P2V(PHYSTOP)); // must come after startothers()

--- a/src-uland/user/beatty_dag_demo.c
+++ b/src-uland/user/beatty_dag_demo.c
@@ -1,7 +1,8 @@
 #include "types.h"
 #include "user.h"
 #include "math_core.h"
-#include "dag.h"
+#include "libos/dag.h"
+#include "libos/beatty_sched.h"
 #include "libos/sched.h"
 
 static double alpha;

--- a/src-uland/user/chan_dag_supervisor_demo.c
+++ b/src-uland/user/chan_dag_supervisor_demo.c
@@ -1,7 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
-#include "dag.h"
+#include "libos/dag.h"
 #include "libos/driver.h"
 #include "proto/driver.capnp.h"
 


### PR DESCRIPTION
## Summary
- move Beatty and DAG schedulers from kernel to libOS
- expose scheduler headers under `src-headers/libos/`
- update demos to use the new headers
- register schedulers from user space
- document selecting schedulers through the libOS

## Testing
- `pytest -q`