### PR TITLE
Add CONFIG_SMP switch with spinlock stubs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 KERNEL_DIR := src-kernel
 ULAND_DIR  := src-uland
 LIBOS_DIR  := libos
+CONFIG_SMP ?= 1
 
 OBJS = \
     $(KERNEL_DIR)/bio.o \
@@ -21,8 +22,8 @@ OBJS = \
     $(KERNEL_DIR)/proc.o \
     $(KERNEL_DIR)/sleeplock.o \
     $(KERNEL_DIR)/spinlock.o \
-    $(KERNEL_DIR)/qspinlock.o \
-    $(KERNEL_DIR)/rspinlock.o \
+    $(if $(filter 1,$(CONFIG_SMP)),$(KERNEL_DIR)/qspinlock.o) \
+    $(if $(filter 1,$(CONFIG_SMP)),$(KERNEL_DIR)/rspinlock.o) \
     $(KERNEL_DIR)/rcu.o \
     $(KERNEL_DIR)/string.o \
     $(KERNEL_DIR)/syscall.o \
@@ -243,6 +244,7 @@ endif
 
 
 CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(KERNEL_DIR)/include -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto
+CFLAGS += -DCONFIG_SMP=$(CONFIG_SMP)
 CFLAGS += $(if $(filter ia16,$(ARCH)),-I$(KERNEL_DIR)/arch/ia16,)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
 # Optional CPU optimization flags

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -1,15 +1,28 @@
-# Phoenix Kernel Overview
+#Phoenix Kernel Overview
 
-The Phoenix kernel implements an exokernel research platform built on top of the xv6 code base. Its goal is to expose low-level hardware resources directly to user space while keeping the in-kernel portion as small as possible. Applications link against a library operating system (libOS) that provides traditional services on top of the primitive capability interface.
+The Phoenix kernel implements an exokernel research platform built on top of the
+        xv6 code base.Its goal is to expose low -
+    level hardware resources directly to user space while keeping the in -
+    kernel portion as small as possible.Applications
+        link against a library operating
+        system(libOS)
+that provides traditional services on top of the primitive capability interface.
 
-## Exokernel Philosophy
+    ##Exokernel Philosophy
 
-Phoenix follows the exokernel approach: the kernel multiplexes hardware resources and enforces protection but leaves higher-level abstractions to user-level code. Instead of implementing full POSIX semantics in the kernel, Phoenix exposes capabilities that grant controlled access to memory regions, devices and communication endpoints. User-space runtimes build whatever abstractions they require.
+        Phoenix follows the exokernel approach
+    : the kernel multiplexes hardware resources and
+          enforces protection but leaves higher -
+    level abstractions to user -
+    level code.Instead of implementing full POSIX semantics in the kernel,
+    Phoenix exposes capabilities that grant controlled access to memory regions,
+    devices and communication endpoints.User -
+        space runtimes build whatever abstractions they require.
 
-## DAG Execution Model
+        ##DAG Execution Model
 
-Scheduling is expressed as a directed acyclic
-graph(DAG) of tasks. Nodes represent units of work and edges encode explicit dependencies. The kernel traverses this graph whenever a context switch is required, allowing cooperative libraries to chain execution without relying on heavyweight kernel threads. The DAG model enables fine-grained scheduling, efficient data-flow processing and transparent composition of user-level schedulers.
+            Scheduling is expressed as a directed acyclic
+            graph(DAG) of tasks. Nodes represent units of work and edges encode explicit dependencies. The kernel traverses this graph whenever a context switch is required, allowing cooperative libraries to chain execution without relying on heavyweight kernel threads. The DAG model enables fine-grained scheduling, efficient data-flow processing and transparent composition of user-level schedulers.
 
 
 Each DAG node now tracks its parents in a reverse dependency
@@ -62,7 +75,8 @@ Phoenix itself does not provide a POSIX interface. Instead the libOS layers POSI
 ## BSD and SVR4 Compatibility Goals
 
 While the current focus is POSIX emulation, the project also aims to
