### PR TITLE
Implement IRQ capability support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,7 @@ OBJS = \
     $(KERNEL_DIR)/main.o \
     $(KERNEL_DIR)/mp.o \
     $(KERNEL_DIR)/picirq.o \
+    $(KERNEL_DIR)/irq.o \
     $(KERNEL_DIR)/pipe.o \
     $(KERNEL_DIR)/proc.o \
     $(KERNEL_DIR)/sleeplock.o \
@@ -342,7 +343,8 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
        $(LIBOS_DIR)/posix.o \
-       $(LIBOS_DIR)/ipc_queue.o 
+       $(LIBOS_DIR)/ipc_queue.o \
+       $(LIBOS_DIR)/irq_client.o
 
 
 

--- a/libos/irq_client.c
+++ b/libos/irq_client.c
@@ -1,0 +1,21 @@
+#include "libos/irq_client.h"
+#include "../src-headers/irq.h"
+
+static void (*user_handler_fn)(void);
+
+static void trampoline(void)
+{
+    if(user_handler_fn)
+        user_handler_fn();
+}
+
+int irq_client_bind(exo_cap cap, void (*handler)(void))
+{
+    user_handler_fn = handler;
+    return irq_bind(cap, trampoline);
+}
+
+void irq_client_simulate(int irq)
+{
+    irq_simulate(irq);
+}

