### PR TITLE
Fix clang-tidy config

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,4 +2,3 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
-Standard: c23

--- a/.clang-tidy-cpp23
+++ b/.clang-tidy-cpp23
@@ -2,4 +2,3 @@ Checks: '-*,bugprone-*,clang-analyzer-*,modernize-*'
 WarningsAsErrors: ''
 HeaderFilterRegex: '.*'
 FormatStyle: file
-Standard: c++23


### PR DESCRIPTION
## Summary
- remove unrecognized `Standard` key from clang-tidy configs

## Testing
- `pytest -q` *(fails: CalledProcessError)*