### PR TITLE
Update tests to use C23

### DIFF
--- a/tests/microbench/Makefile
+++ b/tests/microbench/Makefile
@@ -1,5 +1,5 @@
 HOSTCC ?= clang
-HOSTCFLAGS ?= -Wall -O2 -std=c99 -I../../libos/include -I../../src-headers
+HOSTCFLAGS ?= -Wall -O2 -std=c23 -I../../libos/include -I../../src-headers
 
 PROGS := cap_verify_bench exo_yield_to_bench proc_cap_test
 

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -55,7 +55,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c11",
+            "gcc", "-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_newtypes.py
+++ b/tests/test_cap_newtypes.py
@@ -55,7 +55,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -56,7 +56,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_types.py
+++ b/tests/test_cap_types.py
@@ -56,7 +56,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -44,7 +44,7 @@ def compile_and_run() -> None:
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(C_CODE)
-        subprocess.check_call(["gcc", "-std=c11", str(src), "-o", str(exe)])
+        subprocess.check_call(["gcc", "-std=c23", str(src), "-o", str(exe)])
         subprocess.check_call([str(exe)])
 
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -38,7 +38,7 @@ def compile_and_run() -> None:
         subprocess.check_call(
             [
                 "gcc",
-                "-std=c11",
+                "-std=c23",
                 "-I",
                 str(ROOT),
                 "-I",

--- a/tests/test_iommu.py
+++ b/tests/test_iommu.py
@@ -49,7 +49,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c11",
+            "gcc", "-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -65,7 +65,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
         )
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -60,7 +60,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c11","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c23","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_lockstress.py
+++ b/tests/test_lockstress.py
@@ -86,7 +86,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c11","-pthread","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c23","-pthread","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_ptrace_concurrent.py
+++ b/tests/test_ptrace_concurrent.py
@@ -52,7 +52,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             str(src),
             "-o", str(exe)
         ])

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -22,7 +22,7 @@ def compile_and_run(use_stub):
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
         cmd = [
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_sys_ipc.py
+++ b/tests/test_sys_ipc.py
@@ -80,7 +80,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
         )
         subprocess.check_call([
-            "gcc", "-std=c11",
+            "gcc", "-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_uv_spinlock_processes.py
+++ b/tests/test_uv_spinlock_processes.py
@@ -53,7 +53,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_uv_spinlock_threads.py
+++ b/tests/test_uv_spinlock_threads.py
@@ -40,7 +40,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c11","-pthread",
+            "gcc","-std=c23","-pthread",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -55,7 +55,7 @@ def compile_and_run(body):
         (pathlib.Path(td)/"mmu.h").write_text('#include "src-headers/types.h"\n#include "src-headers/mmu.h"\n')
         (pathlib.Path(td)/"memlayout.h").write_text('#include "src-headers/memlayout.h"\n')
         subprocess.check_call([
-            "gcc","-std=c11",
+            "gcc","-std=c23",
             "-I", str(td),
             "-I", str(ROOT),
             str(src),


### PR DESCRIPTION
## Summary
- update microbench Makefile to build with C23
- compile all test helper programs with `-std=c23`

## Testing
- `pytest -q` *(fails: `gcc` does not recognize `-std=c23`)*