### PR TITLE
Add DDEKit stubs and demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -342,7 +342,10 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
        $(LIBOS_DIR)/posix.o \
-       $(LIBOS_DIR)/ipc_queue.o 
+       $(LIBOS_DIR)/ipc_queue.o \
+       $(LIBOS_DIR)/process.o \
+       $(LIBOS_DIR)/capwrap.o \
+       $(LIBOS_DIR)/ddekit/ddekit.o
 
 
 
@@ -445,6 +448,7 @@ _wc\
         _libos_posix_extra_test\
         _qspin_demo\
         _tty_demo\
+        _ddekit_demo\
 
 
 ifeq ($(ARCH),x86_64)

--- a/libos/capwrap.c
+++ b/libos/capwrap.c
@@ -1,0 +1,22 @@
+#include "capwrap.h"
+#include "caplib.h"
+
+exo_cap cap_page_alloc(void)
+{
+    return cap_alloc_page();
+}
+
+int cap_page_free(exo_cap cap)
+{
+    return cap_unbind_page(cap);
+}
+
+int cap_send_simple(exo_cap dest, const void *buf, size_t len)
+{
+    return cap_send(dest, buf, len);
+}
+
+int cap_recv_simple(exo_cap src, void *buf, size_t len)
+{
+    return cap_recv(src, buf, len);
+}

--- a/libos/ddekit/ddekit.c
+++ b/libos/ddekit/ddekit.c
@@ -1,0 +1,19 @@
+#include "ddekit.h"
+#include "user.h"
+
+void ddekit_init(void)
+{
+    /* No special initialization for stub implementation */
+}
+
+int ddekit_request_irq(int irq)
+{
+    (void)irq;
+    /* Stub always succeeds */
+    return 0;
+}
+
+void ddekit_print(const char *fmt, ...)
+{
+    printf(1, "%s", fmt);
+}

--- a/libos/ddekit/ddekit.h
+++ b/libos/ddekit/ddekit.h
@@ -1,0 +1,14 @@
+#pragma once
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void ddekit_init(void);
+int ddekit_request_irq(int irq);
+void ddekit_print(const char *fmt, ...);
+
+#ifdef __cplusplus
+}
+#endif

--- a/libos/process.c
+++ b/libos/process.c
@@ -1,0 +1,27 @@
+#include "process.h"
+#include "user.h"
+
+int proc_spawn(const char *path, char *const argv[])
+{
+    int pid = fork();
+    if(pid == 0) {
+        exec((char *)path, (char **)argv);
+        exit();
+    }
+    return pid;
+}
+
+int proc_wait(int pid)
+{
+    int w;
+    while((w = wait()) >= 0) {
+        if(w == pid)
+            return w;
+    }
+    return -1;
+}
+
+int proc_kill(int pid)
+{
+    return kill(pid);
+}

--- a/src-headers/libos/capwrap.h
+++ b/src-headers/libos/capwrap.h
@@ -1,0 +1,15 @@
+#pragma once
+#include "caplib.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+exo_cap cap_page_alloc(void);
+int cap_page_free(exo_cap cap);
+int cap_send_simple(exo_cap dest, const void *buf, size_t len);
+int cap_recv_simple(exo_cap src, void *buf, size_t len);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/process.h
+++ b/src-headers/libos/process.h
@@ -1,0 +1,14 @@
+#pragma once
+#include "types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int proc_spawn(const char *path, char *const argv[]);
+int proc_wait(int pid);
+int proc_kill(int pid);
+
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/process.h
+++ b/src-headers/process.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "types.h"
+
+int proc_spawn(const char *path, char *const argv[]);
+int proc_wait(int pid);
+int proc_kill(int pid);

--- a/src-uland/ddekit_demo.c
+++ b/src-uland/ddekit_demo.c
@@ -1,0 +1,10 @@
+#include "ddekit/ddekit.h"
+#include "user.h"
+
+int main(int argc, char *argv[])
+{
+    (void)argc; (void)argv;
+    ddekit_init();
+    ddekit_print("ddekit demo running\n");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add process management and capability wrapper headers
- create stub implementations for new wrappers
- add DDEKit stub port in `libos/ddekit`
- wire new objects and demo target into Makefile
- provide a minimal `ddekit_demo` program

## Testing
- `make libos` *(fails: gcc doesn't recognize `-std=c23`)*