### PR TITLE
Add ABI checks for cap_entry

### DIFF
--- a/src-headers/cap.h
+++ b/src-headers/cap.h
@@ -20,6 +20,14 @@ struct cap_entry {
     uint rights;
     uint owner;
 };
+// The capability table layout is part of the public ABI.  All translation
+// units (C and C++) rely on this size and alignment.  Expected size: 20 bytes
+// and expected alignment: 4 bytes.
+#ifdef __cplusplus
+static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
+#else
+_Static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
+#endif
 
 extern uint global_epoch;
 

--- a/tests/test_cap_entry_cpp.py
+++ b/tests/test_cap_entry_cpp.py
@@ -1,0 +1,30 @@
+import subprocess, tempfile, pathlib, textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+CPP_CODE = textwrap.dedent("""
+#include <iostream>
+#include "src-headers/cap.h"
+int main(){
+    std::cout << sizeof(struct cap_entry) << ' ' << alignof(struct cap_entry);
+    return 0;
+}
+""")
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.cpp"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(CPP_CODE)
+        subprocess.check_call([
+            "g++","-std=c++17",
+            "-iquote", str(ROOT),
+            "-iquote", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        out = subprocess.check_output([str(exe)], text=True)
+        return out.strip()
+
+def test_cap_entry_cpp_size():
+    assert compile_and_run() == "20 4"


### PR DESCRIPTION
## Summary
- enforce fixed size for `struct cap_entry`
- document `cap_entry` ABI requirements in header
- add C++ compilation test for `cap_entry`

## Testing
- `pytest -q`