### PR TITLE
Add arbitration table with pluggable policy

### DIFF
--- a/doc/arbitration.md
+++ b/doc/arbitration.md
@@ -1,0 +1,22 @@
+# Arbitration Policies
+
+The arbitration table tracks ownership of arbitrary resources. Each entry
+records a resource `type`, a `resource_id` and the current `owner`. When a new
+request arrives for the same resource, a pluggable policy decides whether the
+existing owner should be replaced.
+
+```c
+int policy(uint type, uint resource_id,
+           uint current_owner, uint new_owner);
+```
+
+If the policy returns non‑zero the new owner takes over the entry.
+`arbitrate_request(type, id, owner)` uses the registered policy and logs the
+result with `cprintf`.
+
+Two simple policies are useful:
+
+* **First win** &ndash; the default policy keeps the first owner and rejects
+  later requests.
+* **Prefer lower ID** &ndash; replaces the current owner only if the new owner has
+  a numerically lower identifier.

--- a/src-headers/arbitrate.h
+++ b/src-headers/arbitrate.h
@@ -1,0 +1,22 @@
+#pragma once
+#include "types.h"
+#include <spinlock.h>
+
+struct arbitrate_entry {
+    uint type;
+    uint resource_id;
+    uint owner;
+};
+
+struct arbitrate_table {
+    struct spinlock lock;
+    struct arbitrate_entry entries[16];
+};
+
+typedef int (*arbitrate_policy_t)(uint type, uint resource_id,
+                                   uint current_owner, uint new_owner);
+
+void arbitrate_init(arbitrate_policy_t policy);
+void arbitrate_use_table(struct arbitrate_table *t);
+void arbitrate_register_policy(arbitrate_policy_t policy);
+int arbitrate_request(uint type, uint resource_id, uint owner);

--- a/src-kernel/arbitrate.c
+++ b/src-kernel/arbitrate.c
@@ -1,0 +1,101 @@
+#include "arbitrate.h"
+#include "spinlock.h"
+#include "defs.h"
+#include <string.h>
+
+#ifndef ARB_MAX
+#define ARB_MAX 16
+#endif
+
+static struct arbitrate_table default_table;
+static int initialized;
+static struct arbitrate_table *tbl = &default_table;
+
+static int default_policy(uint type, uint res, uint cur, uint newo) {
+    (void)type; (void)res; (void)cur; (void)newo;
+    return 0; // keep current owner
+}
+
+static arbitrate_policy_t policy = default_policy;
+
+void
+arbitrate_use_table(struct arbitrate_table *t)
+{
+    if(!t)
+        t = &default_table;
+    tbl = t;
+    initlock(&tbl->lock, "arb");
+    memset(tbl->entries, 0, sizeof(tbl->entries));
+    initialized = 1;
+}
+
+void
+arbitrate_init(arbitrate_policy_t p)
+{
+    arbitrate_use_table(&default_table);
+    if(p)
+        policy = p;
+}
+
+void
+arbitrate_register_policy(arbitrate_policy_t p)
+{
+    if(p)
+        policy = p;
+}
+
+int
+arbitrate_request(uint type, uint resource_id, uint owner)
+{
+    if(!initialized)
+        arbitrate_init(policy);
+
+    acquire(&tbl->lock);
+    int free_idx = -1;
+    struct arbitrate_entry *match = 0;
+    for(int i=0;i<ARB_MAX;i++){
+        struct arbitrate_entry *e = &tbl->entries[i];
+        if(e->owner == 0){
+            if(free_idx < 0)
+                free_idx = i;
+            continue;
+        }
+        if(e->type == type && e->resource_id == resource_id){
+            match = e;
+            break;
+        }
+    }
+
+    if(!match){
+        if(free_idx < 0){
+            release(&tbl->lock);
+            cprintf("arbitrate: no slot for %u/%u\n", type, resource_id);
+            return -1;
+        }
+        match = &tbl->entries[free_idx];
+        match->type = type;
+        match->resource_id = resource_id;
+        match->owner = owner;
+        release(&tbl->lock);
+        cprintf("arbitrate: grant %u/%u to %u\n", type, resource_id, owner);
+        return 0;
+    }
+
+    if(match->owner == owner){
+        release(&tbl->lock);
+        return 0;
+    }
+
+    int allow = policy ? policy(type, resource_id, match->owner, owner) : 0;
+    if(allow){
+        uint old = match->owner;
+        match->owner = owner;
+        release(&tbl->lock);
+        cprintf("arbitrate: replace %u/%u %u -> %u\n", type, resource_id, old, owner);
+        return 0;
+    }
+
+    release(&tbl->lock);
+    cprintf("arbitrate: deny %u/%u to %u (owner %u)\n", type, resource_id, owner, match->owner);
+    return -1;
+}

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -1,0 +1,69 @@
+import subprocess
+import tempfile
+import pathlib
+import textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent("""
+#include <assert.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include "src-headers/arbitrate.h"
+
+struct cpu; static struct cpu* mycpu(void){ return 0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; _exit(1); }
+static void cprintf(const char *f, ...){ (void)f; }
+
+#include "src-kernel/arbitrate.c"
+
+static int prefer_low(uint t, uint r, uint cur, uint newo){
+    (void)t; (void)r;
+    return newo < cur;
+}
+
+int main(void){
+    struct arbitrate_table *tbl = mmap(NULL, sizeof(struct arbitrate_table),
+                                       PROT_READ|PROT_WRITE,
+                                       MAP_ANON|MAP_SHARED, -1, 0);
+    assert(tbl != MAP_FAILED);
+    arbitrate_use_table(tbl);
+    arbitrate_init(prefer_low);
+
+    pid_t pid = fork();
+    if(pid==0){
+        int r = arbitrate_request(1, 42, 2);
+        _exit(r==0 ? 0 : 1);
+    }
+    int r1 = arbitrate_request(1, 42, 3);
+    int st; waitpid(pid, &st, 0);
+    int r2 = arbitrate_request(1, 42, 2);
+    return (r1==0 && st==0 && r2==0) ? 0 : 1;
+}
+""")
+
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        src.write_text(C_CODE)
+        (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
+        (pathlib.Path(td)/"defs.h").write_text("")
+        exe = pathlib.Path(td)/"test"
+        subprocess.check_call([
+            "gcc", "-std=c11",
+            "-I", str(td),
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_arbitration_conflict():
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- implement basic arbitration table in `src-kernel/arbitrate.c`
- expose policy hooks in `src-headers/arbitrate.h`
- document sample policies in `doc/arbitration.md`
- add unit test for conflicting requests between processes

## Testing
- `pytest -q`