-support BSD and System&nbsp;V Release&nbsp;4 personalities entirely in user
+support BSD and System&nbsp;
+V Release &nbsp;4 personalities entirely in user
 space.  Additional modules under `libos/` will translate Phoenix
 capabilities to the expected interfaces.  Planned components include
 `bsd_signals.c` and `bsd_termios.c` for the classic BSD signal and
@@ -122,12 +136,14 @@ whenever the current task yields or no runnable work remains.
 
 ### IPC
 
-- `exo_send(dest, buf, len)` – send a message to `dest`; queuing is handled in user space.
-- `exo_recv(src, buf, len)` – receive data from `src` via the libOS queue.
-- `zipc_call(msg)` – perform a fast IPC syscall using the `zipc_msg_t`
-  structure defined in `ipc.h`.
+- `exo_send(dest, buf, len)` – send a message to `dest`;
+queuing is handled in user
+        space.- `exo_recv(src, buf,
+                          len)` – receive data from `src` via the libOS queue
+                    .- `zipc_call(msg)` – perform a fast IPC syscall
+                       using the `zipc_msg_t` structure defined in `ipc.h`.
 
-IPC messages are now queued entirely in user space; the kernel merely forwards each `exo_send` or `exo_recv` request.
+                       IPC messages are now queued entirely in user space; the kernel merely forwards each `exo_send` or `exo_recv` request.
 Typed channels built with the `CHAN_DECLARE` macro wrap these primitives
 and automatically serialize Cap'n Proto messages.  Each channel is
 backed by a `msg_type_desc` describing the size of the Cap'n Proto
@@ -341,11 +357,11 @@ inside the xv6 environment.
 int
 main(void)
 {
-    exo_cap page = exo_alloc_page();
-    void *va = map_page(page.id); // provided by the libOS
-    memset(va, 0, PGSIZE);
-    exo_unbind_page(page);
-    return 0;
+  exo_cap page = exo_alloc_page();
+  void *va = map_page(page.id); // provided by the libOS
+  memset(va, 0, PGSIZE);
+  exo_unbind_page(page);
+  return 0;
 }
 ```
 
@@ -363,10 +379,10 @@ CHAN_DECLARE(ping_chan, ping_MESSAGE_SIZE);
 int
 main(void)
 {
-    struct ping msg = ping_init();
-    ping_chan_send(&ping_chan, &msg);
-    ping_chan_recv(&ping_chan, &msg);
-    return 0;
+  struct ping msg = ping_init();
+  ping_chan_send(&ping_chan, &msg);
+  ping_chan_recv(&ping_chan, &msg);
+  return 0;
 }
 ```
 
@@ -381,10 +397,10 @@ main(void)
 int
 main(void)
 {
-    int pid = driver_spawn("blk_driver", 0);
-    exo_cap ep = obtain_driver_ep(pid); // helper returning the endpoint
-    driver_connect(pid, ep);
-    return 0;
+  int pid = driver_spawn("blk_driver", 0);
+  exo_cap ep = obtain_driver_ep(pid); // helper returning the endpoint
+  driver_connect(pid, ep);
+  return 0;
 }
 ```
 
@@ -407,9 +423,9 @@ calling the initializer before submitting DAG nodes.
 
 Phoenix exposes several locking primitives that mirror the kernel's spinlock
 implementations.  Most drivers are single threaded, so the default stub locks
-found in `src-headers/libos/spinlock.h` compile to no-ops.  When the
-`CONFIG_SMP` flag is unset or set to `0`, these stubs remove all locking
-overhead.
+found in `src-headers/libos/spinlock.h` compile to no-ops.  Set `CONFIG_SMP` in
+`config.h` to `0` to remove all locking overhead when running on a single
+processor system.
 
 When building with `CONFIG_SMP=1` the libOS can use either the regular ticket
 lock API or the randomized qspinlock variant.  Ticket locks are invoked through
@@ -429,22 +445,21 @@ struct spinlock lk;
 
 int main(void) {
 #if CONFIG_SMP
-    initlock(&lk, "demo");
+  initlock(&lk, "demo");
 #ifdef USE_QSPIN
-    qspin_lock(&lk);
-    qspin_unlock(&lk);
+  qspin_lock(&lk);
+  qspin_unlock(&lk);
 #else
-    acquire(&lk);
-    release(&lk);
+  acquire(&lk);
+  release(&lk);
 #endif
 #else
-    // locking disabled when CONFIG_SMP=0
+// locking disabled when CONFIG_SMP=0
 #endif
-    return 0;
+  return 0;
 }
 ```
 
 Disable locking when a service never runs on more than one CPU or when
 `CONFIG_SMP` is not enabled.  For multi-core systems, prefer qspinlocks when
 heavy contention is expected; otherwise the ticket lock suffices.
