### PR TITLE
Add microbenchmarks and initial TLA+ spec

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,7 @@ jobs:
       run: make check
     - name: Run fuzz smoke test
       run: python3 scripts/swift_fuzz.py -runs=1
+    - name: Run microbenchmarks
+      run: make -C tests/microbench run
     - name: Clean
       run: make clean

--- a/specs/Capability.tla
+++ b/specs/Capability.tla
@@ -1,0 +1,38 @@
+---- MODULE Capability ----
+EXTENDS Naturals, TLC
+
+CONSTANT Users
+
+VARIABLES caps, owner, active
+
+Init == /\ caps = {}
+         /\ owner = [c \in {} |-> 0]
+         /\ active = NULL
+
+Create(c,u) == /\ c \notin caps
+                /\ caps' = caps \cup {c}
+                /\ owner' = [owner EXCEPT ![c] = u]
+                /\ UNCHANGED active
+
+Revoke(c,u) == /\ c \in caps
+                /\ owner[c] = u
+                /\ caps' = caps \ {c}
+                /\ owner' = [o \in DOMAIN owner \ {c} |-> owner[o]]
+                /\ active' = IF active = c THEN NULL ELSE active
+
+YieldTo(src,dst,u) == /\ src \in caps
+                     /\ dst \in caps
+                     /\ owner[src] = u
+                     /\ active = src
+                     /\ active' = dst
+                     /\ UNCHANGED <<caps, owner>>
+
+Next == \E c \in Nat, u \in Users : Create(c,u)
+        \/ \E c \in caps, u \in Users : Revoke(c,u)
+        \/ \E s \in caps, d \in caps, u \in Users : YieldTo(s,d,u)
+
+Spec == Init /\ [][Next]_<<caps,owner,active>>
+
+ActiveInv == active = NULL \/ active \in caps
+
+====

--- a/specs/README.md
+++ b/specs/README.md
@@ -1,0 +1,17 @@
+# TLA+ Models
+
+This directory contains specifications used to explore the capability
+lifecycle and arbitration rules in ExO.
+
+## Running the Model Checker
+
+TLA+ tooling is distributed as part of the [TLA Toolbox](https://github.com/tlaplus/tlaplus).
+After installing the `tla2tools.jar` package, the model can be checked via:
+
+```bash
+java -jar /path/to/tla2tools.jar Capability.tla
+```
+
+The default specification defines a constant set of `Users` and verifies
+`ActiveInv`, which ensures that the current active capability is always
+part of the allocated set.

--- a/tests/microbench/Makefile
+++ b/tests/microbench/Makefile
@@ -1,0 +1,19 @@
+HOSTCC ?= gcc
+HOSTCFLAGS ?= -Wall -O2 -std=c99
+
+PROGS := cap_verify_bench exo_yield_to_bench
+
+all: $(PROGS)
+
+cap_verify_bench: cap_verify_bench.c
+	$(HOSTCC) $(HOSTCFLAGS) -o $@ $<
+
+exo_yield_to_bench: exo_yield_to_bench.c
+	$(HOSTCC) $(HOSTCFLAGS) -o $@ $<
+
+clean:
+	rm -f $(PROGS)
+
+run: all
+	./cap_verify_bench
+	./exo_yield_to_bench

--- a/tests/microbench/cap_verify_bench.c
+++ b/tests/microbench/cap_verify_bench.c
@@ -1,0 +1,71 @@
+#define _POSIX_C_SOURCE 199309L
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+typedef unsigned int uint;
+typedef unsigned long uint64;
+
+typedef struct hash256 { uint64 parts[4]; } hash256_t;
+typedef struct exo_cap { uint pa; uint id; uint rights; uint owner; hash256_t auth_tag; } exo_cap;
+
+static const uint8_t cap_secret[32] = {
+    0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
+    0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
+    0x55,0xaa,0x55,0xaa,0x00,0x11,0x22,0x33,
+    0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
+};
+
+static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
+    const uint64 prime = 1099511628211ULL;
+    uint64 h = seed;
+    for(size_t i=0;i<len;i++) {
+        h ^= data[i];
+        h *= prime;
+    }
+    return h;
+}
+
+static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
+    const uint64 basis = 14695981039346656037ULL;
+    for(int i=0;i<4;i++)
+        out->parts[i] = fnv64(data, len, basis + i);
+}
+
+static void compute_tag(uint id, uint rights, uint owner, hash256_t *out) {
+    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
+    memmove(buf, cap_secret, sizeof(cap_secret));
+    memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
+    hash256(buf, sizeof(buf), out);
+}
+
+static exo_cap cap_new(uint id, uint rights, uint owner) {
+    exo_cap c;
+    c.pa = 0;
+    c.id = id;
+    c.rights = rights;
+    c.owner = owner;
+    compute_tag(id, rights, owner, &c.auth_tag);
+    return c;
+}
+
+static int cap_verify(exo_cap c) {
+    hash256_t h;
+    compute_tag(c.id, c.rights, c.owner, &h);
+    return memcmp(h.parts, c.auth_tag.parts, sizeof(h.parts)) == 0;
+}
+
+int main(void) {
+    const int iters = 100000;
+    exo_cap c = cap_new(1,2,3);
+    struct timespec s,e;
+    clock_gettime(CLOCK_MONOTONIC, &s);
+    for(int i=0;i<iters;i++)
+        cap_verify(c);
+    clock_gettime(CLOCK_MONOTONIC, &e);
+    long long ns = (e.tv_sec - s.tv_sec)*1000000000LL + (e.tv_nsec - s.tv_nsec);
+    printf("cap_verify: %.2f ns\n", (double)ns/iters);
+    return 0;
+}