--- a/src-headers/cap.h
+++ b/src-headers/cap.h
@@ -7,6 +7,7 @@
 enum cap_type {
     CAP_TYPE_NONE = 0,
     CAP_TYPE_PAGE = 1,
+    CAP_TYPE_IRQ  = 2,
 };
 
 struct cap_entry {

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -274,6 +274,13 @@ void dag_node_set_priority(struct dag_node *, int);
 void dag_node_add_dep(struct dag_node *, struct dag_node *);
 void dag_sched_submit(struct dag_node *);
 
+// irq.c
+void irq_init(void);
+int irq_bind(exo_cap, void (*)(void));
+void irq_queue_event(int);
+void irq_dispatch(struct trapframe *);
+void irq_simulate(int);
+
 // rcu.c
 void rcuinit(void);
 void rcu_read_lock(void);

--- a/src-headers/irq.h
+++ b/src-headers/irq.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "exo.h"
+struct trapframe;
+
+void irq_init(void);
+int irq_bind(exo_cap cap, void (*handler)(void));
+void irq_queue_event(int irq);
+void irq_dispatch(struct trapframe *tf);
+void irq_simulate(int irq);

--- a/src-headers/libos/irq_client.h
+++ b/src-headers/libos/irq_client.h
@@ -1,0 +1,5 @@
+#pragma once
+#include "caplib.h"
+
+int irq_client_bind(exo_cap cap, void (*handler)(void));
+void irq_client_simulate(int irq);

--- a/src-kernel/irq.c
+++ b/src-kernel/irq.c
@@ -1,0 +1,87 @@
+#include "types.h"
+#include "defs.h"
+#include "spinlock.h"
+#include "cap.h"
+#include "mmu.h"
+#include "irq.h"
+#include <string.h>
+
+#define MAX_IRQ 32
+
+struct irq_entry {
+    void (*handler)(void);
+    int owner;
+    uint pending;
+};
+
+static struct spinlock irq_lock;
+static struct irq_entry irq_table[MAX_IRQ];
+
+void irq_init(void)
+{
+    initlock(&irq_lock, "irq");
+    memset(irq_table, 0, sizeof(irq_table));
+}
+
+static int check_cap(exo_cap c, int irq)
+{
+    struct cap_entry e;
+    if(!cap_verify(c))
+        return -1;
+    if(cap_table_lookup(c.id, &e) < 0)
+        return -1;
+    if(e.type != CAP_TYPE_IRQ || e.resource != (uint)irq)
+        return -1;
+    if(c.owner != myproc()->pid || e.owner != myproc()->pid)
+        return -1;
+    return 0;
+}
+
+int irq_bind(exo_cap c, void (*handler)(void))
+{
+    int irq = c.pa;
+    if(irq < 0 || irq >= MAX_IRQ)
+        return -1;
+    if(check_cap(c, irq) < 0)
+        return -1;
+    acquire(&irq_lock);
+    irq_table[irq].handler = handler;
+    irq_table[irq].owner = myproc()->pid;
+    irq_table[irq].pending = 0;
+    release(&irq_lock);
+    return 0;
+}
+
+void irq_queue_event(int irq)
+{
+    if(irq < 0 || irq >= MAX_IRQ)
+        return;
+    acquire(&irq_lock);
+    if(irq_table[irq].handler)
+        irq_table[irq].pending++;
+    release(&irq_lock);
+}
+
+void irq_dispatch(struct trapframe *tf)
+{
+    struct proc *p = myproc();
+    void (*fn)(void) = 0;
+    acquire(&irq_lock);
+    for(int i = 0; i < MAX_IRQ; i++){
+        struct irq_entry *e = &irq_table[i];
+        if(e->handler && e->owner == p->pid && e->pending){
+            e->pending--;
+            fn = e->handler;
+            break;
+        }
+    }
+    release(&irq_lock);
+    if(fn)
+        fn();
+}
+
+// testing helper
+void irq_simulate(int irq)
+{
+    irq_queue_event(irq);
+}

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -1,0 +1,78 @@
+import subprocess
+import tempfile
+import pathlib
+import textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent("""
+#include <assert.h>
+#include <stdint.h>
+#include <string.h>
+#include "src-headers/cap.h"
+#include "src-headers/irq.h"
+#include "src-headers/mmu.h"
+
+struct spinlock; struct cpu; static struct cpu* mycpu(void){ return 0; }
+static int holding(struct spinlock*l){(void)l;return 0;}
+static void getcallerpcs(void*v,unsigned pcs[]){(void)v;pcs[0]=0;}
+static void panic(char*msg){(void)msg;assert(0);}
+static void cprintf(const char*f,...){(void)f;}
+
+struct trapframe { uint64_t rip, rsp, cs; };
+struct proc { int pid; };
+static struct proc proc0 = {1};
+struct proc* myproc(void){ return &proc0; }
+
+#include "src-kernel/cap.c"
+#include "src-kernel/cap_table.c"
+#include "src-kernel/irq.c"
+#include "libos/irq_client.c"
+
+static int fired = 0;
+static void handler(void){ fired++; }
+
+int main(void){
+    cap_table_init();
+    irq_init();
+    char stack[16];
+    struct trapframe tf = { .rip = 0x1234, .rsp = (uint64_t)(stack + 8), .cs = DPL_USER };
+    exo_cap cap = cap_new(cap_table_alloc(CAP_TYPE_IRQ, 1, 0, proc0.pid), 0, proc0.pid);
+    cap.pa = 1;
+    assert(irq_client_bind(cap, handler) == 0);
+    irq_client_simulate(1);
+    irq_dispatch(&tf);
+    assert(fired == 1);
+    return 0;
+}
+""")
+
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        src.write_text(C_CODE)
+        # use existing stub spinlock helpers
+        (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
+        (pathlib.Path(td)/"defs.h").write_text("")
+        (pathlib.Path(td)/"types.h").write_text(
+            "typedef unsigned int uint;\n"
+            "typedef unsigned long uint64;\n"
+            "typedef unsigned short ushort;\n"
+            "typedef unsigned char uchar;\n")
+        (pathlib.Path(td)/"stdint.h").write_text("#include </usr/include/stdint.h>\n")
+        (pathlib.Path(td)/"mmu.h").write_text('#include "src-headers/mmu.h"\n')
+        exe = pathlib.Path(td)/"test"
+        subprocess.check_call([
+            "gcc", "-std=c11",
+            "-I", str(td),
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_irq_basic():
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- add CAP_TYPE_IRQ and implement IRQ queueing in the kernel
- create irq client helper in libos
- wire up build system for new objects
- add integration test for IRQ handling

## Testing
- `pytest -q`