-

--- a/src-headers/config.h
+++ b/src-headers/config.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#ifndef CONFIG_SMP
+#define CONFIG_SMP 1
+#endif

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -3,6 +3,7 @@
 
 #include "types.h"
 #include "param.h"
+#include "config.h"
 #include "spinlock.h"
 #include "proc.h"
 #include "ipc.h"

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <config.h>
 
 // Ticket-based mutual exclusion lock.
 struct ticketlock {
@@ -13,16 +14,31 @@ struct spinlock {
   struct ticketlock ticket; // Ticket lock implementation
 
   // For debugging:
-  char *name;        // Name of lock.
-  struct cpu *cpu;   // The cpu holding the lock.
-  uint pcs[10];      // The call stack (an array of program counters)
-                     // that locked the lock.
+  char *name;      // Name of lock.
+  struct cpu *cpu; // The cpu holding the lock.
+  uint pcs[10];    // The call stack (an array of program counters)
+                   // that locked the lock.
 };
 
+#if CONFIG_SMP
+void initlock(struct spinlock *lk, char *name);
+void acquire(struct spinlock *lk);
+void release(struct spinlock *lk);
+int holding(struct spinlock *lk);
+#else
+static inline void initlock(struct spinlock *lk, char *name) {
+  (void)lk;
+  (void)name;
+}
+static inline void acquire(struct spinlock *lk) { (void)lk; }
+static inline void release(struct spinlock *lk) { (void)lk; }
+static inline int holding(struct spinlock *lk) {
+  (void)lk;
+  return 1;
+}
+#endif
+
 // Returns the recommended alignment for instances of struct spinlock.
-static inline size_t
-spinlock_optimal_alignment(void)
-{
+static inline size_t spinlock_optimal_alignment(void) {
   return __alignof__(struct spinlock);
 }
-

--- a/src-kernel/qspinlock.c
+++ b/src-kernel/qspinlock.c
@@ -1,33 +1,33 @@
 #include "qspinlock.h"
 #include <stdint.h>
+#include <config.h>
 
 struct cpu;
 
-extern struct cpu* mycpu(void);
-extern void getcallerpcs(void*, unsigned int*);
+extern struct cpu *mycpu(void);
+extern void getcallerpcs(void *, unsigned int *);
 extern void pushcli(void);
 extern void popcli(void);
-extern int holding(struct spinlock*);
-extern void panic(char*);
+extern int holding(struct spinlock *);
+extern void panic(char *);
 
-static uint32_t lcg_rand(void)
-{
+#if CONFIG_SMP
+
+static uint32_t lcg_rand(void) {
   static uint32_t seed = 123456789;
   seed = seed * 1103515245 + 12345;
   return seed;
 }
 
-void
-qspin_lock(struct spinlock *lk)
-{
+void qspin_lock(struct spinlock *lk) {
   pushcli();
-  if(holding(lk))
+  if (holding(lk))
     panic("qspin_lock");
 
   uint16_t ticket = __atomic_fetch_add(&lk->ticket.tail, 1, __ATOMIC_SEQ_CST);
-  while(__atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST) != ticket){
+  while (__atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST) != ticket) {
     unsigned delay = (lcg_rand() & 0xff) + 1;
-    while(delay--)
+    while (delay--)
       __asm__ volatile("pause");
   }
 
@@ -36,10 +36,8 @@ qspin_lock(struct spinlock *lk)
   getcallerpcs(&lk, lk->pcs);
 }
 
-void
-qspin_unlock(struct spinlock *lk)
-{
-  if(!holding(lk))
+void qspin_unlock(struct spinlock *lk) {
+  if (!holding(lk))
     panic("qspin_unlock");
   lk->pcs[0] = 0;
   lk->cpu = 0;
@@ -48,22 +46,20 @@ qspin_unlock(struct spinlock *lk)
   popcli();
 }
 
-int
-qspin_trylock(struct spinlock *lk)
-{
+int qspin_trylock(struct spinlock *lk) {
   pushcli();
-  if(holding(lk))
+  if (holding(lk))
     panic("qspin_trylock");
 
   uint16_t head = __atomic_load_n(&lk->ticket.head, __ATOMIC_SEQ_CST);
   uint16_t tail = __atomic_load_n(&lk->ticket.tail, __ATOMIC_SEQ_CST);
-  if(head != tail){
+  if (head != tail) {
     popcli();
     return 0;
   }
   uint16_t expected = tail;
-  if(!__atomic_compare_exchange_n(&lk->ticket.tail, &expected, tail+1, 0,
-                                  __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)){
+  if (!__atomic_compare_exchange_n(&lk->ticket.tail, &expected, tail + 1, 0,
+                                   __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST)) {
     popcli();
     return 0;
   }
@@ -73,3 +69,11 @@ qspin_trylock(struct spinlock *lk)
   getcallerpcs(&lk, lk->pcs);
   return 1;
 }
+#else
+void qspin_lock(struct spinlock *lk) { (void)lk; }
+void qspin_unlock(struct spinlock *lk) { (void)lk; }
+int qspin_trylock(struct spinlock *lk) {
+  (void)lk;
+  return 1;
+}
+#endif

--- a/src-kernel/rspinlock.c
+++ b/src-kernel/rspinlock.c
@@ -1,28 +1,27 @@
 #include "rspinlock.h"
+#include <config.h>
 
 struct cpu;
 
-extern struct cpu* mycpu(void);
+extern struct cpu *mycpu(void);
 extern void pushcli(void);
 extern void popcli(void);
-extern void acquire(struct spinlock*);
-extern void release(struct spinlock*);
-extern int holding(struct spinlock*);
-extern void panic(char*);
+extern void acquire(struct spinlock *);
+extern void release(struct spinlock *);
+extern int holding(struct spinlock *);
+extern void panic(char *);
 
-void
-rinitlock(struct rspinlock *rlk, char *name)
-{
+#if CONFIG_SMP
+
+void rinitlock(struct rspinlock *rlk, char *name) {
   rlk->owner = 0;
   rlk->depth = 0;
   initlock(&rlk->lk, name);
 }
 
-void
-racquire(struct rspinlock *rlk)
-{
+void racquire(struct rspinlock *rlk) {
   pushcli();
-  if(rlk->owner == mycpu()){
+  if (rlk->owner == mycpu()) {
     rlk->depth++;
     return;
   }
@@ -31,25 +30,33 @@ racquire(struct rspinlock *rlk)
   rlk->depth = 1;
 }
 
-void
-rrelease(struct rspinlock *rlk)
-{
-  if(rlk->owner != mycpu() || rlk->depth < 1)
+void rrelease(struct rspinlock *rlk) {
+  if (rlk->owner != mycpu() || rlk->depth < 1)
     panic("rrelease");
   rlk->depth--;
-  if(rlk->depth == 0){
+  if (rlk->depth == 0) {
     rlk->owner = 0;
     release(&rlk->lk);
   }
   popcli();
 }
 
-int
-rholding(struct rspinlock *rlk)
-{
+int rholding(struct rspinlock *rlk) {
   int r;
   pushcli();
   r = (rlk->owner == mycpu());
   popcli();
   return r;
 }
+#else
+void rinitlock(struct rspinlock *rlk, char *name) {
+  (void)rlk;
+  (void)name;
+}
+void racquire(struct rspinlock *rlk) { (void)rlk; }
+void rrelease(struct rspinlock *rlk) { (void)rlk; }
+int rholding(struct rspinlock *rlk) {
+  (void)rlk;
+  return 1;
+}
+#endif


### PR DESCRIPTION
## Summary
- introduce `config.h` defining `CONFIG_SMP`
- compile qspinlock and rspinlock only if CONFIG_SMP
- provide stub spinlock operations when SMP is disabled
- gate spinlock objects in Makefile
- document CONFIG_SMP usage in the manual

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*