### PR TITLE
Add C model aligned with TLA spec and update tests

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -15,3 +15,11 @@ java -jar /path/to/tla2tools.jar Capability.tla
 The default specification defines a constant set of `Users` and verifies
 `ActiveInv`, which ensures that the current active capability is always
 part of the allocated set.
+
+## C Reference Model
+
+For easier experimentation, `c/capability_model.c` provides a small C
+translation of `Capability.tla`. The state machine mirrors the TLA+
+transitions (`Create`, `Revoke`, and `YieldTo`) and exposes a simple
+API that can be embedded in unit tests or further model checking tools.
+Compile with `-DCAPABILITY_MODEL_DEMO` to see a short demonstration.

--- a/specs/c/capability_model.c
+++ b/specs/c/capability_model.c
@@ -1,0 +1,87 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+/*
+ * Capability State Machine - C model aligned with Capability.tla
+ * --------------------------------------------------------------
+ * This simple C translation mirrors the state transitions of the
+ * TLA+ specification located in Capability.tla. The model keeps
+ * track of a small set of capability IDs and their owners along
+ * with the currently active capability.
+ */
+
+#define MAX_CAPS 64
+#define NULL_CAP 0u
+
+typedef struct {
+    uint32_t owner[MAX_CAPS];
+    uint8_t in_use[MAX_CAPS];
+    uint32_t active;
+} CapabilityModel;
+
+void model_init(CapabilityModel *m)
+{
+    memset(m, 0, sizeof(*m));
+    m->active = NULL_CAP;
+}
+
+/* Create(c,u) */
+int model_create(CapabilityModel *m, uint32_t c, uint32_t u)
+{
+    if (c >= MAX_CAPS || m->in_use[c])
+        return -1;
+    m->in_use[c] = 1;
+    m->owner[c] = u;
+    return 0;
+}
+
+/* Revoke(c,u) */
+int model_revoke(CapabilityModel *m, uint32_t c, uint32_t u)
+{
+    if (c >= MAX_CAPS || !m->in_use[c] || m->owner[c] != u)
+        return -1;
+    m->in_use[c] = 0;
+    if (m->active == c)
+        m->active = NULL_CAP;
+    return 0;
+}
+
+/* YieldTo(src,dst,u) */
+int model_yield_to(CapabilityModel *m, uint32_t src, uint32_t dst, uint32_t u)
+{
+    if (src >= MAX_CAPS || dst >= MAX_CAPS)
+        return -1;
+    if (!m->in_use[src] || !m->in_use[dst])
+        return -1;
+    if (m->owner[src] != u || m->active != src)
+        return -1;
+    m->active = dst;
+    return 0;
+}
+
+/* ActiveInv */
+int model_active_inv(const CapabilityModel *m)
+{
+    if (m->active == NULL_CAP)
+        return 1;
+    if (m->active < MAX_CAPS && m->in_use[m->active])
+        return 1;
+    return 0;
+}
+
+#ifdef CAPABILITY_MODEL_DEMO
+int main(void)
+{
+    CapabilityModel m;
+    model_init(&m);
+
+    model_create(&m, 1, 42);
+    model_create(&m, 2, 42);
+    m.active = 1;
+    model_yield_to(&m, 1, 2, 42);
+    printf("Active capability: %u\n", m.active);
+    printf("Invariant holds: %s\n", model_active_inv(&m) ? "yes" : "no");
+    return 0;
+}
+#endif

--- a/tests/microbench/Makefile
+++ b/tests/microbench/Makefile
@@ -1,5 +1,5 @@
 HOSTCC ?= clang
-HOSTCFLAGS ?= -Wall -O2 -std=c23 -I../../libos/include -I../../src-headers
+HOSTCFLAGS ?= -Wall -O2 -std=c2x -I../../libos/include -I../../src-headers
 
 PROGS := cap_verify_bench exo_yield_to_bench proc_cap_test
 

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -55,7 +55,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c23",
+            "gcc", "-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_newtypes.py
+++ b/tests/test_cap_newtypes.py
@@ -55,7 +55,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -56,7 +56,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_types.py
+++ b/tests/test_cap_types.py
@@ -56,7 +56,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -44,7 +44,7 @@ def compile_and_run() -> None:
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(C_CODE)
-        subprocess.check_call(["gcc", "-std=c23", str(src), "-o", str(exe)])
+        subprocess.check_call(["gcc", "-std=c2x", str(src), "-o", str(exe)])
         subprocess.check_call([str(exe)])
 
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -38,7 +38,7 @@ def compile_and_run() -> None:
         subprocess.check_call(
             [
                 "gcc",
-                "-std=c23",
+                "-std=c2x",
                 "-I",
                 str(ROOT),
                 "-I",

--- a/tests/test_iommu.py
+++ b/tests/test_iommu.py
@@ -49,7 +49,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c23",
+            "gcc", "-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -65,7 +65,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
         )
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -60,7 +60,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c23","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c2x","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_lockstress.py
+++ b/tests/test_lockstress.py
@@ -86,7 +86,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c23","-pthread","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c2x","-pthread","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_ptrace_concurrent.py
+++ b/tests/test_ptrace_concurrent.py
@@ -52,7 +52,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             str(src),
             "-o", str(exe)
         ])

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -22,7 +22,7 @@ def compile_and_run(use_stub):
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
         cmd = [
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_sys_ipc.py
+++ b/tests/test_sys_ipc.py
@@ -80,7 +80,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
         )
         subprocess.check_call([
-            "gcc", "-std=c23",
+            "gcc", "-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_uv_spinlock_processes.py
+++ b/tests/test_uv_spinlock_processes.py
@@ -53,7 +53,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_uv_spinlock_threads.py
+++ b/tests/test_uv_spinlock_threads.py
@@ -40,7 +40,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c23","-pthread",
+            "gcc","-std=c2x","-pthread",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -55,7 +55,7 @@ def compile_and_run(body):
         (pathlib.Path(td)/"mmu.h").write_text('#include "src-headers/types.h"\n#include "src-headers/mmu.h"\n')
         (pathlib.Path(td)/"memlayout.h").write_text('#include "src-headers/memlayout.h"\n')
         subprocess.check_call([
-            "gcc","-std=c23",
+            "gcc","-std=c2x",
             "-I", str(td),
             "-I", str(ROOT),
             str(src),


### PR DESCRIPTION
## Summary
- provide a C reference implementation for `Capability.tla`
- document the new C model in the TLA+ specs README
- update tests and microbench Makefile to use `-std=c2x` instead of `-std=c23`

## Testing
- `pytest -q`