--- a/tests/microbench/exo_yield_to_bench.c
+++ b/tests/microbench/exo_yield_to_bench.c
@@ -1,0 +1,80 @@
+#define _POSIX_C_SOURCE 199309L
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+typedef unsigned int uint;
+typedef unsigned long uint64;
+
+typedef struct hash256 { uint64 parts[4]; } hash256_t;
+typedef struct exo_cap { uint pa; uint id; uint rights; uint owner; hash256_t auth_tag; } exo_cap;
+
+static const uint8_t cap_secret[32] = {
+    0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
+    0xfe,0xdc,0xba,0x98,0x76,0x54,0x32,0x10,
+    0x55,0xaa,0x55,0xaa,0x00,0x11,0x22,0x33,
+    0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
+};
+
+static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
+    const uint64 prime = 1099511628211ULL;
+    uint64 h = seed;
+    for(size_t i=0;i<len;i++) {
+        h ^= data[i];
+        h *= prime;
+    }
+    return h;
+}
+
+static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
+    const uint64 basis = 14695981039346656037ULL;
+    for(int i=0;i<4;i++)
+        out->parts[i] = fnv64(data, len, basis + i);
+}
+
+static void compute_tag(uint id, uint rights, uint owner, hash256_t *out) {
+    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
+    memmove(buf, cap_secret, sizeof(cap_secret));
+    memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
+    hash256(buf, sizeof(buf), out);
+}
+
+static exo_cap cap_new(uint id, uint rights, uint owner) {
+    exo_cap c;
+    c.pa = 0;
+    c.id = id;
+    c.rights = rights;
+    c.owner = owner;
+    compute_tag(id, rights, owner, &c.auth_tag);
+    return c;
+}
+
+static int cap_verify(exo_cap c) {
+    hash256_t h;
+    compute_tag(c.id, c.rights, c.owner, &h);
+    return memcmp(h.parts, c.auth_tag.parts, sizeof(h.parts)) == 0;
+}
+
+static int exo_yield_to(exo_cap target) {
+    if (target.pa == 0)
+        return -1;
+    if (!cap_verify(target))
+        return -1;
+    return 0;
+}
+
+int main(void) {
+    const int iters = 100000;
+    exo_cap c = cap_new(1,2,3);
+    c.pa = 1; // valid address
+    struct timespec s,e;
+    clock_gettime(CLOCK_MONOTONIC, &s);
+    for(int i=0;i<iters;i++)
+        exo_yield_to(c);
+    clock_gettime(CLOCK_MONOTONIC, &e);
+    long long ns = (e.tv_sec - s.tv_sec)*1000000000LL + (e.tv_nsec - s.tv_nsec);
+    printf("exo_yield_to: %.2f ns\n", (double)ns/iters);
+    return 0;
+}


### PR DESCRIPTION
## Summary
- create microbench programs for `cap_verify` and `exo_yield_to`
- run benchmarks in CI
- start a TLA+ spec capturing capability lifecycle
- document how to run the TLA+ model checker

## Testing
- `make check`
- `make -C tests/microbench run`
