### PR TITLE
Add microbenchmarks and TLA+ model

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
       run: make check
     - name: Run fuzz smoke test
       run: python3 scripts/swift_fuzz.py -runs=1
+    - name: Run microbenchmarks
+      run: make microbench
     - name: Clean
       run: make clean

--- a/Makefile
+++ b/Makefile
@@ -582,7 +582,7 @@ tar:
 	cp dist/* dist/.gdbinit.tmpl /tmp/xv6
 	(cd /tmp; tar cf - xv6) | gzip >xv6-rev10.tar.gz  # the next one will be 10 (9/17)
 
-.PHONY: dist-test dist check
+.PHONY: dist-test dist check microbench
 
 HOSTCC ?= gcc
 HOSTCFLAGS ?= -Wall -Werror -std=c99
@@ -599,6 +599,9 @@ src-uland/exo_unit_test: src-uland/exo_unit_test.c
 check: src-uland/exo_unit_test
 	./src-uland/exo_unit_test
 	pytest -q
+
+microbench:
+	python3 tests/microbench/run.py
 
 clang-tidy:
 	@for f in $(TIDY_SRCS); do \

--- a/specs/CapabilityLifecycle.tla
+++ b/specs/CapabilityLifecycle.tla
@@ -1,0 +1,41 @@
+----------------------------- MODULE CapabilityLifecycle -----------------------------
+EXTENDS Naturals, Sequences
+
+CONSTANT Caps
+
+VARIABLES state, owner, requests
+
+CapStates == {"free", "active", "revoked"}
+
+Init == /\ state = [c \in Caps |-> "free"]
+        /\ owner = [c \in Caps |-> 0]
+        /\ requests = <<>>
+
+Create(c, o) == /\ state[c] = "free"
+                /\ state' = [state EXCEPT ![c] = "active"]
+                /\ owner' = [owner EXCEPT ![c] = o]
+                /\ UNCHANGED requests
+
+Revoke(c) == /\ state[c] = "active"
+             /\ state' = [state EXCEPT ![c] = "revoked"]
+             /\ UNCHANGED <<owner, requests>>
+
+Verify(c) == /\ state[c] = "active"
+             /\ UNCHANGED <<state, owner, requests>>
+
+Request(c) == requests' = Append(requests, c) /\ UNCHANGED <<state, owner>>
+
+Grant == /\ requests # <<>>
+         /\ LET c == Head(requests) IN state[c] = "active"
+         /\ requests' = Tail(requests)
+         /\ UNCHANGED <<state, owner>>
+
+Next == \E c \in Caps, o \in Nat : Create(c, o)
+        \/ \E c \in Caps : Revoke(c)
+        \/ \E c \in Caps : Verify(c)
+        \/ \E c \in Caps : Request(c)
+        \/ Grant
+
+Spec == Init /\ [][Next]_<<state, owner, requests>>
+
+=============================================================================

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,16 @@
+# TLA+ Specifications
+
+This directory contains TLA+ models for Exo.
+
+## Running the model checker
+
+Install the TLA+ tools and ensure `tlc` is on your `PATH`. To check the
+capability life cycle model run:
+
+```bash
+cd specs
+tlc CapabilityLifecycle.tla
+```
+
+The checker explores the state space defined in `CapabilityLifecycle.tla` and
+reports any invariant violations.

--- a/tests/microbench/cap_verify.c
+++ b/tests/microbench/cap_verify.c
@@ -1,0 +1,74 @@
+#include <stdio.h>
+#include <stdint.h>
+#include "src-headers/exo.h"
+#include <string.h>
+
+static const uint8_t cap_secret[32] = {
+    0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
+    0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
+    0x55,0xaa,0x55,0xaa,0x00,0x11,0x22,0x33,
+    0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
+};
+
+static uint64_t fnv64(const uint8_t *data, size_t len, uint64_t seed)
+{
+    const uint64_t prime = 1099511628211ULL;
+    uint64_t h = seed;
+    for(size_t i = 0; i < len; i++){
+        h ^= data[i];
+        h *= prime;
+    }
+    return h;
+}
+
+static void hash256(const uint8_t *data, size_t len, hash256_t *out)
+{
+    const uint64_t basis = 14695981039346656037ULL;
+    for(int i = 0; i < 4; i++)
+        out->parts[i] = fnv64(data, len, basis + i);
+}
+
+static void compute_tag(uint id, uint rights, uint owner, hash256_t *out)
+{
+    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
+    memmove(buf, cap_secret, sizeof(cap_secret));
+    memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
+    hash256(buf, sizeof(buf), out);
+}
+
+static exo_cap cap_new_local(uint id, uint rights, uint owner)
+{
+    exo_cap c;
+    c.id = id;
+    c.rights = rights;
+    c.owner = owner;
+    compute_tag(id, rights, owner, &c.auth_tag);
+    return c;
+}
+
+static int cap_verify_local(exo_cap c)
+{
+    hash256_t h;
+    compute_tag(c.id, c.rights, c.owner, &h);
+    return memcmp(h.parts, c.auth_tag.parts, sizeof(h.parts)) == 0;
+}
+
+static inline uint64_t rdtsc(void)
+{
+    unsigned hi, lo;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)hi << 32) | lo;
+}
+
+int main(void)
+{
+    exo_cap c = cap_new_local(1, 1, 1);
+    const int ITER = 1000000;
+    uint64_t start = rdtsc();
+    for (int i = 0; i < ITER; i++)
+        cap_verify_local(c);
+    uint64_t end = rdtsc();
+    printf("cap_verify: %lu cycles\n", (end - start) / ITER);
+    return 0;
+}

--- a/tests/microbench/context_switch.c
+++ b/tests/microbench/context_switch.c
@@ -1,0 +1,52 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+typedef struct context64 {
+    unsigned long r15;
+    unsigned long r14;
+    unsigned long r13;
+    unsigned long r12;
+    unsigned long rbx;
+    unsigned long rbp;
+    unsigned long rip;
+} context_t;
+
+void swtch(context_t **old, context_t *new);
+
+static inline uint64_t rdtsc(void)
+{
+    unsigned hi, lo;
+    __asm__ __volatile__("rdtsc" : "=a"(lo), "=d"(hi));
+    return ((uint64_t)hi << 32) | lo;
+}
+
+#define ITER 100000
+
+static context_t *main_ctx_ptr;
+static context_t *thread_ctx;
+static context_t main_ctx_storage;
+
+static void thread_func(void)
+{
+    for (;;)
+        swtch(&thread_ctx, main_ctx_ptr);
+}
+
+int main(void)
+{
+    static unsigned char stack[8192];
+    main_ctx_ptr = &main_ctx_storage;
+
+    thread_ctx = (context_t *)(stack + sizeof(stack) - sizeof(*thread_ctx));
+    memset(thread_ctx, 0, sizeof(*thread_ctx));
+    thread_ctx->rip = (unsigned long)thread_func;
+
+    uint64_t start = rdtsc();
+    for (int i = 0; i < ITER; i++)
+        swtch(&main_ctx_ptr, thread_ctx);
+    uint64_t end = rdtsc();
+
+    printf("context switch: %lu cycles\n", (end - start) / (ITER * 2));
+    return 0;
+}

--- a/tests/microbench/run.py
+++ b/tests/microbench/run.py
@@ -1,0 +1,38 @@
+import subprocess
+import tempfile
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+MB_DIR = ROOT / 'tests' / 'microbench'
+
+
+def build_and_run(sources):
+    with tempfile.TemporaryDirectory() as td:
+        exe = pathlib.Path(td) / 'bench'
+        cmd = [
+            'gcc',
+            '-std=c11',
+            '-I', str(ROOT),
+            '-I', str(ROOT / 'src-headers'),
+        ]
+        cmd.extend(str(s) for s in sources)
+        cmd.extend(['-o', str(exe)])
+        subprocess.check_call(cmd)
+        return subprocess.check_output([str(exe)]).decode()
+
+
+def main():
+    cap_out = build_and_run([
+        MB_DIR / 'cap_verify.c'
+    ])
+    print(cap_out.strip())
+
+    ctx_out = build_and_run([
+        MB_DIR / 'context_switch.c',
+        ROOT / 'src-kernel' / 'swtch64.S',
+    ])
+    print(ctx_out.strip())
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add small microbench programs for capability verification and context switching
- run microbenchmarks in CI
- start a TLA+ specification covering capability lifecycle
- document running the model checker

## Testing
- `make check`
- `make microbench`
