### PR TITLE
Implement STREAMS scheduler integration and docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,8 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
        $(LIBOS_DIR)/posix.o \
-       $(LIBOS_DIR)/ipc_queue.o 
+       $(LIBOS_DIR)/ipc_queue.o \
+       $(LIBOS_DIR)/streams.o
 
 
 

--- a/README
+++ b/README
@@ -480,6 +480,9 @@ constant. The ``flow_pid.py`` helpers ``set_kp()``, ``set_ki()`` and
 For testing the base directory can be overridden with the environment
 variable ``FLOW_PID_DIR``.
 
+Additional details on this interface can be found in
+``doc/streams_fc.md``.
+
 STREAMS LOGGING
 ---------------
 Python STREAMS modules log messages using ``strlog_json()`` from

--- a/doc/streams_fc.md
+++ b/doc/streams_fc.md
@@ -1,0 +1,14 @@
+# STREAMS Flow Control
+
+The STREAMS prototype uses a PID controller to throttle message flow.
+The tuning constants are exposed via procfs files under `/proc/streams/fc/`:
+
+* `/proc/streams/fc/Kp`
+* `/proc/streams/fc/Ki`
+* `/proc/streams/fc/Kd`
+
+Each file holds a floating point value. The kernel reads these values at
+start-up and applies changes whenever a new value is written.  The
+helpers in `flow_pid.py` wrap this interface and honour the `FLOW_PID_DIR`
+environment variable, making it easy to experiment with different
+parameters during testing.

--- a/libos/streams.c
+++ b/libos/streams.c
@@ -1,0 +1,6 @@
+#include "exo_stream.h"
+#include "streams.h"
+
+void streams_stop(void) { exo_stream_halt(); }
+
+void streams_yield(void) { exo_stream_yield(); }

--- a/scripts/simulate.py
+++ b/scripts/simulate.py
@@ -12,16 +12,26 @@ from encrypt_mod import XorEncryptModule
 from stream_module import mblk_t, attach_module
 
 
-def main() -> None:
-    key = 0x55
-    pipeline = attach_module([XorEncryptModule(key)])
+def _run_pipeline(modules: list) -> float:
+    pipeline = attach_module(modules)
     iterations = 10000
     start = time.perf_counter()
     for _ in range(iterations):
         msg = mblk_t(b"hello")
         pipeline(msg)
     elapsed = time.perf_counter() - start
-    print(f"Average latency: {elapsed / iterations * 1e6:.2f} us")
+    return elapsed / iterations
+
+
+def main() -> None:
+    combos = [
+        [XorEncryptModule(0x55)],
+        [XorEncryptModule(0x55), XorEncryptModule(0xAA)],
+    ]
+
+    for mods in combos:
+        avg = _run_pipeline(mods)
+        print(f"{len(mods)} modules: {avg * 1e6:.2f} us")
 
 
 if __name__ == "__main__":

--- a/src-headers/streams.h
+++ b/src-headers/streams.h
@@ -1,0 +1,4 @@
+#pragma once
+
+void streams_stop(void);
+void streams_yield(void);

--- a/src-uland/user/dag_demo.c
+++ b/src-uland/user/dag_demo.c
@@ -2,22 +2,28 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include "libos/sched.h"
+#include "streams.h"
 
-typedef struct exo_cap { uint32_t pa; } exo_cap;
+typedef struct exo_cap {
+  uint32_t pa;
+} exo_cap;
 
-struct dag_node { int pending; int priority; };
+struct dag_node {
+  int pending;
+  int priority;
+};
 
 static void dag_node_init(struct dag_node *n, exo_cap ctx) {
-  (void)ctx; n->pending = 0; n->priority = 0;
+  (void)ctx;
+  n->pending = 0;
+  n->priority = 0;
 }
 static void dag_node_add_dep(struct dag_node *parent, struct dag_node *child) {
-  (void)parent; (void)child;
+  (void)parent;
+  (void)child;
 }
 static void dag_sched_submit(struct dag_node *node) {
   printf("dag_sched_submit priority %d\n", node->priority);
-}
-static void exo_stream_yield(void) {
-  printf("exo_stream_yield called\n");
 }
 
 static struct dag_node a, b, c;
