### PR TITLE
Move IPC queue to user level

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ OBJS = \
     $(KERNEL_DIR)/exo_cpu.o \
     $(KERNEL_DIR)/exo_disk.o \
     $(KERNEL_DIR)/exo_ipc.o \
-    $(KERNEL_DIR)/exo_ipc_queue.o \
     $(KERNEL_DIR)/exo_stream.o \
     $(KERNEL_DIR)/cap.o \
     $(KERNEL_DIR)/cap_table.o \
@@ -340,7 +339,9 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/file.o \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
-       $(LIBOS_DIR)/posix.o
+       $(LIBOS_DIR)/posix.o \
+       $(LIBOS_DIR)/ipc_queue.o 
+
 
 
 libos: libos.a

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -140,12 +140,12 @@ whenever the current task yields or no runnable work remains.
 
 ### IPC
 
-- `exo_send(dest, buf, len)` – enqueue a message to the destination
-  capability.
-- `exo_recv(src, buf, len)` – receive data from the source capability.
+- `exo_send(dest, buf, len)` – send a message to `dest`; queuing is handled in user space.
+- `exo_recv(src, buf, len)` – receive data from `src` via the libOS queue.
 - `zipc_call(msg)` – perform a fast IPC syscall using the `zipc_msg_t`
   structure defined in `ipc.h`.
 
+IPC messages are now queued entirely in user space; the kernel merely forwards each `exo_send` or `exo_recv` request.
 Typed channels built with the `CHAN_DECLARE` macro wrap these primitives
 and automatically serialize Cap'n Proto messages.  Each channel is
 backed by a `msg_type_desc` describing the size of the Cap'n Proto

--- a/libos/ipc_queue.c
+++ b/libos/ipc_queue.c
@@ -1,0 +1,103 @@
+#include "include/exokernel.h"
+#include "exo_ipc.h"
+#include "ipc.h"
+#include "uv_spinlock.h"
+#include <string.h>
+#include <errno.h>
+
+#define IPC_BUFSZ 64
+
+struct ipc_entry {
+    zipc_msg_t msg;
+    exo_cap frame;
+};
+
+static struct {
+    uv_spinlock_t lock;
+    struct ipc_entry buf[IPC_BUFSZ];
+    unsigned r, w;
+    int inited;
+} ipcs;
+
+static void ipc_init(void) {
+    if (!ipcs.inited) {
+        uv_spinlock_init(&ipcs.lock);
+        ipcs.r = ipcs.w = 0;
+        ipcs.inited = 1;
+    }
+}
+
+int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
+    ipc_init();
+    if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
+        return -EPERM;
+    if(len > sizeof(zipc_msg_t) + sizeof(exo_cap))
+        len = sizeof(zipc_msg_t) + sizeof(exo_cap);
+
+    zipc_msg_t m = {0};
+    size_t mlen = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
+    memmove(&m, buf, mlen);
+
+    exo_cap fr = {0};
+    if(len > sizeof(zipc_msg_t)) {
+        memmove(&fr, (const char*)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
+        if(!cap_has_rights(fr.rights, EXO_RIGHT_R))
+            return -EPERM;
+        if(dest.owner)
+            fr.owner = dest.owner;
+    }
+
+    uv_spinlock_lock(&ipcs.lock);
+    while(ipcs.w - ipcs.r == IPC_BUFSZ) {
+        uv_spinlock_unlock(&ipcs.lock);
+        uv_spinlock_lock(&ipcs.lock);
+    }
+    ipcs.buf[ipcs.w % IPC_BUFSZ].msg = m;
+    ipcs.buf[ipcs.w % IPC_BUFSZ].frame = fr;
+    ipcs.w++;
+    uv_spinlock_unlock(&ipcs.lock);
+
+    return exo_send(dest, buf, len);
+}
+
+int ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
+    if(!cap_has_rights(src.rights, EXO_RIGHT_R))
+        return -EPERM;
+    ipc_init();
+    uv_spinlock_lock(&ipcs.lock);
+    while(ipcs.r == ipcs.w) {
+        uv_spinlock_unlock(&ipcs.lock);
+        char tmp[sizeof(zipc_msg_t) + sizeof(exo_cap)];
+        int r = exo_recv(src, tmp, sizeof(tmp));
+        if(r > 0) {
+            uv_spinlock_lock(&ipcs.lock);
+            struct ipc_entry *e = &ipcs.buf[ipcs.w % IPC_BUFSZ];
+            memset(e, 0, sizeof(*e));
+            size_t cplen = r < sizeof(zipc_msg_t) ? r : sizeof(zipc_msg_t);
+            memmove(&e->msg, tmp, cplen);
+            if(r > sizeof(zipc_msg_t))
+                memmove(&e->frame, tmp + sizeof(zipc_msg_t), r - sizeof(zipc_msg_t));
+            ipcs.w++;
+        } else {
+            uv_spinlock_lock(&ipcs.lock);
+        }
+    }
+    struct ipc_entry e = ipcs.buf[ipcs.r % IPC_BUFSZ];
+    ipcs.r++;
+    uv_spinlock_unlock(&ipcs.lock);
+
+    size_t total = sizeof(zipc_msg_t);
+    if(e.frame.id)
+        total += sizeof(exo_cap);
+    if(len > sizeof(zipc_msg_t))
+        len = len < total ? len : total;
+    else
+        len = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
+
+    size_t cplen = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
+    memmove(buf, &e.msg, cplen);
+    if(cplen < len)
+        memmove((char*)buf + sizeof(zipc_msg_t), &e.frame, len - sizeof(zipc_msg_t));
+
+    return (int)len;
+}

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -8,10 +8,6 @@ struct exo_ipc_ops {
   int (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
-/* Default in-kernel IPC queue implementation */
-extern struct exo_ipc_ops exo_ipc_queue_ops;
-int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
-int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
 
 void exo_ipc_register(struct exo_ipc_ops *ops);
 int exo_send(exo_cap dest, const void *buf, uint64_t len);

--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "exo_ipc.h"
+
+int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
+int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -41,7 +41,6 @@ int main(void) {
   ideinit();                         // disk
   dag_sched_init();                  // initialize DAG scheduler
   beatty_sched_init();               // initialize Beatty scheduler
-  exo_ipc_register(&exo_ipc_queue_ops);
   startothers();                              // start other processors
   kinit2(P2V(4 * 1024 * 1024), P2V(PHYSTOP)); // must come after startothers()
   userinit();                                 // first user process


### PR DESCRIPTION
## Summary
- shift IPC queue implementation from the kernel into libOS
- expose `ipc_queue_send` and `ipc_queue_recv` in a new header
- remove kernel registration and build of the queue module
- document that IPC queuing now happens in user space

## Testing
- `make check`