### PR TITLE
Mark important return values [[nodiscard]]

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -23,7 +23,7 @@ typedef struct exo_blockcap {
 
 #ifdef EXO_KERNEL
 exo_cap exo_alloc_page(void);
-int exo_unbind_page(exo_cap c);
+[[nodiscard]] int exo_unbind_page(exo_cap c);
 exo_cap cap_new(uint id, uint rights, uint owner);
 int cap_verify(exo_cap c);
 #endif

--- a/libos/affine_runtime.c
+++ b/libos/affine_runtime.c
@@ -2,7 +2,8 @@
 #include "ulib.h" // for malloc/free
 
 // Allocate an affine channel
-affine_chan_t *affine_chan_create(const struct msg_type_desc *desc) {
+[[nodiscard]] affine_chan_t *
+affine_chan_create(const struct msg_type_desc *desc) {
   affine_chan_t *c = malloc(sizeof(affine_chan_t));
   if (c) {
     c->base.desc = desc;
@@ -17,8 +18,8 @@ affine_chan_t *affine_chan_create(const struct msg_type_desc *desc) {
 void affine_chan_destroy(affine_chan_t *c) { free(c); }
 
 // Send once through the channel
-int affine_chan_send(affine_chan_t *c, exo_cap dest, const void *msg,
-                     size_t len) {
+[[nodiscard]] int affine_chan_send(affine_chan_t *c, exo_cap dest,
+                                   const void *msg, size_t len) {
   if (!c || c->used_send)
     return -1;
   int r = chan_endpoint_send(&c->base, dest, msg, len);
@@ -28,7 +29,8 @@ int affine_chan_send(affine_chan_t *c, exo_cap dest, const void *msg,
 }
 
 // Receive once through the channel
-int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg, size_t len) {
+[[nodiscard]] int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg,
+                                   size_t len) {
   if (!c || c->used_recv)
     return -1;
   int r = chan_endpoint_recv(&c->base, src, msg, len);

--- a/libos/driver.c
+++ b/libos/driver.c
@@ -1,17 +1,15 @@
 #include "driver.h"
 #include "user.h"
 
-int driver_spawn(const char *path, char *const argv[])
-{
-    int pid = fork();
-    if(pid == 0) {
-        exec((char *)path, (char **)argv);
-        exit();
-    }
-    return pid;
+[[nodiscard]] int driver_spawn(const char *path, char *const argv[]) {
+  int pid = fork();
+  if (pid == 0) {
+    exec((char *)path, (char **)argv);
+    exit();
+  }
+  return pid;
 }
 
-int driver_connect(int pid, exo_cap ep)
-{
-    return cap_send(ep, &pid, sizeof(pid));
+[[nodiscard]] int driver_connect(int pid, exo_cap ep) {
+  return cap_send(ep, &pid, sizeof(pid));
 }

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -4,20 +4,22 @@
 #include "exokernel.h"
 
 exo_cap cap_alloc_page(void);
-int cap_unbind_page(exo_cap cap);
-int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap);
-int cap_bind_block(exo_blockcap *cap, void *data, int write);
+[[nodiscard]] int cap_unbind_page(exo_cap cap);
+[[nodiscard]] int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap);
+[[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write);
 void cap_flush_block(exo_blockcap *cap, void *data);
-int cap_send(exo_cap dest, const void *buf, uint64 len);
-int cap_recv(exo_cap src, void *buf, uint64 len);
-int cap_set_timer(void (*handler)(void));
-int cap_set_gas(uint64 amount);
-int cap_get_gas(void);
-int cap_out_of_gas(void);
+[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len);
+[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] int cap_set_timer(void (*handler)(void));
+[[nodiscard]] int cap_set_gas(uint64 amount);
+[[nodiscard]] int cap_get_gas(void);
+[[nodiscard]] int cap_out_of_gas(void);
 void cap_yield_to(context_t **old, context_t *target);
-int cap_yield_to_cap(exo_cap target);
-int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
-int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
-int cap_ipc_echo_demo(void);
-int cap_inc(uint16_t id);
-int cap_dec(uint16_t id);
+[[nodiscard]] int cap_yield_to_cap(exo_cap target);
+[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64 off,
+                                uint64 n);
+[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64 off,
+                                 uint64 n);
+[[nodiscard]] int cap_ipc_echo_demo(void);
+[[nodiscard]] int cap_inc(uint16_t id);
+[[nodiscard]] int cap_dec(uint16_t id);

--- a/src-headers/chan.h
+++ b/src-headers/chan.h
@@ -4,46 +4,43 @@
 
 // Generic channel descriptor storing expected message size and type
 typedef struct chan {
-    size_t msg_size;
-    const struct msg_type_desc *desc;
+  size_t msg_size;
+  const struct msg_type_desc *desc;
 } chan_t;
 
 // Allocate a channel expecting messages of size msg_size bytes
-chan_t *chan_create(const struct msg_type_desc *desc);
+[[nodiscard]] chan_t *chan_create(const struct msg_type_desc *desc);
 
 // Free a channel allocated with chan_create
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len);
-int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len);
+[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
+                                     size_t len);
+[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+                                     size_t len);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
 // Provides mychan_t type with create/send/recv functions
-#define CHAN_DECLARE(name, type)                                    \
-    static const struct msg_type_desc name##_typedesc = { type##_MESSAGE_SIZE }; \
-    typedef struct {                                                \
-        chan_t base;                                                \
-    } name##_t;                                                     \
-    static inline name##_t *name##_create(void) {                   \
-        return (name##_t *)chan_create(&name##_typedesc);           \
-    }                                                               \
-    static inline void name##_destroy(name##_t *c) {                 \
-        chan_destroy(&c->base);                                     \
-    }                                                               \
-    static inline int name##_send(name##_t *c, exo_cap dest, const type *m){ \
-        unsigned char buf[type##_MESSAGE_SIZE];                     \
-        type##_encode(m, buf);                                      \
-        return chan_endpoint_send(&c->base, dest, buf,              \
-                                  type##_MESSAGE_SIZE);             \
-    }                                                               \
-    static inline int name##_recv(name##_t *c, exo_cap src, type *m){ \
-        unsigned char buf[type##_MESSAGE_SIZE];                     \
-        int r = chan_endpoint_recv(&c->base, src, buf,              \
-                                   type##_MESSAGE_SIZE);            \
-        if(r == 0)                                                 \
-            type##_decode(m, buf);                                  \
-        return r;                                                   \
-    }
-
+#define CHAN_DECLARE(name, type)                                               \
+  static const struct msg_type_desc name##_typedesc = {type##_MESSAGE_SIZE};   \
+  typedef struct {                                                             \
+    chan_t base;                                                               \
+  } name##_t;                                                                  \
+  static inline name##_t *name##_create(void) {                                \
+    return (name##_t *)chan_create(&name##_typedesc);                          \
+  }                                                                            \
+  static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
+  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    type##_encode(m, buf);                                                     \
+    return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
+  }                                                                            \
+  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
+    if (r == 0)                                                                \
+      type##_decode(m, buf);                                                   \
+    return r;                                                                  \
+  }

--- a/src-headers/door.h
+++ b/src-headers/door.h
@@ -7,14 +7,14 @@ extern "C" {
 #endif
 
 typedef struct door {
-    exo_cap dest;
-    void (*handler)(zipc_msg_t *msg);
-    int is_local;
+  exo_cap dest;
+  void (*handler)(zipc_msg_t *msg);
+  int is_local;
 } door_t;
 
 door_t door_create_local(void (*handler)(zipc_msg_t *msg));
 door_t door_create_remote(exo_cap dest);
-int door_call(door_t *d, zipc_msg_t *msg);
+[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg);
 void door_server_loop(door_t *d);
 
 #ifdef __cplusplus

--- a/src-headers/driver.h
+++ b/src-headers/driver.h
@@ -2,5 +2,5 @@
 #include "types.h"
 #include "caplib.h"
 
-int driver_spawn(const char *path, char *const argv[]);
-int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
+[[nodiscard]] int driver_connect(int pid, exo_cap ep);

--- a/src-headers/endpoint.h
+++ b/src-headers/endpoint.h
@@ -3,16 +3,16 @@
 #include "spinlock.h"
 
 struct endpoint {
-    struct spinlock lock;
-    zipc_msg_t *q;
-    uint size;
-    uint r, w;
-    int inited;
-    const struct msg_type_desc *desc;
+  struct spinlock lock;
+  zipc_msg_t *q;
+  uint size;
+  uint r, w;
+  int inited;
+  const struct msg_type_desc *desc;
 };
 
 void endpoint_init(struct endpoint *ep);
 void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
                      const struct msg_type_desc *desc);
 void endpoint_send(struct endpoint *ep, zipc_msg_t *m);
-int endpoint_recv(struct endpoint *ep, zipc_msg_t *m);
+[[nodiscard]] int endpoint_recv(struct endpoint *ep, zipc_msg_t *m);

--- a/src-headers/exo_cpu.h
+++ b/src-headers/exo_cpu.h
@@ -58,4 +58,4 @@ static inline void cap_yield(context_t **old, context_t *target) {
   swtch(old, target);
 }
 
-int exo_yield_to(exo_cap target);
+[[nodiscard]] int exo_yield_to(exo_cap target);

--- a/src-headers/exo_disk.h
+++ b/src-headers/exo_disk.h
@@ -4,5 +4,7 @@
 #include "../exo.h"
 #include <stdint.h>
 
-int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n);
-int exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n);
+[[nodiscard]] int exo_read_disk(struct exo_blockcap cap, void *dst,
+                                uint64_t off, uint64_t n);
+[[nodiscard]] int exo_write_disk(struct exo_blockcap cap, const void *src,
+                                 uint64_t off, uint64_t n);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -8,7 +8,6 @@ struct exo_ipc_ops {
   int (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
-
 void exo_ipc_register(struct exo_ipc_ops *ops);
-int exo_send(exo_cap dest, const void *buf, uint64_t len);
-int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-headers/exo_irq.h
+++ b/src-headers/exo_irq.h
@@ -8,8 +8,8 @@ extern "C" {
 #endif
 
 exo_cap exo_alloc_irq(uint irq, uint rights);
-int exo_irq_wait(exo_cap cap, uint *irq);
-int exo_irq_ack(exo_cap cap);
+[[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq);
+[[nodiscard]] int exo_irq_ack(exo_cap cap);
 void irq_trigger(uint irq);
 
 #ifdef __cplusplus

--- a/src-headers/exo_mem.h
+++ b/src-headers/exo_mem.h
@@ -2,4 +2,4 @@
 #include "../exo.h"
 
 exo_cap exo_alloc_page(void);
-int exo_unbind_page(exo_cap cap);
+[[nodiscard]] int exo_unbind_page(exo_cap cap);

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -4,16 +4,14 @@
 #include "syscall.h"
 
 /* Capability access rights. */
-#define EXO_RIGHT_R   0x1
-#define EXO_RIGHT_W   0x2
-#define EXO_RIGHT_X   0x4
+#define EXO_RIGHT_R 0x1
+#define EXO_RIGHT_W 0x2
+#define EXO_RIGHT_X 0x4
 #define EXO_RIGHT_CTL 0x8
 
-static inline int cap_has_rights(uint rights, uint need)
-{
-    return (rights & need) == need;
+static inline int cap_has_rights(uint rights, uint need) {
+  return (rights & need) == need;
 }
-
 
 /*
  * Minimal exokernel capability primitives.  Library operating systems
@@ -29,16 +27,16 @@ exo_cap exo_alloc_page(void);
 
 /* Free the page referenced by cap and remove any mappings to it.  Returns 0
  * on success and -1 on failure. */
-int exo_unbind_page(exo_cap cap);
+[[nodiscard]] int exo_unbind_page(exo_cap cap);
 
 /* Allocate a disk block capability for device 'dev'.  On success the
  * capability is stored in *cap and zero is returned. */
-int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap);
+[[nodiscard]] int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap);
 
 /* Bind the block capability to the buffer 'data'.  If 'write' is non-zero the
  * contents of the buffer are written to disk; otherwise the block is read into
  * the buffer.  Returns 0 on success. */
-int exo_bind_block(exo_blockcap *cap, void *data, int write);
+[[nodiscard]] int exo_bind_block(exo_blockcap *cap, void *data, int write);
 
 /* Allocate a capability referencing an I/O port. */
 exo_cap exo_alloc_ioport(uint port);
@@ -52,24 +50,26 @@ exo_cap exo_alloc_dma(uint chan);
 /* Switch to the context referenced by 'target'.  The caller's context must be
  * saved in a user-managed structure.  The kernel does not choose the next
  * runnable task. */
-int exo_yield_to(exo_cap target);
+[[nodiscard]] int exo_yield_to(exo_cap target);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any queuing
  * or flow control is managed in user space. */
-int exo_send(exo_cap dest, const void *buf, uint64 len);
+[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64 len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
-int exo_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64 len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
-int exo_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n);
-int exo_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
+[[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64 off,
+                                uint64 n);
+[[nodiscard]] int exo_write_disk(exo_blockcap cap, const void *src, uint64 off,
+                                 uint64 n);
 
 /* Allocate and wait/acknowledge interrupt events. */
 exo_cap exo_alloc_irq(uint irq, uint rights);
-int exo_irq_wait(exo_cap cap, uint *irq);
-int exo_irq_ack(exo_cap cap);
+[[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq);
+[[nodiscard]] int exo_irq_ack(exo_cap cap);
 /* Allocate capabilities for I/O ports, IRQs, and DMA channels. */
 exo_cap exo_alloc_ioport(uint port);
 exo_cap exo_bind_irq(uint irq);
@@ -78,22 +78,22 @@ exo_cap exo_alloc_dma(uint chan);
 
 /* Enumeration of syscall numbers for the primitives. */
 enum exo_syscall {
-    EXO_SYSCALL_ALLOC_PAGE  = SYS_exo_alloc_page,
-    EXO_SYSCALL_UNBIND_PAGE = SYS_exo_unbind_page,
-    EXO_SYSCALL_ALLOC_BLOCK = SYS_exo_alloc_block,
-    EXO_SYSCALL_BIND_BLOCK  = SYS_exo_bind_block,
-    EXO_SYSCALL_FLUSH_BLOCK = SYS_exo_flush_block,
-    EXO_SYSCALL_YIELD_TO    = SYS_exo_yield_to,
-    EXO_SYSCALL_SEND        = SYS_exo_send,
-    EXO_SYSCALL_RECV        = SYS_exo_recv,
-    EXO_SYSCALL_READ_DISK   = SYS_exo_read_disk,
-    EXO_SYSCALL_WRITE_DISK  = SYS_exo_write_disk,
-    EXO_SYSCALL_ALLOC_IOPORT = SYS_exo_alloc_ioport,
-    EXO_SYSCALL_BIND_IRQ     = SYS_exo_bind_irq,
-    EXO_SYSCALL_ALLOC_DMA    = SYS_exo_alloc_dma,
-    EXO_SYSCALL_CAP_INC     = SYS_cap_inc,
-    EXO_SYSCALL_CAP_DEC     = SYS_cap_dec,
-    EXO_SYSCALL_IRQ_ALLOC   = SYS_exo_irq_alloc,
-    EXO_SYSCALL_IRQ_WAIT    = SYS_exo_irq_wait,
-    EXO_SYSCALL_IRQ_ACK     = SYS_exo_irq_ack,
+  EXO_SYSCALL_ALLOC_PAGE = SYS_exo_alloc_page,
+  EXO_SYSCALL_UNBIND_PAGE = SYS_exo_unbind_page,
+  EXO_SYSCALL_ALLOC_BLOCK = SYS_exo_alloc_block,
+  EXO_SYSCALL_BIND_BLOCK = SYS_exo_bind_block,
+  EXO_SYSCALL_FLUSH_BLOCK = SYS_exo_flush_block,
+  EXO_SYSCALL_YIELD_TO = SYS_exo_yield_to,
+  EXO_SYSCALL_SEND = SYS_exo_send,
+  EXO_SYSCALL_RECV = SYS_exo_recv,
+  EXO_SYSCALL_READ_DISK = SYS_exo_read_disk,
+  EXO_SYSCALL_WRITE_DISK = SYS_exo_write_disk,
+  EXO_SYSCALL_ALLOC_IOPORT = SYS_exo_alloc_ioport,
+  EXO_SYSCALL_BIND_IRQ = SYS_exo_bind_irq,
+  EXO_SYSCALL_ALLOC_DMA = SYS_exo_alloc_dma,
+  EXO_SYSCALL_CAP_INC = SYS_cap_inc,
+  EXO_SYSCALL_CAP_DEC = SYS_cap_dec,
+  EXO_SYSCALL_IRQ_ALLOC = SYS_exo_irq_alloc,
+  EXO_SYSCALL_IRQ_WAIT = SYS_exo_irq_wait,
+  EXO_SYSCALL_IRQ_ACK = SYS_exo_irq_ack,
 };

--- a/src-headers/libos/affine_runtime.h
+++ b/src-headers/libos/affine_runtime.h
@@ -9,11 +9,13 @@ typedef struct affine_chan {
   int used_recv;
 } affine_chan_t;
 
-affine_chan_t *affine_chan_create(const struct msg_type_desc *desc);
+[[nodiscard]] affine_chan_t *
+affine_chan_create(const struct msg_type_desc *desc);
 void affine_chan_destroy(affine_chan_t *c);
-int affine_chan_send(affine_chan_t *c, exo_cap dest, const void *msg,
-                     size_t len);
-int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg, size_t len);
+[[nodiscard]] int affine_chan_send(affine_chan_t *c, exo_cap dest,
+                                   const void *msg, size_t len);
+[[nodiscard]] int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg,
+                                   size_t len);
 
 // Simple lambda term representation
 typedef int (*lambda_fn)(void *env);

--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -2,5 +2,5 @@
 #include "types.h"
 #include "caplib.h"
 
-int driver_spawn(const char *path, char *const argv[]);
-int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
+[[nodiscard]] int driver_connect(int pid, exo_cap ep);

--- a/src-kernel/chan.c
+++ b/src-kernel/chan.c
@@ -2,7 +2,8 @@
 #include "exo_ipc.h"
 
 // Kernel variant of chan_endpoint_send validating the message size
-int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
+[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
+                                     size_t len) {
   if (!c) {
     cprintf("chan_endpoint_send: null channel\n");
     return -1;
@@ -16,7 +17,8 @@ int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
 }
 
 // Kernel variant of chan_endpoint_recv validating the message size
-int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
+[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+                                     size_t len) {
   if (!c) {
     cprintf("chan_endpoint_recv: null channel\n");
     return -1;

--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -6,90 +6,79 @@
 
 static struct endpoint global_ep;
 
-
-
-void
-endpoint_init(struct endpoint *ep)
-{
-    if(!ep->inited){
-        initlock(&ep->lock, "endpoint");
-        ep->r = ep->w = 0;
-        ep->inited = 1;
-        ep->desc = 0;
-    }
-}
-
-void
-endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
-                const struct msg_type_desc *desc)
-{
-    endpoint_init(ep);
-    acquire(&ep->lock);
-    ep->q = buf;
-    ep->size = size;
-    ep->desc = desc;
+void endpoint_init(struct endpoint *ep) {
+  if (!ep->inited) {
+    initlock(&ep->lock, "endpoint");
     ep->r = ep->w = 0;
-    release(&ep->lock);
+    ep->inited = 1;
+    ep->desc = 0;
+  }
 }
 
-void
-endpoint_send(struct endpoint *ep, zipc_msg_t *m)
-{
-    endpoint_init(ep);
-    acquire(&ep->lock);
-    if(ep->q && ep->size && ep->w - ep->r < ep->size){
-        size_t sz = msg_desc_size(ep->desc);
-        const uchar *p = (const uchar *)m;
-        for(size_t i = sz; i < sizeof(zipc_msg_t); i++)
-            if(p[i]){ release(&ep->lock); return; }
-        zipc_msg_t tmp = {0};
-        memmove(&tmp, m, sz);
-        ep->q[ep->w % ep->size] = tmp;
-        ep->w++;
-        wakeup(&ep->r);
-    }
-    release(&ep->lock);
+void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+                     const struct msg_type_desc *desc) {
+  endpoint_init(ep);
+  acquire(&ep->lock);
+  ep->q = buf;
+  ep->size = size;
+  ep->desc = desc;
+  ep->r = ep->w = 0;
+  release(&ep->lock);
 }
 
-int
-endpoint_recv(struct endpoint *ep, zipc_msg_t *m)
-{
-    endpoint_init(ep);
-    acquire(&ep->lock);
-    while(ep->q && ep->r == ep->w){
-        sleep(&ep->r, &ep->lock);
-    }
-    if(!ep->q){
-        release(&ep->lock);
-        return -1;
-    }
-    zipc_msg_t t = ep->q[ep->r % ep->size];
-    ep->r++;
+void endpoint_send(struct endpoint *ep, zipc_msg_t *m) {
+  endpoint_init(ep);
+  acquire(&ep->lock);
+  if (ep->q && ep->size && ep->w - ep->r < ep->size) {
     size_t sz = msg_desc_size(ep->desc);
-    memmove(m, &t, sz);
-    memset((char *)m + sz, 0, sizeof(zipc_msg_t) - sz);
+    const uchar *p = (const uchar *)m;
+    for (size_t i = sz; i < sizeof(zipc_msg_t); i++)
+      if (p[i]) {
+        release(&ep->lock);
+        return;
+      }
+    zipc_msg_t tmp = {0};
+    memmove(&tmp, m, sz);
+    ep->q[ep->w % ep->size] = tmp;
+    ep->w++;
+    wakeup(&ep->r);
+  }
+  release(&ep->lock);
+}
+
+[[nodiscard]] int endpoint_recv(struct endpoint *ep, zipc_msg_t *m) {
+  endpoint_init(ep);
+  acquire(&ep->lock);
+  while (ep->q && ep->r == ep->w) {
+    sleep(&ep->r, &ep->lock);
+  }
+  if (!ep->q) {
     release(&ep->lock);
-    return 0;
+    return -1;
+  }
+  zipc_msg_t t = ep->q[ep->r % ep->size];
+  ep->r++;
+  size_t sz = msg_desc_size(ep->desc);
+  memmove(m, &t, sz);
+  memset((char *)m + sz, 0, sizeof(zipc_msg_t) - sz);
+  release(&ep->lock);
+  return 0;
 }
 
-int
-sys_endpoint_send(void)
-{
-    zipc_msg_t *umsg;
-    if(argptr(0, (void*)&umsg, sizeof(*umsg)) < 0)
-        return -1;
-    endpoint_send(&global_ep, umsg);
-    return 0;
+int sys_endpoint_send(void) {
+  zipc_msg_t *umsg;
+  if (argptr(0, (void *)&umsg, sizeof(*umsg)) < 0)
+    return -1;
+  endpoint_send(&global_ep, umsg);
+  return 0;
 }
 
-int
-sys_endpoint_recv(void)
-{
-    zipc_msg_t *udst;
-    zipc_msg_t m;
-    if(argptr(0, (void*)&udst, sizeof(*udst)) < 0)
-        return -1;
-    endpoint_recv(&global_ep, &m);
-    memmove(udst, &m, sizeof(m));
-    return 0;
+int sys_endpoint_recv(void) {
+  zipc_msg_t *udst;
+  zipc_msg_t m;
+  if (argptr(0, (void *)&udst, sizeof(*udst)) < 0)
+    return -1;
+  endpoint_recv(&global_ep, &m);
+  memmove(udst, &m, sizeof(m));
+  return 0;
 }

--- a/src-kernel/exo_cpu.c
+++ b/src-kernel/exo_cpu.c
@@ -5,14 +5,13 @@
 #include "memlayout.h"
 #include "exo_cpu.h"
 
-int exo_yield_to(exo_cap target)
-{
+[[nodiscard]] int exo_yield_to(exo_cap target) {
   if (target.pa == 0)
     return -1;
   if (!cap_verify(target))
     return -1;
 
-  context_t *newctx = (context_t*)P2V(target.id);
+  context_t *newctx = (context_t *)P2V(target.id);
   swtch(&myproc()->context, newctx);
   return 0;
 }

--- a/src-kernel/exo_disk.c
+++ b/src-kernel/exo_disk.c
@@ -8,13 +8,11 @@
 #define EXO_KERNEL
 #include "include/exokernel.h"
 
-#define MIN(a,b) ((a) < (b) ? (a) : (b))
+#define MIN(a, b) ((a) < (b) ? (a) : (b))
 
-int
-exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
-{
-  if(cap.owner != myproc()->pid ||
-     !cap_has_rights(cap.rights, EXO_RIGHT_R))
+[[nodiscard]] int exo_read_disk(struct exo_blockcap cap, void *dst,
+                                uint64_t off, uint64_t n) {
+  if (cap.owner != myproc()->pid || !cap_has_rights(cap.rights, EXO_RIGHT_R))
     return -EPERM;
   struct buf b;
   uint64_t tot = 0;
@@ -23,13 +21,13 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE,
-                                cap.rights, cap.owner };
+    struct exo_blockcap blk = {cap.dev, cap.blockno + cur / BSIZE, cap.rights,
+                               cap.owner};
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);
     int r = exo_bind_block(&blk, &b, 0);
-    if(r < 0){
+    if (r < 0) {
       releasesleep(&b.lock);
       return r;
     }
@@ -42,11 +40,9 @@ exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n)
   return (int)tot;
 }
 
-int
-exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n)
-{
-  if(cap.owner != myproc()->pid ||
-     !cap_has_rights(cap.rights, EXO_RIGHT_W))
+[[nodiscard]] int exo_write_disk(struct exo_blockcap cap, const void *src,
+                                 uint64_t off, uint64_t n) {
+  if (cap.owner != myproc()->pid || !cap_has_rights(cap.rights, EXO_RIGHT_W))
     return -EPERM;
   struct buf b;
   uint64_t tot = 0;
@@ -55,14 +51,14 @@ exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t 
 
   while (tot < n) {
     uint64_t cur = off + tot;
-    struct exo_blockcap blk = { cap.dev, cap.blockno + cur/BSIZE,
-                                cap.rights, cap.owner };
+    struct exo_blockcap blk = {cap.dev, cap.blockno + cur / BSIZE, cap.rights,
+                               cap.owner};
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);
     memmove(b.data + cur % BSIZE, (char *)src + tot, m);
     int r = exo_bind_block(&blk, &b, 1);
-    if(r < 0){
+    if (r < 0) {
       releasesleep(&b.lock);
       return r;
     }

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -4,23 +4,15 @@
 
 static struct exo_ipc_ops ipc_ops;
 
-void
-exo_ipc_register(struct exo_ipc_ops *ops)
-{
-  ipc_ops = *ops;
-}
+void exo_ipc_register(struct exo_ipc_ops *ops) { ipc_ops = *ops; }
 
-int
-exo_send(exo_cap dest, const void *buf, uint64_t len)
-{
+[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len) {
   if (ipc_ops.send)
     return ipc_ops.send(dest, buf, len);
   return -1;
 }
 
-int
-exo_recv(exo_cap src, void *buf, uint64_t len)
-{
+[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len) {
   if (ipc_ops.recv)
     return ipc_ops.recv(src, buf, len);
   return -1;

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -26,15 +26,13 @@
 #include "exo.h"
 
 #define min(a, b) ((a) < (b) ? (a) : (b))
-static void itrunc(struct inode*);
+static void itrunc(struct inode *);
 // there should be one superblock per disk device, but we run with
 // only one device
-struct superblock sb; 
+struct superblock sb;
 
 // Read the super block.
-void
-readsb(int dev, struct superblock *sb)
-{
+void readsb(int dev, struct superblock *sb) {
   struct buf *bp;
 
   bp = bread(dev, 1);
@@ -43,9 +41,7 @@ readsb(int dev, struct superblock *sb)
 }
 
 // Zero a block.
-static void
-bzero(int dev, int bno)
-{
+static void bzero(int dev, int bno) {
   struct buf *bp;
 
   bp = bread(dev, bno);
@@ -57,19 +53,17 @@ bzero(int dev, int bno)
 // Blocks.
 
 // Allocate a zeroed disk block.
-static uint
-balloc(uint dev)
-{
+static uint balloc(uint dev) {
   int b, bi, m;
   struct buf *bp;
 
   bp = 0;
-  for(b = 0; b < sb.size; b += BPB){
+  for (b = 0; b < sb.size; b += BPB) {
     bp = bread(dev, BBLOCK(b, sb));
-    for(bi = 0; bi < BPB && b + bi < sb.size; bi++){
+    for (bi = 0; bi < BPB && b + bi < sb.size; bi++) {
       m = 1 << (bi % 8);
-      if((bp->data[bi/8] & m) == 0){  // Is block free?
-        bp->data[bi/8] |= m;  // Mark block in use.
+      if ((bp->data[bi / 8] & m) == 0) { // Is block free?
+        bp->data[bi / 8] |= m;           // Mark block in use.
         log_write(bp);
         brelse(bp);
         bzero(dev, b + bi);
@@ -82,9 +76,7 @@ balloc(uint dev)
 }
 
 // Allocate a zeroed disk block and return a capability for it.
-struct exo_blockcap
-exo_alloc_block(uint dev, uint rights)
-{
+struct exo_blockcap exo_alloc_block(uint dev, uint rights) {
   struct exo_blockcap cap = {0, 0, 0, 0};
   int b, bi, m;
   struct buf *bp = 0;
@@ -112,13 +104,12 @@ exo_alloc_block(uint dev, uint rights)
 }
 
 // Perform direct I/O on the given buffer using a capability.
-int
-exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
-{
-  if(cap->owner != myproc()->pid)
+[[nodiscard]] int exo_bind_block(struct exo_blockcap *cap, struct buf *buf,
+                                 int write) {
+  if (cap->owner != myproc()->pid)
     return -EPERM;
   uint need = write ? EXO_RIGHT_W : EXO_RIGHT_R;
-  if(!cap_has_rights(cap->rights, need))
+  if (!cap_has_rights(cap->rights, need))
     return -EPERM;
 
   buf->dev = cap->dev;
@@ -129,10 +120,8 @@ exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
   return 0;
 }
 
-void
-exo_flush_block(struct exo_blockcap *cap, void *data)
-{
-  if(cap->owner != myproc()->pid)
+void exo_flush_block(struct exo_blockcap *cap, void *data) {
+  if (cap->owner != myproc()->pid)
     return;
   struct buf b;
   memset(&b, 0, sizeof(b));
@@ -144,18 +133,16 @@ exo_flush_block(struct exo_blockcap *cap, void *data)
 }
 
 // Free a disk block.
-static void
-bfree(int dev, uint b)
-{
+static void bfree(int dev, uint b) {
   struct buf *bp;
   int bi, m;
 
   bp = bread(dev, BBLOCK(b, sb));
   bi = b % BPB;
   m = 1 << (bi % 8);
-  if((bp->data[bi/8] & m) == 0)
+  if ((bp->data[bi / 8] & m) == 0)
     panic("freeing free block");
-  bp->data[bi/8] &= ~m;
+  bp->data[bi / 8] &= ~m;
   log_write(bp);
   brelse(bp);
 }
@@ -234,43 +221,39 @@ struct {
   struct inode inode[NINODE];
 } icache;
 
-void
-iinit(int dev)
-{
+void iinit(int dev) {
   int i = 0;
-  
+
   initlock(&icache.lock, "icache");
-  for(i = 0; i < NINODE; i++) {
+  for (i = 0; i < NINODE; i++) {
     initsleeplock(&icache.inode[i].lock, "inode");
   }
 
   readsb(dev, &sb);
   cprintf("sb: size %d nblocks %d ninodes %d nlog %d logstart %d\
- inodestart %d bmap start %d\n", sb.size, sb.nblocks,
-          sb.ninodes, sb.nlog, sb.logstart, sb.inodestart,
+ inodestart %d bmap start %d\n",
+          sb.size, sb.nblocks, sb.ninodes, sb.nlog, sb.logstart, sb.inodestart,
           sb.bmapstart);
 }
 
-static struct inode* iget(uint dev, uint inum);
+static struct inode *iget(uint dev, uint inum);
 
-//PAGEBREAK!
-// Allocate an inode on device dev.
-// Mark it as allocated by  giving it type type.
-// Returns an unlocked but allocated and referenced inode.
-struct inode*
-ialloc(uint dev, short type)
-{
+// PAGEBREAK!
+//  Allocate an inode on device dev.
+//  Mark it as allocated by  giving it type type.
+//  Returns an unlocked but allocated and referenced inode.
+struct inode *ialloc(uint dev, short type) {
   int inum;
   struct buf *bp;
   struct dinode *dip;
 
-  for(inum = 1; inum < sb.ninodes; inum++){
+  for (inum = 1; inum < sb.ninodes; inum++) {
     bp = bread(dev, IBLOCK(inum, sb));
-    dip = (struct dinode*)bp->data + inum%IPB;
-    if(dip->type == 0){  // a free inode
+    dip = (struct dinode *)bp->data + inum % IPB;
+    if (dip->type == 0) { // a free inode
       memset(dip, 0, sizeof(*dip));
       dip->type = type;
-      log_write(bp);   // mark it allocated on the disk
+      log_write(bp); // mark it allocated on the disk
       brelse(bp);
       return iget(dev, inum);
     }
@@ -283,14 +266,12 @@ ialloc(uint dev, short type)
 // Must be called after every change to an ip->xxx field
 // that lives on disk, since i-node cache is write-through.
 // Caller must hold ip->lock.
-void
-iupdate(struct inode *ip)
-{
+void iupdate(struct inode *ip) {
   struct buf *bp;
   struct dinode *dip;
 
   bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-  dip = (struct dinode*)bp->data + ip->inum%IPB;
+  dip = (struct dinode *)bp->data + ip->inum % IPB;
   dip->type = ip->type;
   dip->major = ip->major;
   dip->minor = ip->minor;
@@ -304,27 +285,25 @@ iupdate(struct inode *ip)
 // Find the inode with number inum on device dev
 // and return the in-memory copy. Does not lock
 // the inode and does not read it from disk.
-static struct inode*
-iget(uint dev, uint inum)
-{
+static struct inode *iget(uint dev, uint inum) {
   struct inode *ip, *empty;
 
   acquire(&icache.lock);
 
   // Is the inode already cached?
   empty = 0;
-  for(ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++){
-    if(ip->ref > 0 && ip->dev == dev && ip->inum == inum){
+  for (ip = &icache.inode[0]; ip < &icache.inode[NINODE]; ip++) {
+    if (ip->ref > 0 && ip->dev == dev && ip->inum == inum) {
       ip->ref++;
       release(&icache.lock);
       return ip;
     }
-    if(empty == 0 && ip->ref == 0)    // Remember empty slot.
+    if (empty == 0 && ip->ref == 0) // Remember empty slot.
       empty = ip;
   }
 
   // Recycle an inode cache entry.
-  if(empty == 0)
+  if (empty == 0)
     panic("iget: no inodes");
 
   ip = empty;
@@ -339,9 +318,7 @@ iget(uint dev, uint inum)
 
 // Increment reference count for ip.
 // Returns ip to enable ip = idup(ip1) idiom.
-struct inode*
-idup(struct inode *ip)
-{
+struct inode *idup(struct inode *ip) {
   acquire(&icache.lock);
   ip->ref++;
   release(&icache.lock);
@@ -350,20 +327,18 @@ idup(struct inode *ip)
 
 // Lock the given inode.
 // Reads the inode from disk if necessary.
-void
-ilock(struct inode *ip)
-{
+void ilock(struct inode *ip) {
   struct buf *bp;
   struct dinode *dip;
 
-  if(ip == 0 || ip->ref < 1)
+  if (ip == 0 || ip->ref < 1)
     panic("ilock");
 
   acquiresleep(&ip->lock);
 
-  if(ip->valid == 0){
+  if (ip->valid == 0) {
     bp = bread(ip->dev, IBLOCK(ip->inum, sb));
-    dip = (struct dinode*)bp->data + ip->inum%IPB;
+    dip = (struct dinode *)bp->data + ip->inum % IPB;
     ip->type = dip->type;
     ip->major = dip->major;
     ip->minor = dip->minor;
@@ -372,16 +347,14 @@ ilock(struct inode *ip)
     memmove(ip->addrs, dip->addrs, sizeof(ip->addrs));
     brelse(bp);
     ip->valid = 1;
-    if(ip->type == 0)
+    if (ip->type == 0)
       panic("ilock: no type");
   }
 }
 
 // Unlock the given inode.
-void
-iunlock(struct inode *ip)
-{
-  if(ip == 0 || !holdingsleep(&ip->lock) || ip->ref < 1)
+void iunlock(struct inode *ip) {
+  if (ip == 0 || !holdingsleep(&ip->lock) || ip->ref < 1)
     panic("iunlock");
 
   releasesleep(&ip->lock);
@@ -394,15 +367,13 @@ iunlock(struct inode *ip)
 // to it, free the inode (and its content) on disk.
 // All calls to iput() must be inside a transaction in
 // case it has to free the inode.
-void
-iput(struct inode *ip)
-{
+void iput(struct inode *ip) {
   acquiresleep(&ip->lock);
-  if(ip->valid && ip->nlink == 0){
+  if (ip->valid && ip->nlink == 0) {
     acquire(&icache.lock);
     int r = ip->ref;
     release(&icache.lock);
-    if(r == 1){
+    if (r == 1) {
       // inode has no links and no other references: truncate and free.
       itrunc(ip);
       ip->type = 0;
@@ -418,43 +389,39 @@ iput(struct inode *ip)
 }
 
 // Common idiom: unlock, then put.
-void
-iunlockput(struct inode *ip)
-{
+void iunlockput(struct inode *ip) {
   iunlock(ip);
   iput(ip);
 }
 
-//PAGEBREAK!
-// Inode content
+// PAGEBREAK!
+//  Inode content
 //
-// The content (data) associated with each inode is stored
-// in blocks on the disk. The first NDIRECT block numbers
-// are listed in ip->addrs[].  The next NINDIRECT blocks are
-// listed in block ip->addrs[NDIRECT].
+//  The content (data) associated with each inode is stored
+//  in blocks on the disk. The first NDIRECT block numbers
+//  are listed in ip->addrs[].  The next NINDIRECT blocks are
+//  listed in block ip->addrs[NDIRECT].
 
 // Return the disk block address of the nth block in inode ip.
 // If there is no such block, bmap allocates one.
-static uint
-bmap(struct inode *ip, uint bn)
-{
+static uint bmap(struct inode *ip, uint bn) {
   uint addr, *a;
   struct buf *bp;
 
-  if(bn < NDIRECT){
-    if((addr = ip->addrs[bn]) == 0)
+  if (bn < NDIRECT) {
+    if ((addr = ip->addrs[bn]) == 0)
       ip->addrs[bn] = addr = balloc(ip->dev);
     return addr;
   }
   bn -= NDIRECT;
 
-  if(bn < NINDIRECT){
+  if (bn < NINDIRECT) {
     // Load indirect block, allocating if necessary.
-    if((addr = ip->addrs[NDIRECT]) == 0)
+    if ((addr = ip->addrs[NDIRECT]) == 0)
       ip->addrs[NDIRECT] = addr = balloc(ip->dev);
     bp = bread(ip->dev, addr);
-    a = (uint*)bp->data;
-    if((addr = a[bn]) == 0){
+    a = (uint *)bp->data;
+    if ((addr = a[bn]) == 0) {
       a[bn] = addr = balloc(ip->dev);
       log_write(bp);
     }
@@ -470,25 +437,23 @@ bmap(struct inode *ip, uint bn)
 // to it (no directory entries referring to it)
 // and has no in-memory reference to it (is
 // not an open file or current directory).
-static void
-itrunc(struct inode *ip)
-{
+static void itrunc(struct inode *ip) {
   int i, j;
   struct buf *bp;
   uint *a;
 
-  for(i = 0; i < NDIRECT; i++){
-    if(ip->addrs[i]){
+  for (i = 0; i < NDIRECT; i++) {
+    if (ip->addrs[i]) {
       bfree(ip->dev, ip->addrs[i]);
       ip->addrs[i] = 0;
     }
   }
 
-  if(ip->addrs[NDIRECT]){
+  if (ip->addrs[NDIRECT]) {
     bp = bread(ip->dev, ip->addrs[NDIRECT]);
-    a = (uint*)bp->data;
-    for(j = 0; j < NINDIRECT; j++){
-      if(a[j])
+    a = (uint *)bp->data;
+    for (j = 0; j < NINDIRECT; j++) {
+      if (a[j])
         bfree(ip->dev, a[j]);
     }
     brelse(bp);
@@ -502,9 +467,7 @@ itrunc(struct inode *ip)
 
 // Copy stat information from inode.
 // Caller must hold ip->lock.
-void
-stati(struct inode *ip, struct stat *st)
-{
+void stati(struct inode *ip, struct stat *st) {
   st->dev = ip->dev;
   st->ino = ip->inum;
   st->type = ip->type;
@@ -512,30 +475,28 @@ stati(struct inode *ip, struct stat *st)
   st->size = ip->size;
 }
 
-//PAGEBREAK!
-// Read data from inode.
-// Caller must hold ip->lock.
-int
-readi(struct inode *ip, char *dst, uint off, size_t n)
-{
+// PAGEBREAK!
+//  Read data from inode.
+//  Caller must hold ip->lock.
+int readi(struct inode *ip, char *dst, uint off, size_t n) {
   size_t tot, m;
   struct buf *bp;
 
-  if(ip->type == T_DEV){
-    if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].read)
+  if (ip->type == T_DEV) {
+    if (ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].read)
       return -1;
     return devsw[ip->major].read(ip, dst, n);
   }
 
-  if(off > ip->size || off + n < off)
+  if (off > ip->size || off + n < off)
     return -1;
-  if(off + n > ip->size)
+  if (off + n > ip->size)
     n = ip->size - off;
 
-  for(tot=0; tot<n; tot+=m, off+=m, dst+=m){
-    bp = bread(ip->dev, bmap(ip, off/BSIZE));
-    m = min(n - tot, BSIZE - off%BSIZE);
-    memmove(dst, bp->data + off%BSIZE, m);
+  for (tot = 0; tot < n; tot += m, off += m, dst += m) {
+    bp = bread(ip->dev, bmap(ip, off / BSIZE));
+    m = min(n - tot, BSIZE - off % BSIZE);
+    memmove(dst, bp->data + off % BSIZE, m);
     brelse(bp);
   }
   return n;
@@ -544,66 +505,58 @@ readi(struct inode *ip, char *dst, uint off, size_t n)
 // PAGEBREAK!
 // Write data to inode.
 // Caller must hold ip->lock.
-int
-writei(struct inode *ip, char *src, uint off, size_t n)
-{
+int writei(struct inode *ip, char *src, uint off, size_t n) {
   size_t tot, m;
   struct buf *bp;
 
-  if(ip->type == T_DEV){
-    if(ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].write)
+  if (ip->type == T_DEV) {
+    if (ip->major < 0 || ip->major >= NDEV || !devsw[ip->major].write)
       return -1;
     return devsw[ip->major].write(ip, src, n);
   }
 
-  if(off > ip->size || off + n < off)
+  if (off > ip->size || off + n < off)
     return -1;
-  if(off + n > MAXFILE*BSIZE)
+  if (off + n > MAXFILE * BSIZE)
     return -1;
 
-  for(tot=0; tot<n; tot+=m, off+=m, src+=m){
-    bp = bread(ip->dev, bmap(ip, off/BSIZE));
-    m = min(n - tot, BSIZE - off%BSIZE);
-    memmove(bp->data + off%BSIZE, src, m);
+  for (tot = 0; tot < n; tot += m, off += m, src += m) {
+    bp = bread(ip->dev, bmap(ip, off / BSIZE));
+    m = min(n - tot, BSIZE - off % BSIZE);
+    memmove(bp->data + off % BSIZE, src, m);
     log_write(bp);
     brelse(bp);
   }
 
-  if(n > 0 && off > ip->size){
+  if (n > 0 && off > ip->size) {
     ip->size = off;
     iupdate(ip);
   }
   return n;
 }
 
-//PAGEBREAK!
-// Directories
+// PAGEBREAK!
+//  Directories
 
-int
-namecmp(const char *s, const char *t)
-{
-  return strncmp(s, t, DIRSIZ);
-}
+int namecmp(const char *s, const char *t) { return strncmp(s, t, DIRSIZ); }
 
 // Look for a directory entry in a directory.
 // If found, set *poff to byte offset of entry.
-struct inode*
-dirlookup(struct inode *dp, char *name, uint *poff)
-{
+struct inode *dirlookup(struct inode *dp, char *name, uint *poff) {
   uint off, inum;
   struct dirent de;
 
-  if(dp->type != T_DIR)
+  if (dp->type != T_DIR)
     panic("dirlookup not DIR");
 
-  for(off = 0; off < dp->size; off += sizeof(de)){
-    if(readi(dp, (char*)&de, off, sizeof(de)) != sizeof(de))
+  for (off = 0; off < dp->size; off += sizeof(de)) {
+    if (readi(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
       panic("dirlookup read");
-    if(de.inum == 0)
+    if (de.inum == 0)
       continue;
-    if(namecmp(name, de.name) == 0){
+    if (namecmp(name, de.name) == 0) {
       // entry matches path element
-      if(poff)
+      if (poff)
         *poff = off;
       inum = de.inum;
       return iget(dp->dev, inum);
@@ -614,37 +567,35 @@ dirlookup(struct inode *dp, char *name, uint *poff)
 }
 
 // Write a new directory entry (name, inum) into the directory dp.
-int
-dirlink(struct inode *dp, char *name, uint inum)
-{
+int dirlink(struct inode *dp, char *name, uint inum) {
   int off;
   struct dirent de;
   struct inode *ip;
 
   // Check that name is not present.
-  if((ip = dirlookup(dp, name, 0)) != 0){
+  if ((ip = dirlookup(dp, name, 0)) != 0) {
     iput(ip);
     return -1;
   }
 
   // Look for an empty dirent.
-  for(off = 0; off < dp->size; off += sizeof(de)){
-    if(readi(dp, (char*)&de, off, sizeof(de)) != sizeof(de))
+  for (off = 0; off < dp->size; off += sizeof(de)) {
+    if (readi(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
       panic("dirlink read");
-    if(de.inum == 0)
+    if (de.inum == 0)
       break;
   }
 
   strncpy(de.name, name, DIRSIZ);
   de.inum = inum;
-  if(writei(dp, (char*)&de, off, sizeof(de)) != sizeof(de))
+  if (writei(dp, (char *)&de, off, sizeof(de)) != sizeof(de))
     panic("dirlink");
 
   return 0;
 }
 
-//PAGEBREAK!
-// Paths
+// PAGEBREAK!
+//  Paths
 
 // Copy the next path element from path into name.
 // Return a pointer to the element following the copied one.
@@ -658,27 +609,25 @@ dirlink(struct inode *dp, char *name, uint inum)
 //   skipelem("a", name) = "", setting name = "a"
 //   skipelem("", name) = skipelem("////", name) = 0
 //
-static char*
-skipelem(char *path, char *name)
-{
+static char *skipelem(char *path, char *name) {
   char *s;
   int len;
 
-  while(*path == '/')
+  while (*path == '/')
     path++;
-  if(*path == 0)
+  if (*path == 0)
     return 0;
   s = path;
-  while(*path != '/' && *path != 0)
+  while (*path != '/' && *path != 0)
     path++;
   len = path - s;
-  if(len >= DIRSIZ)
+  if (len >= DIRSIZ)
     memmove(name, s, DIRSIZ);
   else {
     memmove(name, s, len);
     name[len] = 0;
   }
-  while(*path == '/')
+  while (*path == '/')
     path++;
   return path;
 }
@@ -687,50 +636,44 @@ skipelem(char *path, char *name)
 // If parent != 0, return the inode for the parent and copy the final
 // path element into name, which must have room for DIRSIZ bytes.
 // Must be called inside a transaction since it calls iput().
-static struct inode*
-namex(char *path, int nameiparent, char *name)
-{
+static struct inode *namex(char *path, int nameiparent, char *name) {
   struct inode *ip, *next;
 
-  if(*path == '/')
+  if (*path == '/')
     ip = iget(ROOTDEV, ROOTINO);
   else
     ip = idup(myproc()->cwd);
 
-  while((path = skipelem(path, name)) != 0){
+  while ((path = skipelem(path, name)) != 0) {
     ilock(ip);
-    if(ip->type != T_DIR){
+    if (ip->type != T_DIR) {
       iunlockput(ip);
       return 0;
     }
-    if(nameiparent && *path == '\0'){
+    if (nameiparent && *path == '\0') {
       // Stop one level early.
       iunlock(ip);
       return ip;
     }
-    if((next = dirlookup(ip, name, 0)) == 0){
+    if ((next = dirlookup(ip, name, 0)) == 0) {
       iunlockput(ip);
       return 0;
     }
     iunlockput(ip);
     ip = next;
   }
-  if(nameiparent){
+  if (nameiparent) {
     iput(ip);
     return 0;
   }
   return ip;
 }
 
-struct inode*
-namei(char *path)
-{
+struct inode *namei(char *path) {
   char name[DIRSIZ];
   return namex(path, 0, name);
 }
 
-struct inode*
-nameiparent(char *path, char *name)
-{
+struct inode *nameiparent(char *path, char *name) {
   return namex(path, 1, name);
 }

--- a/src-kernel/irq.c
+++ b/src-kernel/irq.c
@@ -44,7 +44,7 @@ static int check_irq_cap(exo_cap cap, uint need) {
   return 1;
 }
 
-int exo_irq_wait(exo_cap cap, uint *irq_out) {
+[[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq_out) {
   if (!check_irq_cap(cap, EXO_RIGHT_R))
     return -EPERM;
   irq_init();
@@ -62,7 +62,7 @@ int exo_irq_wait(exo_cap cap, uint *irq_out) {
   return 0;
 }
 
-int exo_irq_ack(exo_cap cap) {
+[[nodiscard]] int exo_irq_ack(exo_cap cap) {
   if (!check_irq_cap(cap, EXO_RIGHT_W))
     return -EPERM;
   return 0;

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -9,18 +9,16 @@
 #include "exo.h"
 #include "elf.h"
 
-extern char data[];  // defined by kernel.ld
+extern char data[]; // defined by kernel.ld
 #if defined(__x86_64__) || defined(__aarch64__)
-pml4e_t *kpgdir;  // for use in scheduler()
+pml4e_t *kpgdir; // for use in scheduler()
 #else
-pde_t *kpgdir;  // for use in scheduler()
+pde_t *kpgdir; // for use in scheduler()
 #endif
 
 // Set up CPU's kernel segment descriptors.
 // Run once on entry on each CPU.
-void
-seginit(void)
-{
+void seginit(void) {
   struct cpu *c;
 
   // Map "logical" addresses to virtual addresses using identity map.
@@ -28,9 +26,9 @@ seginit(void)
   // because it would have to have DPL_USR, but the CPU forbids
   // an interrupt from CPL=0 to DPL=3.
   c = &cpus[cpuid()];
-  c->gdt[SEG_KCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, 0);
+  c->gdt[SEG_KCODE] = SEG(STA_X | STA_R, 0, 0xffffffff, 0);
   c->gdt[SEG_KDATA] = SEG(STA_W, 0, 0xffffffff, 0);
-  c->gdt[SEG_UCODE] = SEG(STA_X|STA_R, 0, 0xffffffff, DPL_USER);
+  c->gdt[SEG_UCODE] = SEG(STA_X | STA_R, 0, 0xffffffff, DPL_USER);
   c->gdt[SEG_UDATA] = SEG(STA_W, 0, 0xffffffff, DPL_USER);
   lgdt(c->gdt, sizeof(c->gdt));
 }
@@ -38,17 +36,15 @@ seginit(void)
 // Return the address of the PTE in page table pgdir
 // that corresponds to virtual address va.  If alloc!=0,
 // create any required page table pages.
-static pte_t *
-walkpgdir(pde_t *pgdir, const void *va, int alloc)
-{
+static pte_t *walkpgdir(pde_t *pgdir, const void *va, int alloc) {
   pde_t *pde;
   pte_t *pgtab;
 
   pde = &pgdir[PDX(va)];
-  if(*pde & PTE_P){
-    pgtab = (pte_t*)P2V(PTE_ADDR(*pde));
+  if (*pde & PTE_P) {
+    pgtab = (pte_t *)P2V(PTE_ADDR(*pde));
   } else {
-    if(!alloc || (pgtab = (pte_t*)kalloc()) == 0)
+    if (!alloc || (pgtab = (pte_t *)kalloc()) == 0)
       return 0;
     // Make sure all those PTE_P bits are zero.
     memset(pgtab, 0, PGSIZE);
@@ -63,21 +59,19 @@ walkpgdir(pde_t *pgdir, const void *va, int alloc)
 // Create PTEs for virtual addresses starting at va that refer to
 // physical addresses starting at pa. va and size might not
 // be page-aligned.
-static int
-mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm)
-{
+static int mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm) {
   char *a, *last;
   pte_t *pte;
 
-  a = (char*)PGROUNDDOWN((uintptr_t)va);
-  last = (char*)PGROUNDDOWN(((uintptr_t)va) + size - 1);
-  for(;;){
-    if((pte = walkpgdir(pgdir, a, 1)) == 0)
+  a = (char *)PGROUNDDOWN((uintptr_t)va);
+  last = (char *)PGROUNDDOWN(((uintptr_t)va) + size - 1);
+  for (;;) {
+    if ((pte = walkpgdir(pgdir, a, 1)) == 0)
       return -1;
-    if(*pte & PTE_P)
+    if (*pte & PTE_P)
       panic("remap");
     *pte = pa | perm | PTE_P;
-    if(a == last)
+    if (a == last)
       break;
     a += PGSIZE;
     pa += PGSIZE;
@@ -114,27 +108,25 @@ static struct kmap {
   uint phys_end;
   int perm;
 } kmap[] = {
- { (void*)KERNBASE, 0,             EXTMEM,    PTE_W}, // I/O space
- { (void*)KERNLINK, V2P(KERNLINK), V2P(data), 0},     // kern text+rodata
- { (void*)data,     V2P(data),     PHYSTOP,   PTE_W}, // kern data+memory
- { (void*)DEVSPACE, DEVSPACE,      0,         PTE_W}, // more devices
+    {(void *)KERNBASE, 0, EXTMEM, PTE_W},            // I/O space
+    {(void *)KERNLINK, V2P(KERNLINK), V2P(data), 0}, // kern text+rodata
+    {(void *)data, V2P(data), PHYSTOP, PTE_W},       // kern data+memory
+    {(void *)DEVSPACE, DEVSPACE, 0, PTE_W},          // more devices
 };
 
 // Set up kernel part of a page table.
-pde_t*
-setupkvm(void)
-{
+pde_t *setupkvm(void) {
   pde_t *pgdir;
   struct kmap *k;
 
-  if((pgdir = (pde_t*)kalloc()) == 0)
+  if ((pgdir = (pde_t *)kalloc()) == 0)
     return 0;
   memset(pgdir, 0, PGSIZE);
-  if (P2V(PHYSTOP) > (void*)DEVSPACE)
+  if (P2V(PHYSTOP) > (void *)DEVSPACE)
     panic("PHYSTOP too high");
-  for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
-    if(mappages(pgdir, k->virt, k->phys_end - k->phys_start,
-                (uintptr_t)k->phys_start, k->perm) < 0) {
+  for (k = kmap; k < &kmap[NELEM(kmap)]; k++)
+    if (mappages(pgdir, k->virt, k->phys_end - k->phys_start,
+                 (uintptr_t)k->phys_start, k->perm) < 0) {
       freevm(pgdir);
       return 0;
     }
@@ -143,9 +135,7 @@ setupkvm(void)
 
 // Allocate one page table for the machine for the kernel address
 // space for scheduler processes.
-void
-kvmalloc(void)
-{
+void kvmalloc(void) {
 #if defined(__x86_64__) || defined(__aarch64__)
   kpgdir = setupkvm64();
 #else
@@ -156,71 +146,64 @@ kvmalloc(void)
 
 // Switch h/w page table register to the kernel-only page table,
 // for when no process is running.
-void
-switchkvm(void)
-{
-  lcr3(V2P(kpgdir));   // switch to the kernel page table
+void switchkvm(void) {
+  lcr3(V2P(kpgdir)); // switch to the kernel page table
 }
 
 // Switch TSS and h/w page table to correspond to process p.
-void
-switchuvm(struct proc *p)
-{
-  if(p == 0)
+void switchuvm(struct proc *p) {
+  if (p == 0)
     panic("switchuvm: no process");
-  if(p->kstack == 0)
+  if (p->kstack == 0)
     panic("switchuvm: no kstack");
-  if(p->pgdir == 0)
+  if (p->pgdir == 0)
     panic("switchuvm: no pgdir");
 
   pushcli();
-  mycpu()->gdt[SEG_TSS] = SEG16(STS_T32A, &mycpu()->ts,
-                                sizeof(mycpu()->ts)-1, 0);
+  mycpu()->gdt[SEG_TSS] =
+      SEG16(STS_T32A, &mycpu()->ts, sizeof(mycpu()->ts) - 1, 0);
   mycpu()->gdt[SEG_TSS].s = 0;
   mycpu()->ts.ss0 = SEG_KDATA << 3;
   mycpu()->ts.esp0 = (uintptr_t)p->kstack + KSTACKSIZE;
   // setting IOPL=0 in eflags *and* iomb beyond the tss segment limit
   // forbids I/O instructions (e.g., inb and outb) from user space
-  mycpu()->ts.iomb = (ushort) 0xFFFF;
+  mycpu()->ts.iomb = (ushort)0xFFFF;
   ltr(SEG_TSS << 3);
-  lcr3(V2P(p->pgdir));  // switch to process's address space
+  lcr3(V2P(p->pgdir)); // switch to process's address space
   popcli();
 }
 
 // Load the initcode into address 0 of pgdir.
 // sz must be less than a page.
-void
-inituvm(pde_t *pgdir, char *init, size_t sz)
-{
+void inituvm(pde_t *pgdir, char *init, size_t sz) {
   char *mem;
 
-  if(sz >= PGSIZE)
+  if (sz >= PGSIZE)
     panic("inituvm: more than a page");
   mem = kalloc();
   memset(mem, 0, PGSIZE);
-  mappages(pgdir, 0, PGSIZE, V2P(mem), PTE_W|PTE_U);
+  mappages(pgdir, 0, PGSIZE, V2P(mem), PTE_W | PTE_U);
   memmove(mem, init, sz);
 }
 
 // Load a program segment into pgdir.  addr must be page-aligned
 // and the pages from addr to addr+sz must already be mapped.
-int
-loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, size_t sz)
-{
+int loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset,
+            size_t sz) {
   uint i, pa, n;
   pte_t *pte;
 
-  if((uintptr_t) addr % PGSIZE != 0)
+  if ((uintptr_t)addr % PGSIZE != 0)
     panic("loaduvm: addr must be page aligned");
-  for(i = 0; i < sz; i += PGSIZE){
-    if((pte = walkpgdir(pgdir, addr+i, 0)) == 0)
+  for (i = 0; i < sz; i += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, addr + i, 0)) == 0)
       panic("loaduvm: address should exist");
     pa = PTE_ADDR(*pte);
-    if(sz - i < PGSIZE)
+    if (sz - i < PGSIZE)
       n = sz - i;
     else
       n = PGSIZE;
-    if(readi(ip, P2V(pa), offset+i, n) != n)
+    if (readi(ip, P2V(pa), offset + i, n) != n)
       return -1;
   }
   return 0;
@@ -228,27 +211,25 @@ loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, size_t sz)
 
 // Allocate page tables and physical memory to grow process from oldsz to
 // newsz, which need not be page aligned.  Returns new size or 0 on error.
-int
-allocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
-{
+int allocuvm(pde_t *pgdir, size_t oldsz, size_t newsz) {
   char *mem;
   uint a;
 
-  if(newsz >= KERNBASE)
+  if (newsz >= KERNBASE)
     return 0;
-  if(newsz < oldsz)
+  if (newsz < oldsz)
     return oldsz;
 
   a = PGROUNDUP(oldsz);
-  for(; a < newsz; a += PGSIZE){
+  for (; a < newsz; a += PGSIZE) {
     mem = kalloc();
-    if(mem == 0){
+    if (mem == 0) {
       cprintf("allocuvm out of memory\n");
       deallocuvm(pgdir, newsz, oldsz);
       return 0;
     }
     memset(mem, 0, PGSIZE);
-    if(mappages(pgdir, (char*)a, PGSIZE, V2P(mem), PTE_W|PTE_U) < 0){
+    if (mappages(pgdir, (char *)a, PGSIZE, V2P(mem), PTE_W | PTE_U) < 0) {
       cprintf("allocuvm out of memory (2)\n");
       deallocuvm(pgdir, newsz, oldsz);
       kfree(mem);
@@ -262,23 +243,21 @@ allocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
 // newsz.  oldsz and newsz need not be page-aligned, nor does newsz
 // need to be less than oldsz.  oldsz can be larger than the actual
 // process size.  Returns the new process size.
-int
-deallocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
-{
+int deallocuvm(pde_t *pgdir, size_t oldsz, size_t newsz) {
   pte_t *pte;
   uint a, pa;
 
-  if(newsz >= oldsz)
+  if (newsz >= oldsz)
     return oldsz;
 
   a = PGROUNDUP(newsz);
-  for(; a  < oldsz; a += PGSIZE){
-    pte = walkpgdir(pgdir, (char*)a, 0);
-    if(!pte)
+  for (; a < oldsz; a += PGSIZE) {
+    pte = walkpgdir(pgdir, (char *)a, 0);
+    if (!pte)
       a = PGADDR(PDX(a) + 1, 0, 0) - PGSIZE;
-    else if((*pte & PTE_P) != 0){
+    else if ((*pte & PTE_P) != 0) {
       pa = PTE_ADDR(*pte);
-      if(pa == 0)
+      if (pa == 0)
         panic("kfree");
       char *v = P2V(pa);
       kfree(v);
@@ -290,45 +269,39 @@ deallocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
 
 // Free a page table and all the physical memory pages
 // in the user part.
-void
-freevm(pde_t *pgdir)
-{
+void freevm(pde_t *pgdir) {
   uint i;
 
-  if(pgdir == 0)
+  if (pgdir == 0)
     panic("freevm: no pgdir");
   deallocuvm(pgdir, KERNBASE, 0);
-  for(i = 0; i < NPDENTRIES; i++){
-    if(pgdir[i] & PTE_P){
-      char * v = P2V(PTE_ADDR(pgdir[i]));
+  for (i = 0; i < NPDENTRIES; i++) {
+    if (pgdir[i] & PTE_P) {
+      char *v = P2V(PTE_ADDR(pgdir[i]));
       kfree(v);
     }
   }
-  kfree((char*)pgdir);
+  kfree((char *)pgdir);
 }
 
 // Clear PTE_U on a page. Used to create an inaccessible
 // page beneath the user stack.
-void
-clearpteu(pde_t *pgdir, char *uva)
-{
+void clearpteu(pde_t *pgdir, char *uva) {
   pte_t *pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if(pte == 0)
+  if (pte == 0)
     panic("clearpteu");
   *pte &= ~PTE_U;
 }
 
-int
-insert_pte(pde_t *pgdir, void *va,
+int insert_pte(pde_t *pgdir, void *va,
 #if defined(__x86_64__) || defined(__aarch64__)
-           uint64 pa,
+               uint64 pa,
 #else
-           uint pa,
+               uint pa,
 #endif
-           int perm)
-{
+               int perm) {
   pte_t *pte;
 
   if ((pte = walkpgdir(pgdir, va, 1)) == 0)
@@ -345,28 +318,26 @@ insert_pte(pde_t *pgdir, void *va,
 
 // Given a parent process's page table, create a copy
 // of it for a child.
-pde_t*
-copyuvm(pde_t *pgdir, size_t sz)
-{
+pde_t *copyuvm(pde_t *pgdir, size_t sz) {
   pde_t *d;
   pte_t *pte;
   uint pa, flags;
   size_t i;
   char *mem;
 
-  if((d = setupkvm()) == 0)
+  if ((d = setupkvm()) == 0)
     return 0;
-  for(i = 0; i < sz; i += PGSIZE){
-    if((pte = walkpgdir(pgdir, (void *) i, 0)) == 0)
+  for (i = 0; i < sz; i += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, (void *)i, 0)) == 0)
       panic("copyuvm: pte should exist");
-    if(!(*pte & PTE_P))
+    if (!(*pte & PTE_P))
       panic("copyuvm: page not present");
     pa = PTE_ADDR(*pte);
     flags = PTE_FLAGS(*pte);
-    if((mem = kalloc()) == 0)
+    if ((mem = kalloc()) == 0)
       goto bad;
-    memmove(mem, (char*)P2V(pa), PGSIZE);
-    if(mappages(d, (void*)i, PGSIZE, V2P(mem), flags) < 0) {
+    memmove(mem, (char *)P2V(pa), PGSIZE);
+    if (mappages(d, (void *)i, PGSIZE, V2P(mem), flags) < 0) {
       kfree(mem);
       goto bad;
     }
@@ -378,19 +349,17 @@ bad:
   return 0;
 }
 
-//PAGEBREAK!
-// Map user virtual address to kernel address.
-char*
-uva2ka(pde_t *pgdir, char *uva)
-{
+// PAGEBREAK!
+//  Map user virtual address to kernel address.
+char *uva2ka(pde_t *pgdir, char *uva) {
   pte_t *pte;
 
   pte = walkpgdir(pgdir, uva, 0);
-  if((*pte & PTE_P) == 0)
+  if ((*pte & PTE_P) == 0)
     return 0;
-  if((*pte & PTE_U) == 0)
+  if ((*pte & PTE_U) == 0)
     return 0;
-  return (char*)P2V(PTE_ADDR(*pte));
+  return (char *)P2V(PTE_ADDR(*pte));
 }
 
 // Copy len bytes from p to user address va in page table pgdir.
@@ -411,18 +380,18 @@ copyout(pde_t *pgdir, uint va, void *p, size_t len)
   uint va0;
 #endif
 
-  buf = (char*)p;
-  while(len > 0){
+  buf = (char *)p;
+  while (len > 0) {
 #ifdef __x86_64__
     va0 = (uint64)PGROUNDDOWN(va);
 #else
     va0 = (uint)PGROUNDDOWN(va);
 #endif
-    pa0 = uva2ka(pgdir, (char*)va0);
-    if(pa0 == 0)
+    pa0 = uva2ka(pgdir, (char *)va0);
+    if (pa0 == 0)
       return -1;
     n = PGSIZE - (va - va0);
-    if(n > len)
+    if (n > len)
       n = len;
     memmove(pa0 + (va - va0), buf, n);
     len -= n;
@@ -432,19 +401,17 @@ copyout(pde_t *pgdir, uint va, void *p, size_t len)
   return 0;
 }
 
-//PAGEBREAK!
-// Blank page.
-//PAGEBREAK!
-// Blank page.
-//PAGEBREAK!
-// Blank page.
+// PAGEBREAK!
+//  Blank page.
+// PAGEBREAK!
+//  Blank page.
+// PAGEBREAK!
+//  Blank page.
 
 // Allocate a page and return a capability referencing its physical address.
-exo_cap
-exo_alloc_page(void)
-{
+exo_cap exo_alloc_page(void) {
   char *mem = kalloc();
-  if(!mem)
+  if (!mem)
     return cap_new(0, 0, 0);
   uint pa = V2P(mem);
   int id = cap_table_alloc(CAP_TYPE_PAGE, pa, 0, myproc()->pid);
@@ -452,25 +419,23 @@ exo_alloc_page(void)
 }
 
 // Remove any mappings to the page referenced by cap and free it.
-int
-exo_unbind_page(exo_cap cap)
-{
+[[nodiscard]] int exo_unbind_page(exo_cap cap) {
   if (!cap_verify(cap))
     return -1;
   struct cap_entry e;
   if (cap_table_lookup(cap.id, &e) < 0)
     return -1;
   struct proc *p = myproc();
-  if(e.owner != p->pid || e.type != CAP_TYPE_PAGE)
+  if (e.owner != p->pid || e.type != CAP_TYPE_PAGE)
     return -1;
   pde_t *pgdir = p->pgdir;
   pte_t *pte;
   uint a;
   uint pa = e.resource;
 
-  for(a = 0; a < p->sz; a += PGSIZE){
-    if((pte = walkpgdir(pgdir, (void*)a, 0)) != 0 && (*pte & PTE_P)){
-      if(PTE_ADDR(*pte) == pa){
+  for (a = 0; a < p->sz; a += PGSIZE) {
+    if ((pte = walkpgdir(pgdir, (void *)a, 0)) != 0 && (*pte & PTE_P)) {
+      if (PTE_ADDR(*pte) == pa) {
         *pte = 0;
         kfree(P2V(pa));
         cap_revoke(cap.id);

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -2,17 +2,15 @@
 #include "types.h"
 #include "user.h"
 
-exo_cap cap_alloc_page(void) {
-  return exo_alloc_page();
-}
+exo_cap cap_alloc_page(void) { return exo_alloc_page(); }
 
-int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
+[[nodiscard]] int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
 
-int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
+[[nodiscard]] int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
   return exo_alloc_block(dev, rights, cap);
 }
 
-int cap_bind_block(exo_blockcap *cap, void *data, int write) {
+[[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write) {
   return exo_bind_block(cap, data, write);
 }
 
@@ -20,37 +18,43 @@ void cap_flush_block(exo_blockcap *cap, void *data) {
   exo_flush_block(cap, data);
 }
 
-int cap_set_timer(void (*handler)(void)) { return set_timer_upcall(handler); }
-int cap_set_gas(uint64 amount) { return set_gas(amount); }
-int cap_get_gas(void) { return get_gas(); }
-int cap_out_of_gas(void) { return get_gas() <= 0; }
+[[nodiscard]] int cap_set_timer(void (*handler)(void)) {
+  return set_timer_upcall(handler);
+}
+[[nodiscard]] int cap_set_gas(uint64 amount) { return set_gas(amount); }
+[[nodiscard]] int cap_get_gas(void) { return get_gas(); }
+[[nodiscard]] int cap_out_of_gas(void) { return get_gas() <= 0; }
 
 void cap_yield_to(context_t **old, context_t *target) {
   cap_yield(old, target);
 }
 
-int cap_yield_to_cap(exo_cap target) { return exo_yield_to(target); }
+[[nodiscard]] int cap_yield_to_cap(exo_cap target) {
+  return exo_yield_to(target);
+}
 
-int cap_read_disk(exo_blockcap cap, void *dst, uint64 off, uint64 n) {
+[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64 off,
+                                uint64 n) {
   return exo_read_disk(cap, dst, off, n);
 }
 
-int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n) {
+[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64 off,
+                                 uint64 n) {
   return exo_write_disk(cap, src, off, n);
 }
 
 extern int cap_revoke_syscall(void);
 int cap_revoke(void) { return cap_revoke_syscall(); }
 
-int cap_send(exo_cap dest, const void *buf, uint64 len) {
+[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len) {
   return exo_send(dest, buf, len);
 }
 
-int cap_recv(exo_cap src, void *buf, uint64 len) {
+[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len) {
   return exo_recv(src, buf, len);
 }
 
-int cap_ipc_echo_demo(void) {
+[[nodiscard]] int cap_ipc_echo_demo(void) {
   const char *msg = "ping";
   char buf[5];
   exo_cap cap = {0, 0};

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -2,41 +2,33 @@
 #include "user.h"
 #include "caplib.h"
 
-chan_t *
-chan_create(const struct msg_type_desc *desc)
-{
-    chan_t *c = malloc(sizeof(chan_t));
-    if(c){
-        c->desc = desc;
-        c->msg_size = msg_desc_size(desc);
-    }
-    return c;
+[[nodiscard]] chan_t *chan_create(const struct msg_type_desc *desc) {
+  chan_t *c = malloc(sizeof(chan_t));
+  if (c) {
+    c->desc = desc;
+    c->msg_size = msg_desc_size(desc);
+  }
+  return c;
 }
 
-void
-chan_destroy(chan_t *c)
-{
-    free(c);
+void chan_destroy(chan_t *c) { free(c); }
+
+[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
+                                     size_t len) {
+  if (len != c->msg_size) {
+    printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
+           (int)c->msg_size);
+    return -1;
+  }
+  return cap_send(dest, msg, c->msg_size);
 }
 
-int
-chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len)
-{
-    if(len != c->msg_size){
-        printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
-               (int)c->msg_size);
-        return -1;
-    }
-    return cap_send(dest, msg, c->msg_size);
-}
-
-int
-chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len)
-{
-    if(len != c->msg_size){
-        printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
-               (int)c->msg_size);
-        return -1;
-    }
-    return cap_recv(src, msg, c->msg_size);
+[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+                                     size_t len) {
+  if (len != c->msg_size) {
+    printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
+           (int)c->msg_size);
+    return -1;
+  }
+  return cap_recv(src, msg, c->msg_size);
 }

--- a/src-uland/door.c
+++ b/src-uland/door.c
@@ -1,47 +1,45 @@
 #include "door.h"
 #include <string.h>
 
-static void clear_cap(exo_cap *c) {
-    memset(c, 0, sizeof(*c));
-}
+static void clear_cap(exo_cap *c) { memset(c, 0, sizeof(*c)); }
 
 door_t door_create_local(void (*handler)(zipc_msg_t *msg)) {
-    door_t d;
-    clear_cap(&d.dest);
-    d.handler = handler;
-    d.is_local = 1;
-    return d;
+  door_t d;
+  clear_cap(&d.dest);
+  d.handler = handler;
+  d.is_local = 1;
+  return d;
 }
 
 door_t door_create_remote(exo_cap dest) {
-    door_t d;
-    d.dest = dest;
-    d.handler = 0;
-    d.is_local = 0;
-    return d;
+  door_t d;
+  d.dest = dest;
+  d.handler = 0;
+  d.is_local = 0;
+  return d;
 }
 
-int door_call(door_t *d, zipc_msg_t *msg) {
-    if (!d)
-        return -1;
-    if (d->is_local) {
-        if (d->handler)
-            d->handler(msg);
-        return 0;
-    }
-    if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
-        return -1;
-    return cap_recv(d->dest, msg, sizeof(*msg));
+[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg) {
+  if (!d)
+    return -1;
+  if (d->is_local) {
+    if (d->handler)
+      d->handler(msg);
+    return 0;
+  }
+  if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
+    return -1;
+  return cap_recv(d->dest, msg, sizeof(*msg));
 }
 
 void door_server_loop(door_t *d) {
-    if (!d || !d->handler)
-        return;
-    while (1) {
-        zipc_msg_t msg;
-        if (cap_recv(d->dest, &msg, sizeof(msg)) < 0)
-            continue;
-        d->handler(&msg);
-        cap_send(d->dest, &msg, sizeof(msg));
-    }
+  if (!d || !d->handler)
+    return;
+  while (1) {
+    zipc_msg_t msg;
+    if (cap_recv(d->dest, &msg, sizeof(msg)) < 0)
+      continue;
+    d->handler(&msg);
+    cap_send(d->dest, &msg, sizeof(msg));
+  }
 }


### PR DESCRIPTION
## Summary
- annotate driver helpers with `[[nodiscard]]`
- require checking return values from door and endpoint operations
- flag channel operations and affine wrappers as not discardable
- mark low-level exokernel and caplib APIs `[[nodiscard]]`
- update corresponding source definitions

## Testing
- `pre-commit run --files exo.h libos/affine_runtime.c libos/driver.c src-headers/caplib.h src-headers/chan.h src-headers/door.h src-headers/driver.h src-headers/endpoint.h src-headers/exo_cpu.h src-headers/exo_disk.h src-headers/exo_ipc.h src-headers/exo_irq.h src-headers/exo_mem.h src-headers/exokernel.h src-headers/libos/affine_runtime.h src-headers/libos/driver.h src-kernel/chan.c src-kernel/endpoint.c src-kernel/exo_cpu.c src-kernel/exo_disk.c src-kernel/exo_ipc.c src-kernel/fs.c src-kernel/irq.c src-kernel/vm.c src-uland/caplib.c src-uland/chan.c src-uland/door.c` *(fails: `pre-commit: command not found`)*
- `cmake -S . -B build -G Ninja`
- `ninja -C build` *(fails: clang-tidy configuration errors)*
