### PR TITLE
Add DDEKit stubs and capability wrappers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,7 +91,7 @@ ARCH ?= x86_64
 CSTD ?= c23
 CPPSTD ?= c++23
 CLANG_TIDY ?= clang-tidy
-TIDY_SRCS := $(wildcard $(KERNEL_DIR)/*.c $(ULAND_DIR)/*.c $(LIBOS_DIR)/*.c)
+TIDY_SRCS := $(wildcard $(KERNEL_DIR)/*.c $(ULAND_DIR)/*.c $(LIBOS_DIR)/*.c $(LIBOS_DIR)/ddekit/*.c)
 
 ifeq ($(ARCH),ia16)
 TOOLPREFIX ?= ia16-elf-
@@ -244,7 +244,7 @@ SIGNBOOT := 0
 endif
 
 
-CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(KERNEL_DIR)/include -I$(ULAND_DIR) -I$(LIBOS_DIR) -Iproto
+CFLAGS = -fno-pic -static -fno-builtin -fno-strict-aliasing -O2 -Wall -MD -ggdb $(ARCHFLAG) -Werror -fno-omit-frame-pointer -std=$(CSTD) -nostdinc -I. -Isrc-headers -I$(KERNEL_DIR) -I$(KERNEL_DIR)/include -I$(ULAND_DIR) -I$(LIBOS_DIR) -I$(LIBOS_DIR)/include -Iproto
 CFLAGS += -DCONFIG_SMP=$(CONFIG_SMP)
 CFLAGS += $(if $(filter ia16,$(ARCH)),-I$(KERNEL_DIR)/arch/ia16,)
 CFLAGS += $(shell $(CC) -fno-stack-protector -E -x c /dev/null >/dev/null 2>&1 && echo -fno-stack-protector)
@@ -342,7 +342,10 @@ LIBOS_OBJS = \
        $(LIBOS_DIR)/driver.o \
         $(LIBOS_DIR)/affine_runtime.o \
        $(LIBOS_DIR)/posix.o \
-       $(LIBOS_DIR)/ipc_queue.o 
+       $(LIBOS_DIR)/ipc_queue.o \
+       $(LIBOS_DIR)/process.o \
+       $(LIBOS_DIR)/capwrap.o \
+       $(LIBOS_DIR)/ddekit/ddekit.o
 
 
 
@@ -445,6 +448,7 @@ _wc\
         _libos_posix_extra_test\
         _qspin_demo\
         _tty_demo\
+        _ddekit_demo\
 
 
 ifeq ($(ARCH),x86_64)
@@ -608,3 +612,6 @@ clang-tidy:
 # Example C++ build rule demonstrating CXXFLAGS usage
 foo.o: foo.cpp
 	$(CXX) $(CXXFLAGS) -c -o $@ $<
+
+ddekit: _ddekit_demo
+

--- a/libos/capwrap.c
+++ b/libos/capwrap.c
@@ -1,0 +1,21 @@
+#include "include/capwrap.h"
+
+exo_cap cap_alloc_page(void)
+{
+    return exo_alloc_page();
+}
+
+int cap_unbind_page(exo_cap cap)
+{
+    return exo_unbind_page(cap);
+}
+
+int cap_send(exo_cap dest, const void *buf, uint64 len)
+{
+    return exo_send(dest, buf, len);
+}
+
+int cap_recv(exo_cap src, void *buf, uint64 len)
+{
+    return exo_recv(src, buf, len);
+}

--- a/libos/ddekit/ddekit.c
+++ b/libos/ddekit/ddekit.c
@@ -1,0 +1,23 @@
+#include "ddekit.h"
+#include "user.h"
+
+int ddekit_init(void)
+{
+    return 0; /* nothing to do for stub */
+}
+
+int ddekit_start_driver(const char *path, char *const argv[], exo_cap *drv_ep)
+{
+    int pid = proc_spawn(path, argv);
+    if(pid < 0)
+        return -1;
+    if(drv_ep)
+        *drv_ep = (exo_cap){0};
+    return pid;
+}
+
+int ddekit_handoff_cap(exo_cap ep, exo_cap cap)
+{
+    /* send capability to driver over provided endpoint */
+    return cap_send(ep, &cap, sizeof(cap));
+}

--- a/libos/ddekit/ddekit.h
+++ b/libos/ddekit/ddekit.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "include/capwrap.h"
+#include "include/process.h"
+
+/* Minimal DDEKit wrapper for Phoenix */
+
+int ddekit_init(void);
+int ddekit_start_driver(const char *path, char *const argv[], exo_cap *drv_ep);
+int ddekit_handoff_cap(exo_cap ep, exo_cap cap);

--- a/libos/include/capwrap.h
+++ b/libos/include/capwrap.h
@@ -1,0 +1,10 @@
+#pragma once
+#include "include/exokernel.h"
+
+/* Basic capability helpers used by DDEKit and libOS */
+
+exo_cap cap_alloc_page(void);
+int cap_unbind_page(exo_cap cap);
+int cap_send(exo_cap dest, const void *buf, uint64 len);
+int cap_recv(exo_cap src, void *buf, uint64 len);
+

--- a/libos/include/process.h
+++ b/libos/include/process.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "user.h"
+
+/* Simple process management helpers */
+
+int proc_spawn(const char *path, char *const argv[]);
+int proc_wait(int pid);
+int proc_kill(int pid);
+

--- a/libos/process.c
+++ b/libos/process.c
@@ -1,0 +1,26 @@
+#include "include/process.h"
+
+int proc_spawn(const char *path, char *const argv[])
+{
+    int pid = fork();
+    if(pid == 0) {
+        exec((char *)path, (char **)argv);
+        exit();
+    }
+    return pid;
+}
+
+int proc_wait(int pid)
+{
+    int w;
+    while((w = wait()) >= 0) {
+        if(w == pid)
+            return w;
+    }
+    return -1;
+}
+
+int proc_kill(int pid)
+{
+    return kill(pid);
+}

--- a/src-uland/ddekit_demo.c
+++ b/src-uland/ddekit_demo.c
@@ -1,0 +1,18 @@
+#include "ddekit/ddekit.h"
+#include "user.h"
+
+int main(void)
+{
+    ddekit_init();
+    char *argv[] = {"pingdriver", 0};
+    exo_cap ep;
+    int pid = ddekit_start_driver("pingdriver", argv, &ep);
+    if(pid < 0) {
+        printf(1, "ddekit_demo: spawn failed\n");
+        exit();
+    }
+    exo_cap page = cap_alloc_page();
+    ddekit_handoff_cap(ep, page);
+    printf(1, "ddekit_demo: capability sent to driver\n");
+    exit();
+}


### PR DESCRIPTION
## Summary
- add basic process/capability wrapper headers under libos/include
- provide corresponding stubs in libos
- introduce a minimal DDEKit port and demo
- hook new objects and test target in Makefile

## Testing
- `make ddekit` *(fails: unrecognized command-line option '-std=c23')*