### PR TITLE
Use stdint types

### DIFF
--- a/libos/driver.c
+++ b/libos/driver.c
@@ -1,5 +1,6 @@
 #include "driver.h"
 #include "user.h"
+#include <stdlib.h>
 
 int driver_spawn(const char *path, char *const argv[])
 {

--- a/libos/file.c
+++ b/libos/file.c
@@ -1,6 +1,6 @@
 #include "file.h"
 #include "fs.h"
-#include "include/exokernel.h"
+#include "exokernel.h"
 #include "sleeplock.h"
 #include "spinlock.h"
 #include "types.h"

--- a/libos/fs.c
+++ b/libos/fs.c
@@ -1,6 +1,6 @@
 #include "fs.h"
 #include "file.h"
-#include "include/exokernel.h"
+#include "exokernel.h"
 #include "sleeplock.h"
 #include "spinlock.h"
 #include "types.h"

--- a/libos/ipc_queue.c
+++ b/libos/ipc_queue.c
@@ -1,4 +1,4 @@
-#include "include/exokernel.h"
+#include "exokernel.h"
 #include "exo_ipc.h"
 #include "ipc.h"
 #include "uv_spinlock.h"

--- a/libos/irq_client.c
+++ b/libos/irq_client.c
@@ -1,4 +1,4 @@
-#include "include/exokernel.h"
+#include "exokernel.h"
 #include "libos/irq_client.h"
 
 int irq_wait(exo_cap cap, unsigned *irq_no) {

--- a/src-headers/buf.h
+++ b/src-headers/buf.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 struct buf {
   int flags;

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 #include "exo.h"
 #include "exo_cpu.h"
 #include "exokernel.h"

--- a/src-headers/date.h
+++ b/src-headers/date.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 struct rtcdate {
   uint second;

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -164,7 +164,7 @@ void swtch(context_t **, context_t *);
 
 // spinlock.c
 void acquire(struct spinlock *);
-void getcallerpcs(void *, uint *);
+void getcallerpcs(void *, uintptr_t *);
 int holding(struct spinlock *);
 void initlock(struct spinlock *, char *);
 void release(struct spinlock *);

--- a/src-headers/elf.h
+++ b/src-headers/elf.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 // Format of an ELF executable file
 

--- a/src-headers/endpoint.h
+++ b/src-headers/endpoint.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 #include "ipc.h"
 #include "spinlock.h"
 

--- a/src-headers/exo_irq.h
+++ b/src-headers/exo_irq.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <stdint.h>
+#include "types.h"
 #include "exo_mem.h"
 #include "../exo.h"
 

--- a/src-headers/file.h
+++ b/src-headers/file.h
@@ -1,4 +1,8 @@
 #pragma once
+#include "types.h"
+#include <stddef.h>
+#include "spinlock.h"
+#include "sleeplock.h"
 
 struct file {
   enum { FD_NONE, FD_PIPE, FD_INODE } type;

--- a/src-headers/fs.h
+++ b/src-headers/fs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 // On-disk file system format.
 // Both the kernel and user programs use this header file.

--- a/src-headers/libfs.h
+++ b/src-headers/libfs.h
@@ -1,7 +1,9 @@
 #pragma once
+#include "types.h"
 #include "file.h"
 #include "fs.h"
-#include "include/exokernel.h"
+#include "defs.h"
+#include "exokernel.h"
 
 int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -13,7 +13,7 @@ struct spinlock {
   struct ticketlock ticket;
   char *name;
   struct cpu *cpu;
-  unsigned int pcs[10];
+  uintptr_t pcs[10];
 };
 
 #ifdef SPINLOCK_NO_STUBS

--- a/src-headers/memlayout.h
+++ b/src-headers/memlayout.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 // Memory layout
 

--- a/src-headers/mmu.h
+++ b/src-headers/mmu.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 // This file contains definitions for the
 // x86 memory management unit (MMU).

--- a/src-headers/mp.h
+++ b/src-headers/mp.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 // See MultiProcessor Specification Version 1.[14]
 

--- a/src-headers/proc.h
+++ b/src-headers/proc.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "types.h"
 
 #include "param.h"
 #include "mmu.h"

--- a/src-headers/types.h
+++ b/src-headers/types.h
@@ -1,11 +1,13 @@
 #ifndef XV6_TYPES_H
 #define XV6_TYPES_H
 
-typedef unsigned int   uint;
-typedef unsigned short ushort;
-typedef unsigned char  uchar;
-typedef unsigned int   uint32;
-typedef unsigned long  uint64;
-typedef unsigned long  uintptr;
+#include <stdint.h>
+
+typedef uint32_t   uint;
+typedef uint16_t   ushort;
+typedef uint8_t    uchar;
+typedef uint32_t   uint32;
+typedef uint64_t   uint64;
+typedef uintptr_t  uintptr;
 
 #endif // XV6_TYPES_H

--- a/src-kernel/arbitrate.c
+++ b/src-kernel/arbitrate.c
@@ -11,7 +11,7 @@ static struct arbitrate_table default_table;
 static int initialized;
 static struct arbitrate_table *tbl = &default_table;
 
-static int default_policy(uint type, uint res, uint cur, uint newo) {
+static int default_policy(uint32_t type, uint32_t res, uint32_t cur, uint32_t newo) {
     (void)type; (void)res; (void)cur; (void)newo;
     return 0; // keep current owner
 }
@@ -45,7 +45,7 @@ arbitrate_register_policy(arbitrate_policy_t p)
 }
 
 int
-arbitrate_request(uint type, uint resource_id, uint owner)
+arbitrate_request(uint32_t type, uint32_t resource_id, uint32_t owner)
 {
     if(!initialized)
         arbitrate_init(policy);
@@ -88,7 +88,7 @@ arbitrate_request(uint type, uint resource_id, uint owner)
 
     int allow = policy ? policy(type, resource_id, match->owner, owner) : 0;
     if(allow){
-        uint old = match->owner;
+        uint32_t old = match->owner;
         match->owner = owner;
         release(&tbl->lock);
         cprintf("arbitrate: replace %u/%u %u -> %u\n", type, resource_id, old, owner);

--- a/src-kernel/bio.c
+++ b/src-kernel/bio.c
@@ -63,7 +63,7 @@ binit(void)
 // If not found, allocate a buffer.
 // In either case, return locked buffer.
 static struct buf*
-bget(uint dev, uint blockno)
+bget(uint32_t dev, uint32_t blockno)
 {
   struct buf *b;
 
@@ -98,7 +98,7 @@ bget(uint dev, uint blockno)
 
 // Return a locked buf with the contents of the indicated block.
 struct buf*
-bread(uint dev, uint blockno)
+bread(uint32_t dev, uint32_t blockno)
 {
   struct buf *b;
   rcu_read_lock();

--- a/src-kernel/bootmain.c
+++ b/src-kernel/bootmain.c
@@ -13,7 +13,7 @@
 
 #define SECTSIZE  512
 
-void readseg(uchar*, uint, uint);
+void readseg(uchar*, uint32_t, uint32_t);
 
 void
 bootmain(void)
@@ -58,7 +58,7 @@ waitdisk(void)
 
 // Read a single sector at offset into dst.
 void
-readsect(void *dst, uint offset)
+readsect(void *dst, uint32_t offset)
 {
   // Issue command.
   waitdisk();
@@ -77,7 +77,7 @@ readsect(void *dst, uint offset)
 // Read 'count' bytes at 'offset' from kernel into physical address 'pa'.
 // Might copy more than asked.
 void
-readseg(uchar* pa, uint count, uint offset)
+readseg(uchar* pa, uint32_t count, uint32_t offset)
 {
   uchar* epa;
 

--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -38,9 +38,9 @@ hash256(const uint8_t *data, size_t len, hash256_t *out)
 
 /* Derive the authentication tag for a capability. */
 static void
-compute_tag(uint id, uint rights, uint owner, hash256_t *out)
+compute_tag(uint32_t id, uint32_t rights, uint32_t owner, hash256_t *out)
 {
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    struct { uint32_t id; uint32_t rights; uint32_t owner; } tmp = { id, rights, owner };
     uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
 
     memmove(buf, cap_secret, sizeof(cap_secret));
@@ -49,7 +49,7 @@ compute_tag(uint id, uint rights, uint owner, hash256_t *out)
 }
 
 exo_cap
-cap_new(uint id, uint rights, uint owner)
+cap_new(uint32_t id, uint32_t rights, uint32_t owner)
 {
     exo_cap c;
     c.id = id;
@@ -69,14 +69,14 @@ cap_verify(exo_cap c)
 
 /* Allocate capabilities for additional resource types. */
 exo_cap
-exo_alloc_ioport(uint port)
+exo_alloc_ioport(uint32_t port)
 {
     int id = cap_table_alloc(CAP_TYPE_IOPORT, port, 0, myproc()->pid);
-    return cap_new(id >= 0 ? (uint)id : 0, 0, myproc()->pid);
+    return cap_new(id >= 0 ? (uint32_t)id : 0, 0, myproc()->pid);
 }
 
 exo_cap
-exo_bind_irq(uint irq)
+exo_bind_irq(uint32_t irq)
 {
     int id = cap_table_alloc(CAP_TYPE_IRQ, irq, 0, myproc()->pid);
 
@@ -84,7 +84,7 @@ exo_bind_irq(uint irq)
 }
 
 exo_cap
-exo_alloc_dma(uint chan)
+exo_alloc_dma(uint32_t chan)
 {
     int id = cap_table_alloc(CAP_TYPE_DMA, chan, 0, myproc()->pid);
     return cap_new(id >= 0 ? id : 0, 0, myproc()->pid);

--- a/src-kernel/cap_table.c
+++ b/src-kernel/cap_table.c
@@ -7,7 +7,7 @@
 
 static struct spinlock cap_lock;
 static struct cap_entry cap_table[CAP_MAX];
-uint global_epoch;
+uint32_t global_epoch;
 
 void cap_table_init(void) {
     initlock(&cap_lock, "captbl");
@@ -15,7 +15,7 @@ void cap_table_init(void) {
     global_epoch = 0;
 }
 
-int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
+int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights, uint32_t owner) {
     if(type == CAP_TYPE_NONE || type > CAP_TYPE_DMA)
         return -1;
     acquire(&cap_lock);
@@ -26,7 +26,7 @@ int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
             cap_table[i].rights = rights;
             cap_table[i].owner = owner;
             cap_table[i].refcnt = 1;
-            uint id = ((uint)cap_table[i].epoch << 16) | i;
+            uint32_t id = ((uint32_t)cap_table[i].epoch << 16) | i;
             release(&cap_lock);
             return id;
         }
@@ -35,7 +35,7 @@ int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
     return -1;
 }
 
-int cap_table_lookup(uint id, struct cap_entry *out) {
+int cap_table_lookup(uint32_t id, struct cap_entry *out) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -50,7 +50,7 @@ int cap_table_lookup(uint id, struct cap_entry *out) {
     return 0;
 }
 
-void cap_table_inc(uint id) {
+void cap_table_inc(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -60,7 +60,7 @@ void cap_table_inc(uint id) {
     release(&cap_lock);
 }
 
-void cap_table_dec(uint id) {
+void cap_table_dec(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -72,7 +72,7 @@ void cap_table_dec(uint id) {
     release(&cap_lock);
 }
 
-int cap_table_remove(uint id) {
+int cap_table_remove(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -86,7 +86,7 @@ int cap_table_remove(uint id) {
     return 0;
 }
 
-int cap_revoke(uint id) {
+int cap_revoke(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);

--- a/src-kernel/console.c
+++ b/src-kernel/console.c
@@ -32,7 +32,7 @@ printint(int xx, int base, int sign)
   static char digits[] = "0123456789abcdef";
   char buf[16];
   int i;
-  uint x;
+  uint32_t x;
 
   if(sign && (sign = xx < 0))
     x = -xx;
@@ -57,7 +57,7 @@ void
 cprintf(char *fmt, ...)
 {
   int i, c, locking;
-  unsigned long *argp;
+  uintptr_t *argp;
   char *s;
 
   locking = cons.locking;
@@ -67,7 +67,7 @@ cprintf(char *fmt, ...)
   if (fmt == 0)
     panic("null fmt");
 
-  argp = (unsigned long*)(void*)(&fmt + 1);
+  argp = (uintptr_t *)(void *)(&fmt + 1);
   for(i = 0; (c = fmt[i] & 0xff) != 0; i++){
     if(c != '%'){
       ttypecho(c, consputc);
@@ -109,7 +109,7 @@ void
 panic(char *s)
 {
   int i;
-  uint pcs[10];
+  uintptr_t pcs[10];
 
   cli();
   cons.locking = 0;

--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -20,7 +20,7 @@ endpoint_init(struct endpoint *ep)
 }
 
 void
-endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint32_t size,
                 const struct msg_type_desc *desc)
 {
     endpoint_init(ep);

--- a/src-kernel/exec.c
+++ b/src-kernel/exec.c
@@ -12,7 +12,7 @@ exec(char *path, char **argv)
 {
   char *s, *last;
   int i, off;
-  uint argc, sz, sp, ustack[3+MAXARG+1];
+  uint32_t argc, sz, sp, ustack[3+MAXARG+1];
   struct elfhdr elf;
   struct inode *ip;
   struct proghdr ph;

--- a/src-kernel/exo.c
+++ b/src-kernel/exo.c
@@ -12,7 +12,7 @@
 extern struct ptable ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
-  uint cap = tf->eax;
+  uint32_t cap = tf->eax;
   struct proc *p;
 
   acquire(&ptable.lock);

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -18,8 +18,8 @@ struct ipc_entry {
 static struct {
   struct spinlock lock;
   struct ipc_entry buf[IPC_BUFSZ];
-  uint r;
-  uint w;
+  uint32_t r;
+  uint32_t w;
   int inited;
 } ipcs;
 

--- a/src-kernel/fastipc.c
+++ b/src-kernel/fastipc.c
@@ -9,7 +9,7 @@
 static struct {
     struct spinlock lock;
     zipc_msg_t buf[FASTIPC_BUFSZ];
-    uint r, w;
+    uint32_t r, w;
     int inited;
 } fastipc;
 

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -57,8 +57,8 @@ bzero(int dev, int bno)
 // Blocks.
 
 // Allocate a zeroed disk block.
-static uint
-balloc(uint dev)
+static uint32_t
+balloc(uint32_t dev)
 {
   int b, bi, m;
   struct buf *bp;
@@ -83,7 +83,7 @@ balloc(uint dev)
 
 // Allocate a zeroed disk block and return a capability for it.
 struct exo_blockcap
-exo_alloc_block(uint dev, uint rights)
+exo_alloc_block(uint32_t dev, uint32_t rights)
 {
   struct exo_blockcap cap = {0, 0, 0, 0};
   int b, bi, m;
@@ -117,7 +117,7 @@ exo_bind_block(struct exo_blockcap *cap, struct buf *buf, int write)
 {
   if(cap->owner != myproc()->pid)
     return -EPERM;
-  uint need = write ? EXO_RIGHT_W : EXO_RIGHT_R;
+  uint32_t need = write ? EXO_RIGHT_W : EXO_RIGHT_R;
   if(!cap_has_rights(cap->rights, need))
     return -EPERM;
 
@@ -145,7 +145,7 @@ exo_flush_block(struct exo_blockcap *cap, void *data)
 
 // Free a disk block.
 static void
-bfree(int dev, uint b)
+bfree(int dev, uint32_t b)
 {
   struct buf *bp;
   int bi, m;
@@ -251,14 +251,14 @@ iinit(int dev)
           sb.bmapstart);
 }
 
-static struct inode* iget(uint dev, uint inum);
+static struct inode* iget(uint32_t dev, uint32_t inum);
 
 //PAGEBREAK!
 // Allocate an inode on device dev.
 // Mark it as allocated by  giving it type type.
 // Returns an unlocked but allocated and referenced inode.
 struct inode*
-ialloc(uint dev, short type)
+ialloc(uint32_t dev, short type)
 {
   int inum;
   struct buf *bp;
@@ -305,7 +305,7 @@ iupdate(struct inode *ip)
 // and return the in-memory copy. Does not lock
 // the inode and does not read it from disk.
 static struct inode*
-iget(uint dev, uint inum)
+iget(uint32_t dev, uint32_t inum)
 {
   struct inode *ip, *empty;
 
@@ -435,10 +435,10 @@ iunlockput(struct inode *ip)
 
 // Return the disk block address of the nth block in inode ip.
 // If there is no such block, bmap allocates one.
-static uint
-bmap(struct inode *ip, uint bn)
+static uint32_t
+bmap(struct inode *ip, uint32_t bn)
 {
-  uint addr, *a;
+  uint32_t addr, *a;
   struct buf *bp;
 
   if(bn < NDIRECT){
@@ -453,7 +453,7 @@ bmap(struct inode *ip, uint bn)
     if((addr = ip->addrs[NDIRECT]) == 0)
       ip->addrs[NDIRECT] = addr = balloc(ip->dev);
     bp = bread(ip->dev, addr);
-    a = (uint*)bp->data;
+    a = (uint32_t*)bp->data;
     if((addr = a[bn]) == 0){
       a[bn] = addr = balloc(ip->dev);
       log_write(bp);
@@ -475,7 +475,7 @@ itrunc(struct inode *ip)
 {
   int i, j;
   struct buf *bp;
-  uint *a;
+  uint32_t *a;
 
   for(i = 0; i < NDIRECT; i++){
     if(ip->addrs[i]){
@@ -486,7 +486,7 @@ itrunc(struct inode *ip)
 
   if(ip->addrs[NDIRECT]){
     bp = bread(ip->dev, ip->addrs[NDIRECT]);
-    a = (uint*)bp->data;
+    a = (uint32_t*)bp->data;
     for(j = 0; j < NINDIRECT; j++){
       if(a[j])
         bfree(ip->dev, a[j]);
@@ -516,7 +516,7 @@ stati(struct inode *ip, struct stat *st)
 // Read data from inode.
 // Caller must hold ip->lock.
 int
-readi(struct inode *ip, char *dst, uint off, size_t n)
+readi(struct inode *ip, char *dst, uint32_t off, size_t n)
 {
   size_t tot, m;
   struct buf *bp;
@@ -545,7 +545,7 @@ readi(struct inode *ip, char *dst, uint off, size_t n)
 // Write data to inode.
 // Caller must hold ip->lock.
 int
-writei(struct inode *ip, char *src, uint off, size_t n)
+writei(struct inode *ip, char *src, uint32_t off, size_t n)
 {
   size_t tot, m;
   struct buf *bp;
@@ -588,9 +588,9 @@ namecmp(const char *s, const char *t)
 // Look for a directory entry in a directory.
 // If found, set *poff to byte offset of entry.
 struct inode*
-dirlookup(struct inode *dp, char *name, uint *poff)
+dirlookup(struct inode *dp, char *name, uint32_t *poff)
 {
-  uint off, inum;
+  uint32_t off, inum;
   struct dirent de;
 
   if(dp->type != T_DIR)
@@ -615,7 +615,7 @@ dirlookup(struct inode *dp, char *name, uint *poff)
 
 // Write a new directory entry (name, inum) into the directory dp.
 int
-dirlink(struct inode *dp, char *name, uint inum)
+dirlink(struct inode *dp, char *name, uint32_t inum)
 {
   int off;
   struct dirent de;

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -16,7 +16,7 @@ struct spinlock {
   // For debugging:
   char *name;      // Name of lock.
   struct cpu *cpu; // The cpu holding the lock.
-  uint pcs[10];    // The call stack (an array of program counters)
+  uintptr_t pcs[10];    // The call stack (an array of program counters)
                    // that locked the lock.
 };
 

--- a/src-kernel/ioapic.c
+++ b/src-kernel/ioapic.c
@@ -26,12 +26,12 @@ volatile struct ioapic *ioapic;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {
-  uint reg;
-  uint pad[3];
-  uint data;
+  uint32_t reg;
+  uint32_t pad[3];
+  uint32_t data;
 };
 
-static uint
+static uint32_t
 ioapicread(int reg)
 {
   ioapic->reg = reg;
@@ -39,7 +39,7 @@ ioapicread(int reg)
 }
 
 static void
-ioapicwrite(int reg, uint data)
+ioapicwrite(int reg, uint32_t data)
 {
   ioapic->reg = reg;
   ioapic->data = data;

--- a/src-kernel/irq.c
+++ b/src-kernel/irq.c
@@ -10,9 +10,9 @@
 
 struct irq_queue {
   struct spinlock lock;
-  uint buf[IRQ_BUFSZ];
-  uint r;
-  uint w;
+  uint32_t buf[IRQ_BUFSZ];
+  uint32_t r;
+  uint32_t w;
   int inited;
 } irq_q;
 
@@ -24,14 +24,14 @@ static void irq_init(void) {
   }
 }
 
-exo_cap exo_alloc_irq(uint irq, uint rights) {
+exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights) {
   int id = cap_table_alloc(CAP_TYPE_IRQ, irq, rights, myproc()->pid);
   if (id < 0)
     return cap_new(0, 0, 0);
   return cap_new(id, rights, myproc()->pid);
 }
 
-static int check_irq_cap(exo_cap cap, uint need) {
+static int check_irq_cap(exo_cap cap, uint32_t need) {
   if (!cap_verify(cap))
     return 0;
   struct cap_entry e;
@@ -44,7 +44,7 @@ static int check_irq_cap(exo_cap cap, uint need) {
   return 1;
 }
 
-int exo_irq_wait(exo_cap cap, uint *irq_out) {
+int exo_irq_wait(exo_cap cap, uint32_t *irq_out) {
   if (!check_irq_cap(cap, EXO_RIGHT_R))
     return -EPERM;
   irq_init();
@@ -53,7 +53,7 @@ int exo_irq_wait(exo_cap cap, uint *irq_out) {
     wakeup(&irq_q.w);
     sleep(&irq_q.r, &irq_q.lock);
   }
-  uint irq = irq_q.buf[irq_q.r % IRQ_BUFSZ];
+  uint32_t irq = irq_q.buf[irq_q.r % IRQ_BUFSZ];
   irq_q.r++;
   wakeup(&irq_q.w);
   release(&irq_q.lock);
@@ -68,7 +68,7 @@ int exo_irq_ack(exo_cap cap) {
   return 0;
 }
 
-void irq_trigger(uint irq) {
+void irq_trigger(uint32_t irq) {
   irq_init();
   acquire(&irq_q.lock);
   if (irq_q.w - irq_q.r < IRQ_BUFSZ) {

--- a/src-kernel/kbd.c
+++ b/src-kernel/kbd.c
@@ -6,11 +6,11 @@
 int
 kbdgetc(void)
 {
-  static uint shift;
+  static uint32_t shift;
   static uchar *charcode[4] = {
     normalmap, shiftmap, ctlmap, ctlmap
   };
-  uint st, data, c;
+  uint32_t st, data, c;
 
   st = inb(KBSTATP);
   if((st & KBS_DIB) == 0)

--- a/src-kernel/lapic.c
+++ b/src-kernel/lapic.c
@@ -10,7 +10,7 @@
 #include "mmu.h"
 #include "x86.h"
 
-// Local APIC registers, divided by 4 for use as uint[] indices.
+// Local APIC registers, divided by 4 for use as uint32_t[] indices.
 #define ID      (0x0020/4)   // ID
 #define VER     (0x0030/4)   // Version
 #define TPR     (0x0080/4)   // Task Priority
@@ -41,7 +41,7 @@
 #define TCCR    (0x0390/4)   // Timer Current Count
 #define TDCR    (0x03E0/4)   // Timer Divide Configuration
 
-volatile uint *lapic;  // Initialized in mp.c
+volatile uint32_t *lapic;  // Initialized in mp.c
 
 //PAGEBREAK!
 static void
@@ -126,7 +126,7 @@ microdelay(int us)
 // Start additional processor running entry code at addr.
 // See Appendix B of MultiProcessor Specification.
 void
-lapicstartap(uchar apicid, uint addr)
+lapicstartap(uchar apicid, uint32_t addr)
 {
   int i;
   ushort *wrv;
@@ -171,8 +171,8 @@ lapicstartap(uchar apicid, uint addr)
 #define MONTH   0x08
 #define YEAR    0x09
 
-static uint
-cmos_read(uint reg)
+static uint32_t
+cmos_read(uint32_t reg)
 {
   outb(CMOS_PORT,  reg);
   microdelay(200);

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -89,7 +89,7 @@ static void startothers(void) {
   memmove(code, _binary_entryother64_start, (size_t)_binary_entryother64_size);
 
 #else
-  memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
+  memmove(code, _binary_entryother_start, (uint32_t)_binary_entryother_size);
 #endif
 
   for (c = cpus; c < cpus + ncpu; c++) {

--- a/src-kernel/memide.c
+++ b/src-kernel/memide.c
@@ -22,7 +22,7 @@ void
 ideinit(void)
 {
   memdisk = _binary_fs_img_start;
-  disksize = (uint)_binary_fs_img_size/BSIZE;
+  disksize = (uint32_t)_binary_fs_img_size/BSIZE;
 }
 
 // Interrupt handler.

--- a/src-kernel/mkfs.c
+++ b/src-kernel/mkfs.c
@@ -29,17 +29,17 @@ int nblocks;  // Number of data blocks
 int fsfd;
 struct superblock sb;
 char zeroes[BSIZE];
-uint freeinode = 1;
-uint freeblock;
+uint32_t freeinode = 1;
+uint32_t freeblock;
 
 
 void balloc(int);
-void wsect(uint, void*);
-void winode(uint, struct dinode*);
-void rinode(uint inum, struct dinode *ip);
-void rsect(uint sec, void *buf);
-uint ialloc(ushort type);
-void iappend(uint inum, void *p, int n);
+void wsect(uint32_t, void*);
+void winode(uint32_t, struct dinode*);
+void rinode(uint32_t inum, struct dinode *ip);
+void rsect(uint32_t sec, void *buf);
+uint32_t ialloc(ushort type);
+void iappend(uint32_t inum, void *p, int n);
 
 // convert to intel byte order
 ushort
@@ -52,10 +52,10 @@ xshort(ushort x)
   return y;
 }
 
-uint
-xint(uint x)
+uint32_t
+xint(uint32_t x)
 {
-  uint y;
+  uint32_t y;
   uchar *a = (uchar*)&y;
   a[0] = x;
   a[1] = x >> 8;
@@ -68,7 +68,7 @@ int
 main(int argc, char *argv[])
 {
   int i, cc, fd;
-  uint rootino, inum, off;
+  uint32_t rootino, inum, off;
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 }
 
 void
-wsect(uint sec, void *buf)
+wsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -181,10 +181,10 @@ wsect(uint sec, void *buf)
 }
 
 void
-winode(uint inum, struct dinode *ip)
+winode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -195,10 +195,10 @@ winode(uint inum, struct dinode *ip)
 }
 
 void
-rinode(uint inum, struct dinode *ip)
+rinode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -208,7 +208,7 @@ rinode(uint inum, struct dinode *ip)
 }
 
 void
-rsect(uint sec, void *buf)
+rsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -220,10 +220,10 @@ rsect(uint sec, void *buf)
   }
 }
 
-uint
+uint32_t
 ialloc(ushort type)
 {
-  uint inum = freeinode++;
+  uint32_t inum = freeinode++;
   struct dinode din;
 
   bzero(&din, sizeof(din));
@@ -253,14 +253,14 @@ balloc(int used)
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
 void
-iappend(uint inum, void *xp, int n)
+iappend(uint32_t inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint fbn, off, n1;
+  uint32_t fbn, off, n1;
   struct dinode din;
   char buf[BSIZE];
-  uint indirect[NINDIRECT];
-  uint x;
+  uint32_t indirect[NINDIRECT];
+  uint32_t x;
 
   rinode(inum, &din);
   off = xint(din.size);

--- a/src-kernel/mmu64.c
+++ b/src-kernel/mmu64.c
@@ -51,7 +51,7 @@ walkpml4(pml4e_t *pml4, const void *va, int alloc)
 }
 
 static int
-mappages64(pml4e_t *pml4, void *va, uint size, uint64 pa, int perm)
+mappages64(pml4e_t *pml4, void *va, uint32_t size, uint64 pa, int perm)
 {
   char *a, *last;
   pte_t *pte;
@@ -76,7 +76,7 @@ pml4e_t*
 setupkvm64(void)
 {
   pml4e_t *pml4;
-  struct kmap { void *virt; uint phys_start; uint phys_end; int perm; };
+  struct kmap { void *virt; uint32_t phys_start; uint32_t phys_end; int perm; };
   static struct kmap kmap[] = {
     { (void*)KERNBASE, 0,             EXTMEM,    PTE_W},
     { (void*)KERNLINK, V2P(KERNLINK), V2P(data), 0},

--- a/src-kernel/mp.c
+++ b/src-kernel/mp.c
@@ -28,7 +28,7 @@ sum(uchar *addr, int len)
 
 // Look for an MP structure in the len bytes at addr.
 static struct mp*
-mpsearch1(uint a, int len)
+mpsearch1(uint32_t a, int len)
 {
   uchar *e, *p, *addr;
 
@@ -49,7 +49,7 @@ static struct mp*
 mpsearch(void)
 {
   uchar *bda;
-  uint p;
+  uint32_t p;
   struct mp *mp;
 
   bda = (uchar *) P2V(0x400);
@@ -101,7 +101,7 @@ mpinit(void)
   if((conf = mpconfig(&mp)) == 0)
     panic("Expect to run on an SMP");
   ismp = 1;
-  lapic = (uint*)conf->lapicaddr;
+  lapic = (uint32_t*)conf->lapicaddr;
   for(p=(uchar*)(conf+1), e=(uchar*)conf+conf->length; p<e; ){
     switch(*p){
     case MPPROC:

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -12,14 +12,14 @@ struct ptable ptable;
 static struct proc *initproc;
 
 int nextpid = 1;
-static uint nextpctr_cap = 1;
+static uint32_t nextpctr_cap = 1;
 extern void forkret(void);
 extern void trapret(void);
 
 // Map exo_pctr capabilities directly to owning processes.
 #define PCTR_HASHSIZE (NPROC * 2)
 struct pctr_entry {
-  uint cap;
+  uint32_t cap;
   struct proc *p;
 };
 static struct pctr_entry pctr_table[PCTR_HASHSIZE];
@@ -27,8 +27,8 @@ static struct pctr_entry pctr_table[PCTR_HASHSIZE];
 static void
 pctr_insert(struct proc *p)
 {
-  uint cap = p->pctr_cap;
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t cap = p->pctr_cap;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p)
     idx = (idx + 1) % PCTR_HASHSIZE;
   pctr_table[idx].cap = cap;
@@ -36,9 +36,9 @@ pctr_insert(struct proc *p)
 }
 
 static void
-pctr_remove(uint cap)
+pctr_remove(uint32_t cap)
 {
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p){
     if(pctr_table[idx].cap == cap){
       pctr_table[idx].p = 0;
@@ -59,9 +59,9 @@ pctr_remove(uint cap)
 }
 
 struct proc *
-pctr_lookup(uint cap)
+pctr_lookup(uint32_t cap)
 {
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p){
     if(pctr_table[idx].cap == cap)
       return pctr_table[idx].p;
@@ -165,25 +165,25 @@ found:
   // Set up new context to start executing at forkret,
   // which returns to trapret.
 #if defined(__x86_64__)
-  sp -= sizeof(unsigned long);
-  *(unsigned long*)sp = (unsigned long)trapret;
+  sp -= sizeof(uintptr_t);
+  *(uintptr_t *)sp = (uintptr_t)trapret;
 #elif defined(__aarch64__)
-  sp -= sizeof(unsigned long);
-  *(unsigned long*)sp = (unsigned long)trapret;
+  sp -= sizeof(uintptr_t);
+  *(uintptr_t *)sp = (uintptr_t)trapret;
 #else
   sp -= 4;
-  *(uint*)sp = (uint)trapret;
+  *(uint32_t*)sp = (uint32_t)trapret;
 #endif
 
   sp -= sizeof *p->context;
   p->context = (context_t*)sp;
   memset(p->context, 0, sizeof *p->context);
 #if defined(__x86_64__)
-  p->context->rip = (unsigned long)forkret;
+  p->context->rip = (uintptr_t)forkret;
 #elif defined(__aarch64__)
-  p->context->lr = (unsigned long)forkret;
+  p->context->lr = (uintptr_t)forkret;
 #else
-  p->context->eip = (uint)forkret;
+  p->context->eip = (uint32_t)forkret;
 #endif
 
   return p;
@@ -233,7 +233,7 @@ userinit(void)
 int
 growproc(int n)
 {
-  uint sz;
+  uint32_t sz;
   struct proc *curproc = myproc();
 
   sz = curproc->sz;
@@ -617,7 +617,7 @@ procdump(void)
   int i;
   struct proc *p;
   char *state;
-  uint pc[10];
+  uintptr_t pc[10];
 
   for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
     if(p->state == UNUSED)
@@ -633,7 +633,7 @@ procdump(void)
 #elif defined(__aarch64__)
       getcallerpcs((void*)p->context->fp + 2*sizeof(uintptr_t), pc);
 #else
-      getcallerpcs((uint*)p->context->ebp+2, pc);
+      getcallerpcs((uintptr_t *)p->context->ebp + 2, pc);
 #endif
       for(i=0; i<10 && pc[i] != 0; i++)
         cprintf(" %p", pc[i]);

--- a/src-kernel/spinlock.c
+++ b/src-kernel/spinlock.c
@@ -69,31 +69,31 @@ void release(struct spinlock *lk) { (void)lk; }
 #endif
 
 // Record the current call stack in pcs[] by following the %ebp chain.
-void getcallerpcs(void *v, uint pcs[]) {
+void getcallerpcs(void *v, uintptr_t pcs[]) {
 #ifdef __x86_64__
-  unsigned long *rbp;
+  uintptr_t *rbp;
   int i;
 
-  rbp = (unsigned long *)v - 2;
+  rbp = (uintptr_t *)v - 2;
   for (i = 0; i < 10; i++) {
-    if (rbp == 0 || rbp < (unsigned long *)KERNBASE ||
-        rbp == (unsigned long *)-1)
+    if (rbp == 0 || rbp < (uintptr_t *)KERNBASE ||
+        rbp == (uintptr_t *)-1)
       break;
     pcs[i] = rbp[1];               // saved %rip
-    rbp = (unsigned long *)rbp[0]; // saved %rbp
+    rbp = (uintptr_t *)rbp[0];     // saved %rbp
   }
   for (; i < 10; i++)
     pcs[i] = 0;
 #else
-  uint *ebp;
+  uintptr_t *ebp;
   int i;
 
-  ebp = (uint *)v - 2;
+  ebp = (uintptr_t *)v - 2;
   for (i = 0; i < 10; i++) {
-    if (ebp == 0 || ebp < (uint *)KERNBASE || ebp == (uint *)0xffffffff)
+    if (ebp == 0 || ebp < (uintptr_t *)KERNBASE || ebp == (uintptr_t *)0xffffffff)
       break;
     pcs[i] = ebp[1];      // saved %eip
-    ebp = (uint *)ebp[0]; // saved %ebp
+    ebp = (uintptr_t *)ebp[0]; // saved %ebp
   }
   for (; i < 10; i++)
     pcs[i] = 0;

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -90,7 +90,7 @@ argptr(int n, char **pp, size_t size)
   int i;
   if (argint(n, &i) < 0)
     return -1;
-  if (size < 0 || (uint)i >= curproc->sz || (uint)i + size > curproc->sz)
+  if (size < 0 || (uint32_t)i >= curproc->sz || (uint32_t)i + size > curproc->sz)
     return -1;
   *pp = (char *)i;
   return 0;

--- a/src-kernel/sysfile.c
+++ b/src-kernel/sysfile.c
@@ -187,7 +187,7 @@ sys_unlink(void)
   struct inode *ip, *dp;
   struct dirent de;
   char name[DIRSIZ], *path;
-  uint off;
+  uint32_t off;
 
   if(argstr(0, &path) < 0)
     return -1;
@@ -399,7 +399,7 @@ sys_exec(void)
 {
   char *path, *argv[MAXARG];
   int i;
-  uint uargv, uarg;
+  uint32_t uargv, uarg;
 
   if(argstr(0, &path) < 0 || argint(1, (int*)&uargv) < 0){
     return -1;

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -48,7 +48,7 @@ int sys_sbrk(void) {
 
 int sys_sleep(void) {
   int n;
-  uint ticks0;
+  uint32_t ticks0;
 
   if (argint(0, &n) < 0)
     return -1;
@@ -68,7 +68,7 @@ int sys_sleep(void) {
 // return how many clock tick interrupts have occurred
 // since start.
 int sys_uptime(void) {
-  uint xticks;
+  uint32_t xticks;
 
   acquire(&tickslock);
   xticks = ticks;
@@ -132,7 +132,7 @@ int sys_exo_alloc_ioport(void) {
   exo_cap *ucap;
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_ioport((uint)port);
+  exo_cap cap = exo_alloc_ioport((uint32_t)port);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -142,7 +142,7 @@ int sys_exo_bind_irq(void) {
   exo_cap *ucap;
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_bind_irq((uint)irq);
+  exo_cap cap = exo_bind_irq((uint32_t)irq);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -152,7 +152,7 @@ int sys_exo_alloc_dma(void) {
   exo_cap *ucap;
   if (argint(0, &chan) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_dma((uint)chan);
+  exo_cap cap = exo_alloc_dma((uint32_t)chan);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -212,7 +212,7 @@ int sys_exo_yield_to(void) {
 int sys_exo_read_disk(void) {
   struct exo_blockcap cap;
   char *dst;
-  uint off, n;
+  uint32_t off, n;
 
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
@@ -226,7 +226,7 @@ int sys_exo_read_disk(void) {
 int sys_exo_write_disk(void) {
   struct exo_blockcap cap;
   char *src;
-  uint off, n;
+  uint32_t off, n;
 
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
@@ -242,7 +242,7 @@ int sys_exo_alloc_ioport(void) {
   exo_cap *ucap;
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_ioport((uint)port);
+  exo_cap cap = exo_alloc_ioport((uint32_t)port);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -252,7 +252,7 @@ int sys_exo_bind_irq(void) {
   exo_cap *ucap;
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_bind_irq((uint)irq);
+  exo_cap cap = exo_bind_irq((uint32_t)irq);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -269,7 +269,7 @@ int sys_exo_alloc_dma(void) {
 int sys_exo_send(void) {
   exo_cap *ucap, cap;
   char *src;
-  uint n;
+  uint32_t n;
   if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)
@@ -283,7 +283,7 @@ int sys_exo_send(void) {
 int sys_exo_recv(void) {
   exo_cap *ucap, cap;
   char *dst;
-  uint n;
+  uint32_t n;
   if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
@@ -380,7 +380,7 @@ int sys_cap_inc(void) {
   int id;
   if (argint(0, &id) < 0)
     return -1;
-  cap_table_inc((uint)id);
+  cap_table_inc((uint32_t)id);
   return 0;
 }
 
@@ -388,7 +388,7 @@ int sys_cap_dec(void) {
   int id;
   if (argint(0, &id) < 0)
     return -1;
-  cap_table_dec((uint)id);
+  cap_table_dec((uint32_t)id);
   return 0;
 }
 
@@ -398,14 +398,14 @@ int sys_exo_irq_alloc(void) {
   if (argint(0, &irq) < 0 || argint(1, &rights) < 0 ||
       argptr(2, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_irq((uint)irq, (uint)rights);
+  exo_cap cap = exo_alloc_irq((uint32_t)irq, (uint32_t)rights);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
 
 int sys_exo_irq_wait(void) {
   exo_cap cap;
-  uint *irq_out;
+  uint32_t *irq_out;
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argptr(1, (void *)&irq_out, sizeof(*irq_out)) < 0)
     return -1;

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -10,9 +10,9 @@
 
 // Interrupt descriptor table (shared by all CPUs).
 struct gatedesc idt[256];
-extern uint vectors[]; // in vectors.S: array of 256 entry pointers
+extern uint32_t vectors[]; // in vectors.S: array of 256 entry pointers
 struct spinlock tickslock;
-uint ticks;
+uint32_t ticks;
 
 void tvinit(void) {
   int i;
@@ -66,8 +66,8 @@ void trap(struct trapframe *tf) {
     if (myproc() && myproc()->timer_upcall && (tf->cs & 3) == DPL_USER) {
 #ifndef __x86_64__
       tf->esp -= 4;
-      *(uint *)tf->esp = tf->eip;
-      tf->eip = (uint)myproc()->timer_upcall;
+      *(uint32_t *)tf->esp = tf->eip;
+      tf->eip = (uint32_t)myproc()->timer_upcall;
 #else
       tf->rsp -= 8;
       *(uint64 *)tf->rsp = tf->rip;

--- a/src-kernel/tty.c
+++ b/src-kernel/tty.c
@@ -11,9 +11,9 @@
 static struct {
   struct spinlock lock;
   char buf[INPUT_BUF];
-  uint r; // read index
-  uint w; // write index
-  uint e; // edit index
+  uint32_t r; // read index
+  uint32_t w; // write index
+  uint32_t e; // edit index
 } tty;
 
 void

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -64,7 +64,7 @@ walkpgdir(pde_t *pgdir, const void *va, int alloc)
 // physical addresses starting at pa. va and size might not
 // be page-aligned.
 static int
-mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm)
+mappages(pde_t *pgdir, void *va, uint32_t size, uint32_t pa, int perm)
 {
   char *a, *last;
   pte_t *pte;
@@ -110,8 +110,8 @@ mappages(pde_t *pgdir, void *va, uint size, uint pa, int perm)
 // every process's page table.
 static struct kmap {
   void *virt;
-  uint phys_start;
-  uint phys_end;
+  uint32_t phys_start;
+  uint32_t phys_end;
   int perm;
 } kmap[] = {
  { (void*)KERNBASE, 0,             EXTMEM,    PTE_W}, // I/O space
@@ -205,9 +205,9 @@ inituvm(pde_t *pgdir, char *init, size_t sz)
 // Load a program segment into pgdir.  addr must be page-aligned
 // and the pages from addr to addr+sz must already be mapped.
 int
-loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint offset, size_t sz)
+loaduvm(pde_t *pgdir, char *addr, struct inode *ip, uint32_t offset, size_t sz)
 {
-  uint i, pa, n;
+  uint32_t i, pa, n;
   pte_t *pte;
 
   if((uintptr_t) addr % PGSIZE != 0)
@@ -232,7 +232,7 @@ int
 allocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
 {
   char *mem;
-  uint a;
+  uint32_t a;
 
   if(newsz >= KERNBASE)
     return 0;
@@ -266,7 +266,7 @@ int
 deallocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
 {
   pte_t *pte;
-  uint a, pa;
+  uint32_t a, pa;
 
   if(newsz >= oldsz)
     return oldsz;
@@ -293,7 +293,7 @@ deallocuvm(pde_t *pgdir, size_t oldsz, size_t newsz)
 void
 freevm(pde_t *pgdir)
 {
-  uint i;
+  uint32_t i;
 
   if(pgdir == 0)
     panic("freevm: no pgdir");
@@ -325,7 +325,7 @@ insert_pte(pde_t *pgdir, void *va,
 #if defined(__x86_64__) || defined(__aarch64__)
            uint64 pa,
 #else
-           uint pa,
+           uint32_t pa,
 #endif
            int perm)
 {
@@ -350,7 +350,7 @@ copyuvm(pde_t *pgdir, size_t sz)
 {
   pde_t *d;
   pte_t *pte;
-  uint pa, flags;
+  uint32_t pa, flags;
   size_t i;
   char *mem;
 
@@ -400,7 +400,7 @@ int
 #if defined(__x86_64__) || defined(__aarch64__)
 copyout(pde_t *pgdir, uint64 va, void *p, size_t len)
 #else
-copyout(pde_t *pgdir, uint va, void *p, size_t len)
+copyout(pde_t *pgdir, uint32_t va, void *p, size_t len)
 #endif
 {
   char *buf, *pa0;
@@ -408,7 +408,7 @@ copyout(pde_t *pgdir, uint va, void *p, size_t len)
 #ifdef __x86_64__
   uint64 va0;
 #else
-  uint va0;
+  uint32_t va0;
 #endif
 
   buf = (char*)p;
@@ -416,7 +416,7 @@ copyout(pde_t *pgdir, uint va, void *p, size_t len)
 #ifdef __x86_64__
     va0 = (uint64)PGROUNDDOWN(va);
 #else
-    va0 = (uint)PGROUNDDOWN(va);
+    va0 = (uint32_t)PGROUNDDOWN(va);
 #endif
     pa0 = uva2ka(pgdir, (char*)va0);
     if(pa0 == 0)
@@ -446,7 +446,7 @@ exo_alloc_page(void)
   char *mem = kalloc();
   if(!mem)
     return cap_new(0, 0, 0);
-  uint pa = V2P(mem);
+  uint32_t pa = V2P(mem);
   int id = cap_table_alloc(CAP_TYPE_PAGE, pa, 0, myproc()->pid);
   return cap_new(id >= 0 ? id : 0, 0, myproc()->pid);
 }
@@ -465,8 +465,8 @@ exo_unbind_page(exo_cap cap)
     return -1;
   pde_t *pgdir = p->pgdir;
   pte_t *pte;
-  uint a;
-  uint pa = e.resource;
+  uint32_t a;
+  uint32_t pa = e.resource;
 
   for(a = 0; a < p->sz; a += PGSIZE){
     if((pte = walkpgdir(pgdir, (void*)a, 0)) != 0 && (*pte & PTE_P)){

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -8,7 +8,7 @@ exo_cap cap_alloc_page(void) {
 
 int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
 
-int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
+int cap_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
   return exo_alloc_block(dev, rights, cap);
 }
 

--- a/src-uland/exo_unit_test.c
+++ b/src-uland/exo_unit_test.c
@@ -3,24 +3,24 @@
 #include <string.h>
 #include <assert.h>
 
-typedef uint32_t uint;
+typedef uint32_t uint32_t;
 
 typedef struct exo_cap {
-    uint pa;
-    uint id;
-    uint rights;
-    uint owner;
+    uint32_t pa;
+    uint32_t id;
+    uint32_t rights;
+    uint32_t owner;
 } exo_cap;
 
 typedef struct exo_blockcap {
-    uint dev;
-    uint blockno;
-    uint rights;
-    uint owner;
+    uint32_t dev;
+    uint32_t blockno;
+    uint32_t rights;
+    uint32_t owner;
 } exo_blockcap;
 
-static uint next_page = 1;
-static uint next_block = 1;
+static uint32_t next_page = 1;
+static uint32_t next_block = 1;
 static unsigned char diskbuf[512];
 
 int exo_alloc_page(exo_cap *cap) {
@@ -38,7 +38,7 @@ int exo_unbind_page(exo_cap *cap) {
     return 0;
 }
 
-int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
+int exo_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
     cap->dev = dev;
     cap->blockno = next_block++;
     cap->rights = rights;

--- a/src-uland/math_core.c
+++ b/src-uland/math_core.c
@@ -4,12 +4,12 @@
 double phi(void) { return 1.618033988749895; }
 
 // Compute the n-th Fibonacci number with F(0) = 0 and F(1) = 1.
-uint64 fib(uint n) {
+uint64 fib(uint32_t n) {
   if (n == 0)
     return 0;
   uint64 a = 0;
   uint64 b = 1;
-  for (uint i = 1; i < n; i++) {
+  for (uint32_t i = 1; i < n; i++) {
     uint64 t = a + b;
     a = b;
     b = t;

--- a/src-uland/printf.c
+++ b/src-uland/printf.c
@@ -14,7 +14,7 @@ printint(int fd, int xx, int base, int sgn)
   static char digits[] = "0123456789ABCDEF";
   char buf[16];
   int i, neg;
-  uint x;
+  uint32_t x;
 
   neg = 0;
   if(sgn && xx < 0){
@@ -41,10 +41,10 @@ printf(int fd, const char *fmt, ...)
 {
   char *s;
   int c, i, state;
-  unsigned long *ap;
+  uintptr_t *ap;
 
   state = 0;
-  ap = (unsigned long*)(void*)&fmt + 1;
+  ap = (uintptr_t *)(void *)&fmt + 1;
   for(i = 0; fmt[i]; i++){
     c = fmt[i] & 0xff;
     if(state == 0){

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -31,7 +31,7 @@ struct driver {
   char *argv[MAX_ARGS];
   char *buf; // backing storage for argv strings
   int pid;
-  uint last_ping;
+  uint32_t last_ping;
   int awaiting_pong;
   int ping_timeout;
   int ping_interval;
@@ -148,14 +148,14 @@ int main(void) {
     drv[i].restarts = 0;
   }
 
-  uint last_report = uptime();
+  uint32_t last_report = uptime();
 
   for (;;) {
-    uint now = uptime();
+    uint32_t now = uptime();
 
     for (int i = 0; i < n; i++) {
       if (drv[i].pid > 0 && !drv[i].awaiting_pong &&
-          now - drv[i].last_ping >= (uint)drv[i].ping_interval) {
+          now - drv[i].last_ping >= (uint32_t)drv[i].ping_interval) {
         zipc_msg_t m = {0};
         m.w0 = PING;
         m.w1 = i;
@@ -167,14 +167,14 @@ int main(void) {
 
     zipc_msg_t m;
     while (read(p[0], &m, sizeof(m)) == sizeof(m)) {
-      if (m.w0 == PONG && m.w1 < (uint)n)
+      if (m.w0 == PONG && m.w1 < (uint32_t)n)
         drv[m.w1].awaiting_pong = 0;
     }
 
     now = uptime();
     for (int i = 0; i < n; i++) {
       if (drv[i].pid > 0 && drv[i].awaiting_pong &&
-          now - drv[i].last_ping > (uint)drv[i].ping_timeout) {
+          now - drv[i].last_ping > (uint32_t)drv[i].ping_timeout) {
         printf(1, "rcrs: restarting %s\n", drv[i].argv[0]);
         kill(drv[i].pid);
         wait();

--- a/src-uland/usertests.c
+++ b/src-uland/usertests.c
@@ -1441,7 +1441,7 @@ sbrktest(void)
 {
   int fds[2], pid, pids[10], ppid;
   char *a, *b, *c, *lastaddr, *oldbrk, *p, scratch;
-  uint amt;
+  uint32_t amt;
 
   printf(stdout, "sbrk test\n");
   oldbrk = sbrk(0);
@@ -1588,7 +1588,7 @@ void
 validatetest(void)
 {
   int hi, pid;
-  uint p;
+  uint32_t p;
 
   printf(stdout, "validate test\n");
   hi = 1100*1024;
@@ -1762,8 +1762,8 @@ void argptest()
   printf(1, "arg test passed\n");
 }
 
-unsigned long randstate = 1;
-unsigned int
+uint32_t randstate = 1;
+uint32_t
 rand()
 {
   randstate = randstate * 1664525 + 1013904223;


### PR DESCRIPTION
## Summary
- replace typedefs in `types.h` with `<stdint.h>` names
- switch kernel/user code from `unsigned long`/`uint` to `uintptr_t`/`uint32_t`
- update lock debug array to use `uintptr_t`
- include `types.h` where needed for `uint32_t`

## Testing
- `pytest -q`
- `cmake -S . -B build -G Ninja -DCLANG_TIDY_EXE=` *(fails: missing headers)*