@@ -38,11 +44,12 @@ static void setup(void) {
 }
 
 int main(int argc, char *argv[]) {
-  (void)argc; (void)argv;
+  (void)argc;
+  (void)argv;
   printf("DAG scheduler demo\n");
   setup();
-  exo_stream_yield();
-  exo_stream_yield();
-  exo_stream_yield();
+  streams_yield();
+  streams_yield();
+  streams_yield();
   return 0;
 }

--- a/src-uland/user/exo_stream_demo.c
+++ b/src-uland/user/exo_stream_demo.c
@@ -1,9 +1,10 @@
 #include <stdio.h>
 #include <stdint.h>
+#include "streams.h"
 
 typedef struct exo_cap {
-    uint32_t pa;
-    uint32_t id;
+  uint32_t pa;
+  uint32_t id;
 } exo_cap;
 
 // Minimal stub implementations used when kernel support is absent.
@@ -13,21 +14,18 @@ int exo_yield_to(exo_cap *target) {
 }
 
 // Simple user-level demonstration for exo_yield_to
-int exo_yield_to_demo(exo_cap target)
-{
-    printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
-    return 0;
+int exo_yield_to_demo(exo_cap target) {
+  printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
+  return 0;
 }
 
-void streams_stop(void) { printf("streams_stop called\n"); }
-void streams_yield(void) { printf("streams_yield called\n"); }
-
 int main(int argc, char **argv) {
-    (void)argc; (void)argv;
-    exo_cap other = {0, 42};
-    exo_yield_to(&other);
-    exo_yield_to_demo(other);
-    streams_yield();
-    streams_stop();
-    return 0;
+  (void)argc;
+  (void)argv;
+  exo_cap other = {0, 42};
+  exo_yield_to(&other);
+  exo_yield_to_demo(other);
+  streams_yield();
+  streams_stop();
+  return 0;
 }

--- a/tests/test_scripts_simulate.py
+++ b/tests/test_scripts_simulate.py
@@ -19,5 +19,7 @@ def test_pipeline_transformation_roundtrip():
 
 def test_latency_reported(capsys):
     script.main()
-    captured = capsys.readouterr().out.strip()
-    assert re.match(r"^Average latency: [0-9.]+ us$", captured)
+    lines = [l for l in capsys.readouterr().out.strip().splitlines() if l]
+    assert len(lines) == 2
+    for idx, line in enumerate(lines, 1):
+        assert re.match(rf"^{idx} modules: [0-9.]+ us$", line)

--- a/tests/test_streams_log.py
+++ b/tests/test_streams_log.py
@@ -6,7 +6,7 @@ import re
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from streams_log import strlog_json
+from streams_log import strlog, strlog_json
 
 
 def test_strlog_json_timestamp_format(capsys):
@@ -17,3 +17,16 @@ def test_strlog_json_timestamp_format(capsys):
     assert record["msg"] == "hello"
     assert record["foo"] == "bar"
     assert re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$", record["ts"])
+
+
+def test_strlog_plain_text(capsys):
+    strlog("plain message")
+    captured = capsys.readouterr().out.strip()
+    assert captured == "plain message"
+
+
+def test_strlog_json_extra_fields(capsys):
+    strlog_json("debug", "hi", alpha=1, beta="b")
+    record = json.loads(capsys.readouterr().err.strip())
+    assert record["alpha"] == 1
+    assert record["beta"] == "b"


### PR DESCRIPTION
## Summary
- wire up STREAMS halt/yield helpers
- provide new C header and user mode stubs
- extend STREAMS latency harness for multiple modules
- flesh out STREAMS logging tests
- document PID based flow control

## Testing
- `pytest -q`