### PR TITLE
Add charter and PTD log

### DIFF
--- a/README
+++ b/README
@@ -3,6 +3,8 @@ their efforts to the RISC-V version
 (https://github.com/mit-pdos/xv6-riscv.git)
 
 This project experiments with decomposition of the xv6 operating system into an exokernel model. 
+The project charter in [doc/charter.md](doc/charter.md) summarizes our goals and contributor guidelines. Philosophical technical debt notes are kept in [doc/ptd_log.md](doc/ptd_log.md).
+
 
 xv6 is a re-implementation of Dennis Ritchie's and Ken Thompson's Unix
 Version 6 (v6).  xv6 loosely follows the structure and style of v6,

--- a/doc/charter.md
+++ b/doc/charter.md
@@ -1,0 +1,38 @@
+# Phoenix Exokernel Charter
+
+This document describes the guiding principles of the Phoenix exokernel
+project. It outlines the long term goals, how contributors can
+participate, and the basic governance model used to steer development.
+
+## Goals
+
+- Build a small, capability based exokernel that exposes hardware
+  resources directly to user space.
+- Provide a flexible libOS that implements POSIX, BSD and SVR4
+  personalities without enlarging the kernel.
+- Encourage experimentation with scheduling models, typed channels and
+  user space drivers.
+- Keep the core code understandable so new contributors can explore the
+  system with minimal friction.
+
+## Contributor Guidelines
+
+Contributions are welcome from anyone. To keep patches manageable,
+please follow these simple rules:
+
+1. Run the provided `pre-commit` hooks before sending patches.
+2. Keep commits focused on a single change and include clear commit
+   messages.
+3. Discuss larger features on the mailing list or issue tracker before
+   implementation.
+4. Documentation updates are just as valuable as code and are strongly
+   encouraged.
+
+## Governance Model
+
+Phoenix is maintained by a small group of volunteers. Design decisions
+are reached by consensus on the public mailing list. In case of
+conflict, the maintainers listed in `MAINTAINERS` have final say.
+Releases are cut periodically once the test suite passes and planned
+features are stable. Everyone is invited to participate in reviews and
+planning.

--- a/doc/ptd_log.md
+++ b/doc/ptd_log.md
@@ -1,0 +1,15 @@
+# Philosophical Technical Debt Log
+
+This file tracks outstanding philosophical or conceptual debt in the
+Phoenix project. Unlike ordinary bugs, these entries capture open
+questions or theoretical shortcuts that may influence future design
+choices.
+
+Each entry should include a date and a short description.
+
+## Example
+
+- **2024-04-27** – Capability semantics around partial revocation remain
+  unclear. Revisit once the permission model stabilizes.
+
+Add new entries below this example as the project evolves.


### PR DESCRIPTION
## Summary
- document project goals and governance in `doc/charter.md`
- add `doc/ptd_log.md` for philosophical technical debt
- link new docs from `README`

## Testing
- `make check`
- `pre-commit` *(fails: command not found)*