### PR TITLE
Add C++ extern guards to headers

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -1,5 +1,8 @@
 #ifndef EXO_H
 #define EXO_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 
 typedef struct hash256 {
@@ -28,4 +31,7 @@ exo_cap cap_new(uint id, uint rights, uint owner);
 int cap_verify(exo_cap c);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 #endif // EXO_H

--- a/libos/include/capwrap.h
+++ b/libos/include/capwrap.h
@@ -1,7 +1,13 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stddef.h>
 #include "caplib.h"
 
 exo_cap capwrap_alloc_page(void);
 int capwrap_send(exo_cap dest, const void *buf, size_t len);
 int capwrap_recv(exo_cap src, void *buf, size_t len);
+#ifdef __cplusplus
+}
+#endif

--- a/libos/include/procwrap.h
+++ b/libos/include/procwrap.h
@@ -1,11 +1,17 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stddef.h>
 #include "types.h"
 
 typedef struct {
-    int pid;
+  int pid;
 } proc_handle_t;
 
 int proc_spawn(proc_handle_t *p, const char *path, char *const argv[]);
 int proc_wait(proc_handle_t *p);
 void proc_exit(int code) __attribute__((noreturn));
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/aarch64.h
+++ b/src-headers/aarch64.h
@@ -1,3 +1,9 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 static inline void cpu_relax(void) { asm volatile("yield" ::: "memory"); }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/arbitrate.h
+++ b/src-headers/arbitrate.h
@@ -1,22 +1,28 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include <spinlock.h>
 
 struct arbitrate_entry {
-    uint type;
-    uint resource_id;
-    uint owner;
+  uint type;
+  uint resource_id;
+  uint owner;
 };
 
 struct arbitrate_table {
-    struct spinlock lock;
-    struct arbitrate_entry entries[16];
+  struct spinlock lock;
+  struct arbitrate_entry entries[16];
 };
 
 typedef int (*arbitrate_policy_t)(uint type, uint resource_id,
-                                   uint current_owner, uint new_owner);
+                                  uint current_owner, uint new_owner);
 
 void arbitrate_init(arbitrate_policy_t policy);
 void arbitrate_use_table(struct arbitrate_table *t);
 void arbitrate_register_policy(arbitrate_policy_t policy);
 int arbitrate_request(uint type, uint resource_id, uint owner);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/asm.h
+++ b/src-headers/asm.h
@@ -1,26 +1,32 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 //
 // assembler macros to create x86 segments
 //
 
-#define SEG_NULLASM                                             \
-        .word 0, 0;                                             \
-        .byte 0, 0, 0, 0
+#define SEG_NULLASM                                                            \
+  .word 0, 0;                                                                  \
+  .byte 0, 0, 0, 0
 
 // The 0xC0 means the limit is in 4096-byte units
 // and (for executable segments) 32-bit mode.
-#define SEG_ASM(type,base,lim)                                  \
-        .word (((lim) >> 12) & 0xffff), ((base) & 0xffff);      \
-        .byte (((base) >> 16) & 0xff), (0x90 | (type)),         \
-                (0xC0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)
+#define SEG_ASM(type, base, lim)                                               \
+  .word(((lim) >> 12) & 0xffff), ((base) & 0xffff);                            \
+  .byte(((base) >> 16) & 0xff), (0x90 | (type)),                               \
+      (0xC0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)
 
-#define STA_X     0x8       // Executable segment
-#define STA_W     0x2       // Writeable (non-executable segments)
-#define STA_R     0x2       // Readable (executable segments)
+#define STA_X 0x8 // Executable segment
+#define STA_W 0x2 // Writeable (non-executable segments)
+#define STA_R 0x2 // Readable (executable segments)
 
 // 64-bit segment descriptor. G=1, L=1, D/B=0.
-#define SEG_ASM64(type, base, lim)                                \
-        .word (((lim) >> 12) & 0xffff), ((base) & 0xffff);      \
-        .byte (((base) >> 16) & 0xff), (0x90 | (type));         \
-        .byte (0xA0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)
+#define SEG_ASM64(type, base, lim)                                             \
+  .word(((lim) >> 12) & 0xffff), ((base) & 0xffff);                            \
+  .byte(((base) >> 16) & 0xff), (0x90 | (type));                               \
+  .byte(0xA0 | (((lim) >> 28) & 0xf)), (((base) >> 24) & 0xff)
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/beatty_sched.h
+++ b/src-headers/beatty_sched.h
@@ -1,6 +1,12 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "exo.h"
 
 void beatty_sched_set_tasks(const exo_cap *tasks, const double *weights, int n);
 void beatty_sched_init(void);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/buf.h
+++ b/src-headers/buf.h
@@ -1,17 +1,23 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct buf {
   int flags;
   uint dev;
   uint blockno;
   struct sleeplock lock;
   size_t refcnt;
-  size_t rcref; // number of read-side references
+  size_t rcref;     // number of read-side references
   struct buf *prev; // LRU cache list
   struct buf *next;
   struct buf *qnext; // disk queue
   uchar data[BSIZE];
 };
-#define B_VALID 0x2  // buffer has been read from disk
-#define B_DIRTY 0x4  // buffer needs to be written to disk
+#define B_VALID 0x2 // buffer has been read from disk
+#define B_DIRTY 0x4 // buffer needs to be written to disk
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/cap.h
+++ b/src-headers/cap.h
@@ -1,24 +1,27 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include <stdint.h>
 
 #define CAP_MAX 1024
 
 enum cap_type {
-    CAP_TYPE_NONE    = 0,
-    CAP_TYPE_PAGE    = 1,
-    CAP_TYPE_IOPORT  = 2,
-    CAP_TYPE_IRQ     = 3,
-    CAP_TYPE_DMA     = 4,
+  CAP_TYPE_NONE = 0,
+  CAP_TYPE_PAGE = 1,
+  CAP_TYPE_IOPORT = 2,
+  CAP_TYPE_IRQ = 3,
+  CAP_TYPE_DMA = 4,
 };
 
 struct cap_entry {
-    uint16_t type;
-    uint16_t refcnt;
-    uint16_t epoch;
-    uint resource;
-    uint rights;
-    uint owner;
+  uint16_t type;
+  uint16_t refcnt;
+  uint16_t epoch;
+  uint resource;
+  uint rights;
+  uint owner;
 };
 
 extern uint global_epoch;
@@ -36,3 +39,6 @@ int cap_table_remove(uint id);
  * epoch to wrap past 0xffff.
  */
 int cap_revoke(uint id);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "exo.h"
 #include "exo_cpu.h"
 #include "exokernel.h"
@@ -21,3 +24,6 @@ int cap_write_disk(exo_blockcap cap, const void *src, uint64 off, uint64 n);
 int cap_ipc_echo_demo(void);
 int cap_inc(uint16_t id);
 int cap_dec(uint16_t id);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/chan.h
+++ b/src-headers/chan.h
@@ -1,11 +1,14 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "caplib.h"
 
 // Generic channel descriptor storing expected message size and type
 typedef struct chan {
-    size_t msg_size;
-    const struct msg_type_desc *desc;
+  size_t msg_size;
+  const struct msg_type_desc *desc;
 } chan_t;
 
 // Allocate a channel expecting messages of size msg_size bytes
@@ -21,29 +24,28 @@ int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len);
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
 // Provides mychan_t type with create/send/recv functions
-#define CHAN_DECLARE(name, type)                                    \
-    static const struct msg_type_desc name##_typedesc = { type##_MESSAGE_SIZE }; \
-    typedef struct {                                                \
-        chan_t base;                                                \
-    } name##_t;                                                     \
-    static inline name##_t *name##_create(void) {                   \
-        return (name##_t *)chan_create(&name##_typedesc);           \
-    }                                                               \
-    static inline void name##_destroy(name##_t *c) {                 \
-        chan_destroy(&c->base);                                     \
-    }                                                               \
-    static inline int name##_send(name##_t *c, exo_cap dest, const type *m){ \
-        unsigned char buf[type##_MESSAGE_SIZE];                     \
-        type##_encode(m, buf);                                      \
-        return chan_endpoint_send(&c->base, dest, buf,              \
-                                  type##_MESSAGE_SIZE);             \
-    }                                                               \
-    static inline int name##_recv(name##_t *c, exo_cap src, type *m){ \
-        unsigned char buf[type##_MESSAGE_SIZE];                     \
-        int r = chan_endpoint_recv(&c->base, src, buf,              \
-                                   type##_MESSAGE_SIZE);            \
-        if(r == 0)                                                 \
-            type##_decode(m, buf);                                  \
-        return r;                                                   \
-    }
+#define CHAN_DECLARE(name, type)                                               \
+  static const struct msg_type_desc name##_typedesc = {type##_MESSAGE_SIZE};   \
+  typedef struct {                                                             \
+    chan_t base;                                                               \
+  } name##_t;                                                                  \
+  static inline name##_t *name##_create(void) {                                \
+    return (name##_t *)chan_create(&name##_typedesc);                          \
+  }                                                                            \
+  static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
+  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    type##_encode(m, buf);                                                     \
+    return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
+  }                                                                            \
+  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
+    if (r == 0)                                                                \
+      type##_decode(m, buf);                                                   \
+    return r;                                                                  \
+  }
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/config.h
+++ b/src-headers/config.h
@@ -1,5 +1,11 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #ifndef CONFIG_SMP
 #define CONFIG_SMP 1
+#endif
+#ifdef __cplusplus
+}
 #endif

--- a/src-headers/dag.h
+++ b/src-headers/dag.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "exo.h"
 
@@ -21,7 +24,6 @@ struct dag_node {
   int ndeps;
   /* set once the node has run */
   int done;
-
 };
 
 void dag_node_init(struct dag_node *n, exo_cap ctx);
@@ -30,3 +32,6 @@ void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
 void dag_sched_submit(struct dag_node *node);
 void dag_sched_init(void);
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/date.h
+++ b/src-headers/date.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct rtcdate {
   uint second;
   uint minute;
@@ -8,3 +11,6 @@ struct rtcdate {
   uint month;
   uint year;
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/ddekit.h
+++ b/src-headers/ddekit.h
@@ -1,9 +1,12 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "caplib.h"
 
 struct ddekit_process {
-    int pid;
+  int pid;
 };
 
 void ddekit_init(void);
@@ -16,3 +19,6 @@ void ddekit_yield(void);
 exo_cap ddekit_cap_alloc_page(void);
 int ddekit_cap_send(exo_cap dest, const void *buf, size_t len);
 int ddekit_cap_recv(exo_cap src, void *buf, size_t len);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -1,3 +1,6 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #pragma once
 
@@ -294,3 +297,6 @@ void *atomic_cas_ptr(volatile void **, void *, void *);
 
 // number of elements in fixed-size array
 #define NELEM(x) (sizeof(x) / sizeof((x)[0]))
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/door.h
+++ b/src-headers/door.h
@@ -7,9 +7,9 @@ extern "C" {
 #endif
 
 typedef struct door {
-    exo_cap dest;
-    void (*handler)(zipc_msg_t *msg);
-    int is_local;
+  exo_cap dest;
+  void (*handler)(zipc_msg_t *msg);
+  int is_local;
 } door_t;
 
 door_t door_create_local(void (*handler)(zipc_msg_t *msg));

--- a/src-headers/driver.h
+++ b/src-headers/driver.h
@@ -1,6 +1,12 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "caplib.h"
 
 int driver_spawn(const char *path, char *const argv[]);
 int driver_connect(int pid, exo_cap ep);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/elf.h
+++ b/src-headers/elf.h
@@ -1,12 +1,15 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // Format of an ELF executable file
 
-#define ELF_MAGIC 0x464C457FU  // "\x7FELF" in little endian
+#define ELF_MAGIC 0x464C457FU // "\x7FELF" in little endian
 
 // File header
 struct elfhdr {
-  uint magic;  // must equal ELF_MAGIC
+  uint magic; // must equal ELF_MAGIC
   uchar elf[12];
   ushort type;
   ushort machine;
@@ -36,9 +39,12 @@ struct proghdr {
 };
 
 // Values for Proghdr type
-#define ELF_PROG_LOAD           1
+#define ELF_PROG_LOAD 1
 
 // Flag bits for Proghdr flags
-#define ELF_PROG_FLAG_EXEC      1
-#define ELF_PROG_FLAG_WRITE     2
-#define ELF_PROG_FLAG_READ      4
+#define ELF_PROG_FLAG_EXEC 1
+#define ELF_PROG_FLAG_WRITE 2
+#define ELF_PROG_FLAG_READ 4
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/endpoint.h
+++ b/src-headers/endpoint.h
@@ -1,14 +1,17 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "ipc.h"
 #include "spinlock.h"
 
 struct endpoint {
-    struct spinlock lock;
-    zipc_msg_t *q;
-    uint size;
-    uint r, w;
-    int inited;
-    const struct msg_type_desc *desc;
+  struct spinlock lock;
+  zipc_msg_t *q;
+  uint size;
+  uint r, w;
+  int inited;
+  const struct msg_type_desc *desc;
 };
 
 void endpoint_init(struct endpoint *ep);
@@ -16,3 +19,6 @@ void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
                      const struct msg_type_desc *desc);
 void endpoint_send(struct endpoint *ep, zipc_msg_t *m);
 int endpoint_recv(struct endpoint *ep, zipc_msg_t *m);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/errno.h
+++ b/src-headers/errno.h
@@ -1,4 +1,10 @@
 #ifndef XV6_ERRNO_H
 #define XV6_ERRNO_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define EPERM 1
+#ifdef __cplusplus
+}
+#endif
 #endif

--- a/src-headers/exo.h
+++ b/src-headers/exo.h
@@ -1,5 +1,8 @@
 #ifndef EXO_H
 #define EXO_H
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 
 typedef struct hash256 {
@@ -28,4 +31,7 @@ exo_cap cap_new(uint id, uint rights, uint owner);
 int cap_verify(exo_cap c);
 #endif
 
+#ifdef __cplusplus
+}
+#endif
 #endif // EXO_H

--- a/src-headers/exo_cpu.h
+++ b/src-headers/exo_cpu.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "../exo.h"
 
@@ -59,3 +62,6 @@ static inline void cap_yield(context_t **old, context_t *target) {
 }
 
 int exo_yield_to(exo_cap target);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/exo_disk.h
+++ b/src-headers/exo_disk.h
@@ -1,8 +1,15 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stdint.h>
 #include "exo_mem.h"
 #include "../exo.h"
 #include <stdint.h>
 
 int exo_read_disk(struct exo_blockcap cap, void *dst, uint64_t off, uint64_t n);
-int exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off, uint64_t n);
+int exo_write_disk(struct exo_blockcap cap, const void *src, uint64_t off,
+                   uint64_t n);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stdint.h>
 #include "exo_mem.h"
 #include "../exo.h"
@@ -8,7 +11,9 @@ struct exo_ipc_ops {
   int (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
-
 void exo_ipc_register(struct exo_ipc_ops *ops);
 int exo_send(exo_cap dest, const void *buf, uint64_t len);
 int exo_recv(exo_cap src, void *buf, uint64_t len);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/exo_mem.h
+++ b/src-headers/exo_mem.h
@@ -1,5 +1,11 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "../exo.h"
 
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap cap);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/exo_stream.h
+++ b/src-headers/exo_stream.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 
 struct exo_sched_ops {
@@ -20,3 +23,6 @@ struct exo_stream {
 void exo_stream_register(struct exo_stream *stream);
 void exo_stream_halt(void);
 void exo_stream_yield(void);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -1,19 +1,20 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "exo.h"
 #include "syscall.h"
 
 /* Capability access rights. */
-#define EXO_RIGHT_R   0x1
-#define EXO_RIGHT_W   0x2
-#define EXO_RIGHT_X   0x4
+#define EXO_RIGHT_R 0x1
+#define EXO_RIGHT_W 0x2
+#define EXO_RIGHT_X 0x4
 #define EXO_RIGHT_CTL 0x8
 
-static inline int cap_has_rights(uint rights, uint need)
-{
-    return (rights & need) == need;
+static inline int cap_has_rights(uint rights, uint need) {
+  return (rights & need) == need;
 }
-
 
 /*
  * Minimal exokernel capability primitives.  Library operating systems
@@ -78,22 +79,25 @@ exo_cap exo_alloc_dma(uint chan);
 
 /* Enumeration of syscall numbers for the primitives. */
 enum exo_syscall {
-    EXO_SYSCALL_ALLOC_PAGE  = SYS_exo_alloc_page,
-    EXO_SYSCALL_UNBIND_PAGE = SYS_exo_unbind_page,
-    EXO_SYSCALL_ALLOC_BLOCK = SYS_exo_alloc_block,
-    EXO_SYSCALL_BIND_BLOCK  = SYS_exo_bind_block,
-    EXO_SYSCALL_FLUSH_BLOCK = SYS_exo_flush_block,
-    EXO_SYSCALL_YIELD_TO    = SYS_exo_yield_to,
-    EXO_SYSCALL_SEND        = SYS_exo_send,
-    EXO_SYSCALL_RECV        = SYS_exo_recv,
-    EXO_SYSCALL_READ_DISK   = SYS_exo_read_disk,
-    EXO_SYSCALL_WRITE_DISK  = SYS_exo_write_disk,
-    EXO_SYSCALL_ALLOC_IOPORT = SYS_exo_alloc_ioport,
-    EXO_SYSCALL_BIND_IRQ     = SYS_exo_bind_irq,
-    EXO_SYSCALL_ALLOC_DMA    = SYS_exo_alloc_dma,
-    EXO_SYSCALL_CAP_INC     = SYS_cap_inc,
-    EXO_SYSCALL_CAP_DEC     = SYS_cap_dec,
-    EXO_SYSCALL_IRQ_ALLOC   = SYS_exo_irq_alloc,
-    EXO_SYSCALL_IRQ_WAIT    = SYS_exo_irq_wait,
-    EXO_SYSCALL_IRQ_ACK     = SYS_exo_irq_ack,
+  EXO_SYSCALL_ALLOC_PAGE = SYS_exo_alloc_page,
+  EXO_SYSCALL_UNBIND_PAGE = SYS_exo_unbind_page,
+  EXO_SYSCALL_ALLOC_BLOCK = SYS_exo_alloc_block,
+  EXO_SYSCALL_BIND_BLOCK = SYS_exo_bind_block,
+  EXO_SYSCALL_FLUSH_BLOCK = SYS_exo_flush_block,
+  EXO_SYSCALL_YIELD_TO = SYS_exo_yield_to,
+  EXO_SYSCALL_SEND = SYS_exo_send,
+  EXO_SYSCALL_RECV = SYS_exo_recv,
+  EXO_SYSCALL_READ_DISK = SYS_exo_read_disk,
+  EXO_SYSCALL_WRITE_DISK = SYS_exo_write_disk,
+  EXO_SYSCALL_ALLOC_IOPORT = SYS_exo_alloc_ioport,
+  EXO_SYSCALL_BIND_IRQ = SYS_exo_bind_irq,
+  EXO_SYSCALL_ALLOC_DMA = SYS_exo_alloc_dma,
+  EXO_SYSCALL_CAP_INC = SYS_cap_inc,
+  EXO_SYSCALL_CAP_DEC = SYS_cap_dec,
+  EXO_SYSCALL_IRQ_ALLOC = SYS_exo_irq_alloc,
+  EXO_SYSCALL_IRQ_WAIT = SYS_exo_irq_wait,
+  EXO_SYSCALL_IRQ_ACK = SYS_exo_irq_ack,
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/fcntl.h
+++ b/src-headers/fcntl.h
@@ -1,10 +1,16 @@
 #pragma once
 
-#define O_RDONLY  0x000
-#define O_WRONLY  0x001
-#define O_RDWR    0x002
-#define O_CREATE  0x200
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define O_RDONLY 0x000
+#define O_WRONLY 0x001
+#define O_RDWR 0x002
+#define O_CREATE 0x200
 #define O_NONBLOCK 0x400
 
 #define F_GETFL 1
 #define F_SETFL 2
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/file.h
+++ b/src-headers/file.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct file {
   enum { FD_NONE, FD_PIPE, FD_INODE } type;
   size_t ref; // reference count
@@ -11,21 +14,20 @@ struct file {
   int flags;
 };
 
-
 // in-memory copy of an inode
 struct inode {
-  uint dev;           // Device number
-  uint inum;          // Inode number
+  uint dev;              // Device number
+  uint inum;             // Inode number
   size_t ref;            // Reference count
   struct sleeplock lock; // protects everything below here
-  int valid;          // inode has been read from disk?
+  int valid;             // inode has been read from disk?
 
-  short type;         // copy of disk inode
+  short type; // copy of disk inode
   short major;
   short minor;
   short nlink;
   size_t size;
-  uint addrs[NDIRECT+1];
+  uint addrs[NDIRECT + 1];
 };
 // Must match on-disk inode layout when compiled for 32-bit targets.
 #ifndef __x86_64__
@@ -35,10 +37,13 @@ _Static_assert(sizeof(struct inode) == 144, "struct inode size incorrect");
 // table mapping major device number to
 // device functions
 struct devsw {
-  int (*read)(struct inode*, char*, size_t);
-  int (*write)(struct inode*, char*, size_t);
+  int (*read)(struct inode *, char *, size_t);
+  int (*write)(struct inode *, char *, size_t);
 };
 
 extern struct devsw devsw[];
 
 #define CONSOLE 1
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/fs.h
+++ b/src-headers/fs.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
 
-
-#define ROOTINO 1  // root i-number
-#define BSIZE 512  // block size
+#define ROOTINO 1 // root i-number
+#define BSIZE 512 // block size
 
 // Disk layout:
 // [ boot block | super block | log | inode blocks |
@@ -14,40 +16,40 @@
 // mkfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 struct superblock {
-  uint size;         // Size of file system image (blocks)
-  uint nblocks;      // Number of data blocks
-  uint ninodes;      // Number of inodes.
-  uint nlog;         // Number of log blocks
-  uint logstart;     // Block number of first log block
-  uint inodestart;   // Block number of first inode block
-  uint bmapstart;    // Block number of first free map block
+  uint size;       // Size of file system image (blocks)
+  uint nblocks;    // Number of data blocks
+  uint ninodes;    // Number of inodes.
+  uint nlog;       // Number of log blocks
+  uint logstart;   // Block number of first log block
+  uint inodestart; // Block number of first inode block
+  uint bmapstart;  // Block number of first free map block
 };
 
 #define NDIRECT 12
 #define NINDIRECT (BSIZE / sizeof(uint))
-#define MAXFILE (NDIRECT + NINDIRECT*1024)
+#define MAXFILE (NDIRECT + NINDIRECT * 1024)
 
 // On-disk inode structure
 struct dinode {
-  short type;           // File type
-  short major;          // Major device number (T_DEV only)
-  short minor;          // Minor device number (T_DEV only)
-  short nlink;          // Number of links to inode in file system
-  uint size;            // Size of file (bytes)
-  uint addrs[NDIRECT+1];   // Data block addresses
+  short type;              // File type
+  short major;             // Major device number (T_DEV only)
+  short minor;             // Minor device number (T_DEV only)
+  short nlink;             // Number of links to inode in file system
+  uint size;               // Size of file (bytes)
+  uint addrs[NDIRECT + 1]; // Data block addresses
 };
 
 // Inodes per block.
-#define IPB           (BSIZE / sizeof(struct dinode))
+#define IPB (BSIZE / sizeof(struct dinode))
 
 // Block containing inode i
-#define IBLOCK(i, sb)     ((i) / IPB + sb.inodestart)
+#define IBLOCK(i, sb) ((i) / IPB + sb.inodestart)
 
 // Bitmap bits per block
-#define BPB           (BSIZE*8)
+#define BPB (BSIZE * 8)
 
 // Block of free map containing bit for block b
-#define BBLOCK(b, sb) (b/BPB + sb.bmapstart)
+#define BBLOCK(b, sb) (b / BPB + sb.bmapstart)
 
 // Directory is a file containing a sequence of dirent structures.
 #define DIRSIZ 14
@@ -57,3 +59,6 @@ struct dirent {
   char name[DIRSIZ];
 };
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/iommu.h
+++ b/src-headers/iommu.h
@@ -6,16 +6,16 @@
 typedef uint64_t iommu_pte_t;
 
 struct iommu_dom {
-    iommu_pte_t *pt;
-    size_t npages;
+  iommu_pte_t *pt;
+  size_t npages;
 };
 
-#define IOMMU_OP_MAP    0xA0
-#define IOMMU_OP_UNMAP  0xA1
+#define IOMMU_OP_MAP 0xA0
+#define IOMMU_OP_UNMAP 0xA1
 #define IOMMU_OP_REVOKE 0xA2
 
-int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa,
-              size_t len, int perm);
+int iommu_map(struct iommu_dom *dom, uintptr_t iova, uintptr_t pa, size_t len,
+              int perm);
 int iommu_unmap(struct iommu_dom *dom, uintptr_t iova, size_t len);
 void iommu_sync(struct iommu_dom *dom);
 void iommu_revoke(struct iommu_dom *dom);

--- a/src-headers/ipc.h
+++ b/src-headers/ipc.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stdint.h>
 #include <stddef.h>
 
@@ -46,3 +49,6 @@ static inline int zipc_call(zipc_msg_t *m) {
   m->w3 = r8;
   return 0;
 }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/kbd.h
+++ b/src-headers/kbd.h
@@ -1,114 +1,318 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // PC keyboard interface constants
 
-#define KBSTATP         0x64    // kbd controller status port(I)
-#define KBS_DIB         0x01    // kbd data in buffer
-#define KBDATAP         0x60    // kbd data port(I)
+#define KBSTATP 0x64 // kbd controller status port(I)
+#define KBS_DIB 0x01 // kbd data in buffer
+#define KBDATAP 0x60 // kbd data port(I)
 
-#define NO              0
+#define NO 0
 
-#define SHIFT           (1<<0)
-#define CTL             (1<<1)
-#define ALT             (1<<2)
+#define SHIFT (1 << 0)
+#define CTL (1 << 1)
+#define ALT (1 << 2)
 
-#define CAPSLOCK        (1<<3)
-#define NUMLOCK         (1<<4)
-#define SCROLLLOCK      (1<<5)
+#define CAPSLOCK (1 << 3)
+#define NUMLOCK (1 << 4)
+#define SCROLLLOCK (1 << 5)
 
-#define E0ESC           (1<<6)
+#define E0ESC (1 << 6)
 
 // Special keycodes
-#define KEY_HOME        0xE0
-#define KEY_END         0xE1
-#define KEY_UP          0xE2
-#define KEY_DN          0xE3
-#define KEY_LF          0xE4
-#define KEY_RT          0xE5
-#define KEY_PGUP        0xE6
-#define KEY_PGDN        0xE7
-#define KEY_INS         0xE8
-#define KEY_DEL         0xE9
+#define KEY_HOME 0xE0
+#define KEY_END 0xE1
+#define KEY_UP 0xE2
+#define KEY_DN 0xE3
+#define KEY_LF 0xE4
+#define KEY_RT 0xE5
+#define KEY_PGUP 0xE6
+#define KEY_PGDN 0xE7
+#define KEY_INS 0xE8
+#define KEY_DEL 0xE9
 
 // C('A') == Control-A
 #define C(x) (x - '@')
 
-static uchar shiftcode[256] =
-{
-  [0x1D] CTL,
-  [0x2A] SHIFT,
-  [0x36] SHIFT,
-  [0x38] ALT,
-  [0x9D] CTL,
-  [0xB8] ALT
-};
+static uchar shiftcode[256] = {
+    [0x1D] CTL, [0x2A] SHIFT, [0x36] SHIFT, [0x38] ALT, [0x9D] CTL, [0xB8] ALT};
 
-static uchar togglecode[256] =
-{
-  [0x3A] CAPSLOCK,
-  [0x45] NUMLOCK,
-  [0x46] SCROLLLOCK
-};
+static uchar togglecode[256] = {
+    [0x3A] CAPSLOCK, [0x45] NUMLOCK, [0x46] SCROLLLOCK};
 
-static uchar normalmap[256] =
-{
-  NO,   0x1B, '1',  '2',  '3',  '4',  '5',  '6',  // 0x00
-  '7',  '8',  '9',  '0',  '-',  '=',  '\b', '\t',
-  'q',  'w',  'e',  'r',  't',  'y',  'u',  'i',  // 0x10
-  'o',  'p',  '[',  ']',  '\n', NO,   'a',  's',
-  'd',  'f',  'g',  'h',  'j',  'k',  'l',  ';',  // 0x20
-  '\'', '`',  NO,   '\\', 'z',  'x',  'c',  'v',
-  'b',  'n',  'm',  ',',  '.',  '/',  NO,   '*',  // 0x30
-  NO,   ' ',  NO,   NO,   NO,   NO,   NO,   NO,
-  NO,   NO,   NO,   NO,   NO,   NO,   NO,   '7',  // 0x40
-  '8',  '9',  '-',  '4',  '5',  '6',  '+',  '1',
-  '2',  '3',  '0',  '.',  NO,   NO,   NO,   NO,   // 0x50
-  [0x9C] '\n',      // KP_Enter
-  [0xB5] '/',       // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
-};
+static uchar normalmap[256] = {NO,
+                               0x1B,
+                               '1',
+                               '2',
+                               '3',
+                               '4',
+                               '5',
+                               '6', // 0x00
+                               '7',
+                               '8',
+                               '9',
+                               '0',
+                               '-',
+                               '=',
+                               '\b',
+                               '\t',
+                               'q',
+                               'w',
+                               'e',
+                               'r',
+                               't',
+                               'y',
+                               'u',
+                               'i', // 0x10
+                               'o',
+                               'p',
+                               '[',
+                               ']',
+                               '\n',
+                               NO,
+                               'a',
+                               's',
+                               'd',
+                               'f',
+                               'g',
+                               'h',
+                               'j',
+                               'k',
+                               'l',
+                               ';', // 0x20
+                               '\'',
+                               '`',
+                               NO,
+                               '\\',
+                               'z',
+                               'x',
+                               'c',
+                               'v',
+                               'b',
+                               'n',
+                               'm',
+                               ',',
+                               '.',
+                               '/',
+                               NO,
+                               '*', // 0x30
+                               NO,
+                               ' ',
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               NO,
+                               '7', // 0x40
+                               '8',
+                               '9',
+                               '-',
+                               '4',
+                               '5',
+                               '6',
+                               '+',
+                               '1',
+                               '2',
+                               '3',
+                               '0',
+                               '.',
+                               NO,
+                               NO,
+                               NO,
+                               NO,          // 0x50
+                               [0x9C] '\n', // KP_Enter
+                               [0xB5] '/',  // KP_Div
+                               [0xC8] KEY_UP,
+                               [0xD0] KEY_DN,
+                               [0xC9] KEY_PGUP,
+                               [0xD1] KEY_PGDN,
+                               [0xCB] KEY_LF,
+                               [0xCD] KEY_RT,
+                               [0x97] KEY_HOME,
+                               [0xCF] KEY_END,
+                               [0xD2] KEY_INS,
+                               [0xD3] KEY_DEL};
 
-static uchar shiftmap[256] =
-{
-  NO,   033,  '!',  '@',  '#',  '$',  '%',  '^',  // 0x00
-  '&',  '*',  '(',  ')',  '_',  '+',  '\b', '\t',
-  'Q',  'W',  'E',  'R',  'T',  'Y',  'U',  'I',  // 0x10
-  'O',  'P',  '{',  '}',  '\n', NO,   'A',  'S',
-  'D',  'F',  'G',  'H',  'J',  'K',  'L',  ':',  // 0x20
-  '"',  '~',  NO,   '|',  'Z',  'X',  'C',  'V',
-  'B',  'N',  'M',  '<',  '>',  '?',  NO,   '*',  // 0x30
-  NO,   ' ',  NO,   NO,   NO,   NO,   NO,   NO,
-  NO,   NO,   NO,   NO,   NO,   NO,   NO,   '7',  // 0x40
-  '8',  '9',  '-',  '4',  '5',  '6',  '+',  '1',
-  '2',  '3',  '0',  '.',  NO,   NO,   NO,   NO,   // 0x50
-  [0x9C] '\n',      // KP_Enter
-  [0xB5] '/',       // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
-};
+static uchar shiftmap[256] = {NO,
+                              033,
+                              '!',
+                              '@',
+                              '#',
+                              '$',
+                              '%',
+                              '^', // 0x00
+                              '&',
+                              '*',
+                              '(',
+                              ')',
+                              '_',
+                              '+',
+                              '\b',
+                              '\t',
+                              'Q',
+                              'W',
+                              'E',
+                              'R',
+                              'T',
+                              'Y',
+                              'U',
+                              'I', // 0x10
+                              'O',
+                              'P',
+                              '{',
+                              '}',
+                              '\n',
+                              NO,
+                              'A',
+                              'S',
+                              'D',
+                              'F',
+                              'G',
+                              'H',
+                              'J',
+                              'K',
+                              'L',
+                              ':', // 0x20
+                              '"',
+                              '~',
+                              NO,
+                              '|',
+                              'Z',
+                              'X',
+                              'C',
+                              'V',
+                              'B',
+                              'N',
+                              'M',
+                              '<',
+                              '>',
+                              '?',
+                              NO,
+                              '*', // 0x30
+                              NO,
+                              ' ',
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              NO,
+                              '7', // 0x40
+                              '8',
+                              '9',
+                              '-',
+                              '4',
+                              '5',
+                              '6',
+                              '+',
+                              '1',
+                              '2',
+                              '3',
+                              '0',
+                              '.',
+                              NO,
+                              NO,
+                              NO,
+                              NO,          // 0x50
+                              [0x9C] '\n', // KP_Enter
+                              [0xB5] '/',  // KP_Div
+                              [0xC8] KEY_UP,
+                              [0xD0] KEY_DN,
+                              [0xC9] KEY_PGUP,
+                              [0xD1] KEY_PGDN,
+                              [0xCB] KEY_LF,
+                              [0xCD] KEY_RT,
+                              [0x97] KEY_HOME,
+                              [0xCF] KEY_END,
+                              [0xD2] KEY_INS,
+                              [0xD3] KEY_DEL};
 
-static uchar ctlmap[256] =
-{
-  NO,      NO,      NO,      NO,      NO,      NO,      NO,      NO,
-  NO,      NO,      NO,      NO,      NO,      NO,      NO,      NO,
-  C('Q'),  C('W'),  C('E'),  C('R'),  C('T'),  C('Y'),  C('U'),  C('I'),
-  C('O'),  C('P'),  NO,      NO,      '\r',    NO,      C('A'),  C('S'),
-  C('D'),  C('F'),  C('G'),  C('H'),  C('J'),  C('K'),  C('L'),  NO,
-  NO,      NO,      NO,      C('\\'), C('Z'),  C('X'),  C('C'),  C('V'),
-  C('B'),  C('N'),  C('M'),  NO,      NO,      C('/'),  NO,      NO,
-  [0x9C] '\r',      // KP_Enter
-  [0xB5] C('/'),    // KP_Div
-  [0xC8] KEY_UP,    [0xD0] KEY_DN,
-  [0xC9] KEY_PGUP,  [0xD1] KEY_PGDN,
-  [0xCB] KEY_LF,    [0xCD] KEY_RT,
-  [0x97] KEY_HOME,  [0xCF] KEY_END,
-  [0xD2] KEY_INS,   [0xD3] KEY_DEL
-};
+static uchar ctlmap[256] = {NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            C('Q'),
+                            C('W'),
+                            C('E'),
+                            C('R'),
+                            C('T'),
+                            C('Y'),
+                            C('U'),
+                            C('I'),
+                            C('O'),
+                            C('P'),
+                            NO,
+                            NO,
+                            '\r',
+                            NO,
+                            C('A'),
+                            C('S'),
+                            C('D'),
+                            C('F'),
+                            C('G'),
+                            C('H'),
+                            C('J'),
+                            C('K'),
+                            C('L'),
+                            NO,
+                            NO,
+                            NO,
+                            NO,
+                            C('\\'),
+                            C('Z'),
+                            C('X'),
+                            C('C'),
+                            C('V'),
+                            C('B'),
+                            C('N'),
+                            C('M'),
+                            NO,
+                            NO,
+                            C('/'),
+                            NO,
+                            NO,
+                            [0x9C] '\r',   // KP_Enter
+                            [0xB5] C('/'), // KP_Div
+                            [0xC8] KEY_UP,
+                            [0xD0] KEY_DN,
+                            [0xC9] KEY_PGUP,
+                            [0xD1] KEY_PGDN,
+                            [0xCB] KEY_LF,
+                            [0xCD] KEY_RT,
+                            [0x97] KEY_HOME,
+                            [0xCF] KEY_END,
+                            [0xD2] KEY_INS,
+                            [0xD3] KEY_DEL};
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libfs.h
+++ b/src-headers/libfs.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "file.h"
 #include "fs.h"
 #include "include/exokernel.h"
@@ -7,3 +10,6 @@ int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);
 int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
 int fs_bind_block(struct exo_blockcap *cap, void *data, int write);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/affine_runtime.h
+++ b/src-headers/libos/affine_runtime.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "chan.h"
 #include "caplib.h"
 
@@ -53,3 +56,6 @@ int lambda_run(lambda_term_t *t, int fuel);
       type##_decode(m, buf);                                                   \
     return r;                                                                  \
   }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -1,6 +1,12 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "caplib.h"
 
 int driver_spawn(const char *path, char *const argv[]);
 int driver_connect(int pid, exo_cap ep);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/file.h
+++ b/src-headers/libos/file.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "include/exokernel.h"
 
 struct file {
@@ -37,3 +40,6 @@ struct devsw {
 extern struct devsw devsw[];
 
 #define CONSOLE 1
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/fs.h
+++ b/src-headers/libos/fs.h
@@ -1,11 +1,13 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // On-disk file system format.
 // Both the kernel and user programs use this header file.
 
-
-#define ROOTINO 1  // root i-number
-#define BSIZE 512  // block size
+#define ROOTINO 1 // root i-number
+#define BSIZE 512 // block size
 
 // Disk layout:
 // [ boot block | super block | log | inode blocks |
@@ -14,40 +16,40 @@
 // mkfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 struct superblock {
-  uint size;         // Size of file system image (blocks)
-  uint nblocks;      // Number of data blocks
-  uint ninodes;      // Number of inodes.
-  uint nlog;         // Number of log blocks
-  uint logstart;     // Block number of first log block
-  uint inodestart;   // Block number of first inode block
-  uint bmapstart;    // Block number of first free map block
+  uint size;       // Size of file system image (blocks)
+  uint nblocks;    // Number of data blocks
+  uint ninodes;    // Number of inodes.
+  uint nlog;       // Number of log blocks
+  uint logstart;   // Block number of first log block
+  uint inodestart; // Block number of first inode block
+  uint bmapstart;  // Block number of first free map block
 };
 
 #define NDIRECT 12
 #define NINDIRECT (BSIZE / sizeof(uint))
-#define MAXFILE (NDIRECT + NINDIRECT*1024)
+#define MAXFILE (NDIRECT + NINDIRECT * 1024)
 
 // On-disk inode structure
 struct dinode {
-  short type;           // File type
-  short major;          // Major device number (T_DEV only)
-  short minor;          // Minor device number (T_DEV only)
-  short nlink;          // Number of links to inode in file system
-  uint size;            // Size of file (bytes)
-  uint addrs[NDIRECT+1];   // Data block addresses
+  short type;              // File type
+  short major;             // Major device number (T_DEV only)
+  short minor;             // Minor device number (T_DEV only)
+  short nlink;             // Number of links to inode in file system
+  uint size;               // Size of file (bytes)
+  uint addrs[NDIRECT + 1]; // Data block addresses
 };
 
 // Inodes per block.
-#define IPB           (BSIZE / sizeof(struct dinode))
+#define IPB (BSIZE / sizeof(struct dinode))
 
 // Block containing inode i
-#define IBLOCK(i, sb)     ((i) / IPB + sb.inodestart)
+#define IBLOCK(i, sb) ((i) / IPB + sb.inodestart)
 
 // Bitmap bits per block
-#define BPB           (BSIZE*8)
+#define BPB (BSIZE * 8)
 
 // Block of free map containing bit for block b
-#define BBLOCK(b, sb) (b/BPB + sb.bmapstart)
+#define BBLOCK(b, sb) (b / BPB + sb.bmapstart)
 
 // Directory is a file containing a sequence of dirent structures.
 #define DIRSIZ 14
@@ -56,3 +58,6 @@ struct dirent {
   ushort inum;
   char name[DIRSIZ];
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,5 +1,11 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "exo_ipc.h"
 
 int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
 int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/irq_client.h
+++ b/src-headers/libos/irq_client.h
@@ -1,5 +1,11 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "exo_irq.h"
 
 int irq_wait(exo_cap cap, unsigned *irq_no);
 int irq_ack(exo_cap cap);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/libfs.h
+++ b/src-headers/libos/libfs.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "file.h"
 #include "fs.h"
 #include "include/exokernel.h"
@@ -12,3 +15,6 @@ struct file *libfs_open(const char *path, int flags);
 int libfs_read(struct file *f, void *buf, size_t n);
 int libfs_write(struct file *f, const void *buf, size_t n);
 void libfs_close(struct file *f);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 
 int libos_open(const char *path, int flags);
@@ -16,3 +19,6 @@ int libos_fork(void);
 int libos_waitpid(int pid);
 int libos_sigsend(int pid, int sig);
 int libos_sigcheck(void);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/sched.h
+++ b/src-headers/libos/sched.h
@@ -1,4 +1,10 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "../dag.h"
 
 void libos_setup_beatty_dag(void);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/sleeplock.h
+++ b/src-headers/libos/sleeplock.h
@@ -1,6 +1,18 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "spinlock.h"
-struct sleeplock { int locked; struct spinlock lk; };
-static inline void initsleeplock(struct sleeplock *lk, const char *name) { (void)lk; (void)name; }
+struct sleeplock {
+  int locked;
+  struct spinlock lk;
+};
+static inline void initsleeplock(struct sleeplock *lk, const char *name) {
+  (void)lk;
+  (void)name;
+}
 static inline void acquiresleep(struct sleeplock *lk) { (void)lk; }
 static inline void releasesleep(struct sleeplock *lk) { (void)lk; }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stddef.h>
 
 struct ticketlock {
@@ -63,3 +66,6 @@ static inline void release(struct spinlock *l) { (void)l; }
 static inline size_t spinlock_optimal_alignment(void) {
   return __alignof__(struct spinlock);
 }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/libsmk_cap.h
+++ b/src-headers/libsmk_cap.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "user.h"
 
@@ -9,3 +12,6 @@ typedef struct {
 
 static inline void borrow(cap_t c) { cap_inc(c.id); }
 static inline void drop(cap_t c) { cap_dec(c.id); }
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/math_core.h
+++ b/src-headers/math_core.h
@@ -1,7 +1,13 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 
 double phi(void);
 uint64 fib(uint n);
 uint64 gcd(uint64 a, uint64 b);
 size_t phi_align(size_t n);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/memlayout.h
+++ b/src-headers/memlayout.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // Memory layout
 
 #define EXTMEM 0x100000 // Start of extended memory
@@ -38,3 +41,6 @@
 
 #define V2P_WO(x) ((x) - KERNBASE) // same as V2P, but without casts
 #define P2V_WO(x) ((x) + KERNBASE) // same as P2V, but without casts
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/mmu.h
+++ b/src-headers/mmu.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // This file contains definitions for the
 // x86 memory management unit (MMU).
 
@@ -241,4 +244,7 @@ struct gatedesc {
     (gate).off_31_16 = (uint)(off) >> 16;                                      \
   }
 
+#endif
+#ifdef __cplusplus
+}
 #endif

--- a/src-headers/mp.h
+++ b/src-headers/mp.h
@@ -1,58 +1,64 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 // See MultiProcessor Specification Version 1.[14]
 
-struct mp {             // floating pointer
-  uchar signature[4];           // "_MP_"
-  uint physaddr;                // phys addr of MP config table
-  uchar length;                 // 1
-  uchar specrev;                // [14]
-  uchar checksum;               // all bytes must add up to 0
-  uchar type;                   // MP system config type
+struct mp {           // floating pointer
+  uchar signature[4]; // "_MP_"
+  uint physaddr;      // phys addr of MP config table
+  uchar length;       // 1
+  uchar specrev;      // [14]
+  uchar checksum;     // all bytes must add up to 0
+  uchar type;         // MP system config type
   uchar imcrp;
   uchar reserved[3];
 } __attribute__((packed));
 
-struct mpconf {         // configuration table header
-  uchar signature[4];           // "PCMP"
-  ushort length;                // total table length
-  uchar version;                // [14]
-  uchar checksum;               // all bytes must add up to 0
-  uchar product[20];            // product id
-  uint *oemtable;               // OEM table pointer
-  ushort oemlength;             // OEM table length
-  ushort entry;                 // entry count
-  uint *lapicaddr;              // address of local APIC
-  ushort xlength;               // extended table length
-  uchar xchecksum;              // extended table checksum
+struct mpconf {       // configuration table header
+  uchar signature[4]; // "PCMP"
+  ushort length;      // total table length
+  uchar version;      // [14]
+  uchar checksum;     // all bytes must add up to 0
+  uchar product[20];  // product id
+  uint *oemtable;     // OEM table pointer
+  ushort oemlength;   // OEM table length
+  ushort entry;       // entry count
+  uint *lapicaddr;    // address of local APIC
+  ushort xlength;     // extended table length
+  uchar xchecksum;    // extended table checksum
   uchar reserved;
 } __attribute__((packed));
 
-struct mpproc {         // processor table entry
-  uchar type;                   // entry type (0)
-  uchar apicid;                 // local APIC id
-  uchar version;                // local APIC verison
-  uchar flags;                  // CPU flags
-    #define MPBOOT 0x02           // This proc is the bootstrap processor.
-  uchar signature[4];           // CPU signature
-  uint feature;                 // feature flags from CPUID instruction
+struct mpproc {       // processor table entry
+  uchar type;         // entry type (0)
+  uchar apicid;       // local APIC id
+  uchar version;      // local APIC verison
+  uchar flags;        // CPU flags
+#define MPBOOT 0x02   // This proc is the bootstrap processor.
+  uchar signature[4]; // CPU signature
+  uint feature;       // feature flags from CPUID instruction
   uchar reserved[8];
 } __attribute__((packed));
 
-struct mpioapic {       // I/O APIC table entry
-  uchar type;                   // entry type (2)
-  uchar apicno;                 // I/O APIC id
-  uchar version;                // I/O APIC version
-  uchar flags;                  // I/O APIC flags
-  uint *addr;                  // I/O APIC address
+struct mpioapic { // I/O APIC table entry
+  uchar type;     // entry type (2)
+  uchar apicno;   // I/O APIC id
+  uchar version;  // I/O APIC version
+  uchar flags;    // I/O APIC flags
+  uint *addr;     // I/O APIC address
 } __attribute__((packed));
 
 // Table entry types
-#define MPPROC    0x00  // One per processor
-#define MPBUS     0x01  // One per bus
-#define MPIOAPIC  0x02  // One per I/O APIC
-#define MPIOINTR  0x03  // One per bus interrupt source
-#define MPLINTR   0x04  // One per system interrupt source
+#define MPPROC 0x00   // One per processor
+#define MPBUS 0x01    // One per bus
+#define MPIOAPIC 0x02 // One per I/O APIC
+#define MPIOINTR 0x03 // One per bus interrupt source
+#define MPLINTR 0x04  // One per system interrupt source
 
-//PAGEBREAK!
-// Blank page.
+// PAGEBREAK!
+//  Blank page.
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/param.h
+++ b/src-headers/param.h
@@ -1,17 +1,23 @@
 #pragma once
 
-#define NPROC        64  // maximum number of processes
-#define KSTACKSIZE 4096  // size of per-process kernel stack
-#define NCPU          8  // maximum number of CPUs
-#define NNODES        2  // number of NUMA nodes
-#define NOFILE       16  // open files per process
-#define NFILE       100  // open files per system
-#define NINODE       50  // maximum number of active i-nodes
-#define NDEV         10  // maximum major device number
-#define ROOTDEV       1  // device number of file system root disk
-#define MAXARG       32  // max exec arguments
-#define MAXOPBLOCKS  10  // max # of blocks any FS op writes
-#define LOGSIZE      (MAXOPBLOCKS*3)  // max data blocks in on-disk log
-#define NBUF         (MAXOPBLOCKS*3)  // size of disk block cache
-#define FSSIZE       1000  // size of file system in blocks
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define NPROC 64                  // maximum number of processes
+#define KSTACKSIZE 4096           // size of per-process kernel stack
+#define NCPU 8                    // maximum number of CPUs
+#define NNODES 2                  // number of NUMA nodes
+#define NOFILE 16                 // open files per process
+#define NFILE 100                 // open files per system
+#define NINODE 50                 // maximum number of active i-nodes
+#define NDEV 10                   // maximum major device number
+#define ROOTDEV 1                 // device number of file system root disk
+#define MAXARG 32                 // max exec arguments
+#define MAXOPBLOCKS 10            // max # of blocks any FS op writes
+#define LOGSIZE (MAXOPBLOCKS * 3) // max data blocks in on-disk log
+#define NBUF (MAXOPBLOCKS * 3)    // size of disk block cache
+#define FSSIZE 1000               // size of file system in blocks
 
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/proc.h
+++ b/src-headers/proc.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "param.h"
 #include "mmu.h"
 #include "x86.h"
@@ -16,32 +19,32 @@ typedef struct context context_t;
 
 // Per-CPU state
 struct cpu {
-  uchar apicid;                // Local APIC ID
-  context_t *scheduler;        // swtch() here to enter scheduler
+  uchar apicid;         // Local APIC ID
+  context_t *scheduler; // swtch() here to enter scheduler
 #ifndef __aarch64__
-  struct taskstate ts;         // Used by x86 to find stack for interrupt
-  struct segdesc gdt[NSEGS];   // x86 global descriptor table
+  struct taskstate ts;       // Used by x86 to find stack for interrupt
+  struct segdesc gdt[NSEGS]; // x86 global descriptor table
 #endif
-  volatile uint started;       // Has the CPU started?
-  int ncli;                    // Depth of pushcli nesting.
-  int intena;                  // Were interrupts enabled before pushcli?
-  struct proc *proc;           // The process running on this cpu or null
+  volatile uint started; // Has the CPU started?
+  int ncli;              // Depth of pushcli nesting.
+  int intena;            // Were interrupts enabled before pushcli?
+  struct proc *proc;     // The process running on this cpu or null
 };
 
 extern struct cpu cpus[NCPU];
 extern int ncpu;
 
-//PAGEBREAK: 17
-// Saved registers for kernel context switches.
-// Don't need to save all the segment registers (%cs, etc),
-// because they are constant across kernel contexts.
-// Don't need to save %eax, %ecx, %edx, because the
-// x86 convention is that the caller has saved them.
-// Contexts are stored at the bottom of the stack they
-// describe; the stack pointer is the address of the context.
-// The layout of the context matches the layout of the stack in swtch.S
-// at the "Switch stacks" comment. Switch doesn't save eip explicitly,
-// but it is on the stack and allocproc() manipulates it.
+// PAGEBREAK: 17
+//  Saved registers for kernel context switches.
+//  Don't need to save all the segment registers (%cs, etc),
+//  because they are constant across kernel contexts.
+//  Don't need to save %eax, %ecx, %edx, because the
+//  x86 convention is that the caller has saved them.
+//  Contexts are stored at the bottom of the stack they
+//  describe; the stack pointer is the address of the context.
+//  The layout of the context matches the layout of the stack in swtch.S
+//  at the "Switch stacks" comment. Switch doesn't save eip explicitly,
+//  but it is on the stack and allocproc() manipulates it.
 struct context {
   uint edi;
   uint esi;
@@ -79,31 +82,30 @@ struct context64 {
 };
 #endif
 
-
 enum procstate { UNUSED, EMBRYO, SLEEPING, RUNNABLE, RUNNING, ZOMBIE };
 
 // Per-process state
 struct proc {
-  size_t sz;                     // Size of process memory (bytes)
-  pde_t* pgdir;                  // Page table
-  char *kstack;                  // Bottom of kernel stack for this process
-  enum procstate state;          // Process state
-  int pid;                       // Process ID
-  struct proc *parent;           // Parent process
-  struct trapframe *tf;          // Trap frame for current syscall
-  context_t *context;            // swtch() here to run process
-  void (*timer_upcall)(void);    // user-mode timer interrupt handler
-  void *chan;                    // If non-zero, sleeping on chan
-  int killed;                    // If non-zero, have been killed
-  int pending_signal;            // Simple signal bitmask
-  struct file *ofile[NOFILE];    // Open files
-  struct inode *cwd;             // Current directory
-  char name[16];                 // Process name (debugging)
-  uint pctr_cap;                 // Capability for exo_pctr_transfer
-  volatile uint pctr_signal;     // Signal counter for exo_pctr_transfer
-  uint64 gas_remaining;          // Remaining CPU budget
-  int preferred_node;            // NUMA allocation preference
-  int out_of_gas;                // Flag set when gas runs out
+  size_t sz;                  // Size of process memory (bytes)
+  pde_t *pgdir;               // Page table
+  char *kstack;               // Bottom of kernel stack for this process
+  enum procstate state;       // Process state
+  int pid;                    // Process ID
+  struct proc *parent;        // Parent process
+  struct trapframe *tf;       // Trap frame for current syscall
+  context_t *context;         // swtch() here to run process
+  void (*timer_upcall)(void); // user-mode timer interrupt handler
+  void *chan;                 // If non-zero, sleeping on chan
+  int killed;                 // If non-zero, have been killed
+  int pending_signal;         // Simple signal bitmask
+  struct file *ofile[NOFILE]; // Open files
+  struct inode *cwd;          // Current directory
+  char name[16];              // Process name (debugging)
+  uint pctr_cap;              // Capability for exo_pctr_transfer
+  volatile uint pctr_signal;  // Signal counter for exo_pctr_transfer
+  uint64 gas_remaining;       // Remaining CPU budget
+  int preferred_node;         // NUMA allocation preference
+  int out_of_gas;             // Flag set when gas runs out
 };
 
 // Ensure scheduler relies on fixed struct proc size
@@ -112,7 +114,6 @@ _Static_assert(sizeof(struct proc) == 256, "struct proc size incorrect");
 #else
 _Static_assert(sizeof(struct proc) == 156, "struct proc size incorrect");
 #endif
-
 
 // Process memory is laid out contiguously, low addresses first:
 //   text
@@ -124,3 +125,6 @@ struct ptable {
   struct spinlock lock;
   struct proc proc[NPROC];
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/qspinlock.h
+++ b/src-headers/qspinlock.h
@@ -1,7 +1,13 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <spinlock.h>
 
 void qspin_lock(struct spinlock *lk);
 void qspin_unlock(struct spinlock *lk);
 int qspin_trylock(struct spinlock *lk);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/rspinlock.h
+++ b/src-headers/rspinlock.h
@@ -1,10 +1,13 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <spinlock.h>
 
 struct rspinlock {
-  struct spinlock lk;  // underlying spinlock
-  struct cpu *owner;   // current owner CPU
-  int depth;           // recursion depth
+  struct spinlock lk; // underlying spinlock
+  struct cpu *owner;  // current owner CPU
+  int depth;          // recursion depth
 };
 
 void rinitlock(struct rspinlock *rlk, char *name);
@@ -12,5 +15,8 @@ void racquire(struct rspinlock *rlk);
 void rrelease(struct rspinlock *rlk);
 int rholding(struct rspinlock *rlk);
 
-#define WITH_RSPINLOCK(rlk) \
-  for(int _once = (racquire(rlk), 0); !_once; rrelease(rlk), _once = 1)
+#define WITH_RSPINLOCK(rlk)                                                    \
+  for (int _once = (racquire(rlk), 0); !_once; rrelease(rlk), _once = 1)
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/sched.h
+++ b/src-headers/sched.h
@@ -1,7 +1,12 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include_next <sched.h>
 #include "dag.h"
 
 void libos_setup_beatty_dag(void);
 
-
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/signal.h
+++ b/src-headers/signal.h
@@ -1,2 +1,8 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define SIGUSR1 1
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stddef.h>
 
 struct ticketlock {
@@ -17,8 +20,16 @@ struct spinlock {
 };
 
 #ifndef SPINLOCK_NO_STUBS
-static inline void initlock(struct spinlock *l, char *name) { (void)l; (void)name; }
+static inline void initlock(struct spinlock *l, char *name) {
+  (void)l;
+  (void)name;
+}
 static inline void acquire(struct spinlock *l) { (void)l; }
 static inline void release(struct spinlock *l) { (void)l; }
 #endif
-static inline size_t spinlock_optimal_alignment(void) { return __alignof__(struct spinlock); }
+static inline size_t spinlock_optimal_alignment(void) {
+  return __alignof__(struct spinlock);
+}
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/stat.h
+++ b/src-headers/stat.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 struct stat {
   int dev;
   unsigned int ino;
@@ -7,3 +10,6 @@ struct stat {
   short nlink;
   unsigned int size;
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/stddef.h
+++ b/src-headers/stddef.h
@@ -1,7 +1,13 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
 #if __has_include_next(<stddef.h>)
-# include_next <stddef.h>
+#include_next <stddef.h>
 #else
 typedef __SIZE_TYPE__ size_t;
 typedef __PTRDIFF_TYPE__ ptrdiff_t;
-#define NULL ((void*)0)
+#define NULL ((void *)0)
+#endif
+#ifdef __cplusplus
+}
 #endif

--- a/src-headers/stdint.h
+++ b/src-headers/stdint.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #if __has_include_next(<stdint.h>)
-# include_next <stdint.h>
+#include_next <stdint.h>
 #else
 typedef signed char int8_t;
 typedef short int16_t;
@@ -15,4 +18,7 @@ typedef unsigned long long uint64_t;
 
 typedef long intptr_t;
 typedef unsigned long uintptr_t;
+#endif
+#ifdef __cplusplus
+}
 #endif

--- a/src-headers/string.h
+++ b/src-headers/string.h
@@ -1,4 +1,10 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stddef.h>
 void *memmove(void *dst, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/svr4_machdep.h
+++ b/src-headers/svr4_machdep.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* Machine dependent definitions for SVR4 compatibility on x86 */
 
 /*
@@ -11,25 +14,25 @@
 #include <compat/svr4/svr4_types.h>
 
 /* General register indices */
-#define SVR4_X86_GS     0
-#define SVR4_X86_FS     1
-#define SVR4_X86_ES     2
-#define SVR4_X86_DS     3
-#define SVR4_X86_EDI    4
-#define SVR4_X86_ESI    5
-#define SVR4_X86_EBP    6
-#define SVR4_X86_ESP    7
-#define SVR4_X86_EBX    8
-#define SVR4_X86_EDX    9
-#define SVR4_X86_ECX    10
-#define SVR4_X86_EAX    11
+#define SVR4_X86_GS 0
+#define SVR4_X86_FS 1
+#define SVR4_X86_ES 2
+#define SVR4_X86_DS 3
+#define SVR4_X86_EDI 4
+#define SVR4_X86_ESI 5
+#define SVR4_X86_EBP 6
+#define SVR4_X86_ESP 7
+#define SVR4_X86_EBX 8
+#define SVR4_X86_EDX 9
+#define SVR4_X86_ECX 10
+#define SVR4_X86_EAX 11
 #define SVR4_X86_TRAPNO 12
-#define SVR4_X86_ERR    13
-#define SVR4_X86_EIP    14
-#define SVR4_X86_CS     15
-#define SVR4_X86_EFL    16
-#define SVR4_X86_UESP   17
-#define SVR4_X86_SS     18
+#define SVR4_X86_ERR 13
+#define SVR4_X86_EIP 14
+#define SVR4_X86_CS 15
+#define SVR4_X86_EFL 16
+#define SVR4_X86_UESP 17
+#define SVR4_X86_SS 18
 #define SVR4_X86_MAXREG 19
 
 typedef int svr4_greg_t;
@@ -37,13 +40,13 @@ typedef svr4_greg_t svr4_gregset_t[SVR4_X86_MAXREG];
 
 /* FPU state container */
 typedef struct {
-    int  f_x87[62];    /* x87 registers */
-    long f_weitek[33]; /* weitek */
+  int f_x87[62];     /* x87 registers */
+  long f_weitek[33]; /* weitek */
 } svr4_fregset_t;
 
 typedef struct svr4_mcontext {
-    svr4_gregset_t greg;
-    svr4_fregset_t freg;
+  svr4_gregset_t greg;
+  svr4_fregset_t freg;
 } svr4_mcontext_t;
 
 #define SVR4_UC_MACHINE_PAD 5
@@ -53,40 +56,42 @@ typedef struct svr4_mcontext {
 #define SVR4_SYSARCH_DSCR 75
 
 struct svr4_ssd {
-    unsigned int selector;
-    unsigned int base;
-    unsigned int limit;
-    unsigned int access1;
-    unsigned int access2;
+  unsigned int selector;
+  unsigned int base;
+  unsigned int limit;
+  unsigned int access1;
+  unsigned int access2;
 };
 
 /* Processor traps */
-#define SVR4_T_DIVIDE    0
-#define SVR4_T_TRCTRAP   1
-#define SVR4_T_NMI       2
-#define SVR4_T_BPTFLT    3
-#define SVR4_T_OFLOW     4
-#define SVR4_T_BOUND     5
+#define SVR4_T_DIVIDE 0
+#define SVR4_T_TRCTRAP 1
+#define SVR4_T_NMI 2
+#define SVR4_T_BPTFLT 3
+#define SVR4_T_OFLOW 4
+#define SVR4_T_BOUND 5
 #define SVR4_T_PRIVINFLT 6
-#define SVR4_T_DNA       7
+#define SVR4_T_DNA 7
 #define SVR4_T_DOUBLEFLT 8
-#define SVR4_T_FPOPFLT   9
-#define SVR4_T_TSSFLT    10
-#define SVR4_T_SEGNPFLT  11
-#define SVR4_T_STKFLT    12
-#define SVR4_T_PROTFLT   13
-#define SVR4_T_PAGEFLT   14
-#define SVR4_T_ALIGNFLT  17
+#define SVR4_T_FPOPFLT 9
+#define SVR4_T_TSSFLT 10
+#define SVR4_T_SEGNPFLT 11
+#define SVR4_T_STKFLT 12
+#define SVR4_T_PROTFLT 13
+#define SVR4_T_PAGEFLT 14
+#define SVR4_T_ALIGNFLT 17
 
 /* Fast syscall gate traps */
-#define SVR4_TRAP_FNULL       0 /* Null trap, for testing */
-#define SVR4_TRAP_FGETFP      1 /* Get emulated FP context */
-#define SVR4_TRAP_FSETFP      2 /* Set emulated FP context */
-#define SVR4_TRAP_GETHRTIME   3 /* implements gethrtime(2) */
-#define SVR4_TRAP_GETHRVTIME  4 /* implements gethrvtime(2) */
+#define SVR4_TRAP_FNULL 0       /* Null trap, for testing */
+#define SVR4_TRAP_FGETFP 1      /* Get emulated FP context */
+#define SVR4_TRAP_FSETFP 2      /* Set emulated FP context */
+#define SVR4_TRAP_GETHRTIME 3   /* implements gethrtime(2) */
+#define SVR4_TRAP_GETHRVTIME 4  /* implements gethrvtime(2) */
 #define SVR4_TRAP_GETHRESTIME 5 /* clock_gettime(CLOCK_REALTIME, tp) */
 
 struct proc;
 void svr4_syscall_intern(struct proc *);
 
-
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/syscall.h
+++ b/src-headers/syscall.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 enum {
   SYS_fork = 1,
   SYS_exit,
@@ -42,3 +45,6 @@ enum {
   SYS_exo_bind_irq,
   SYS_exo_alloc_dma,
 };
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/traps.h
+++ b/src-headers/traps.h
@@ -1,2 +1,8 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #define T_SYSCALL 64
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/tty.h
+++ b/src-headers/tty.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include "types.h"
 #include "spinlock.h"
 #include "kbd.h"
@@ -14,3 +17,6 @@ void ttyinit(void);
 void ttyintr(int c, void (*putc)(int));
 void ttypecho(int c, void (*putc)(int));
 int ttyread(struct inode *ip, char *dst, size_t n);
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/types.h
+++ b/src-headers/types.h
@@ -1,11 +1,17 @@
 #ifndef XV6_TYPES_H
 #define XV6_TYPES_H
 
-typedef unsigned int   uint;
+#ifdef __cplusplus
+extern "C" {
+#endif
+typedef unsigned int uint;
 typedef unsigned short ushort;
-typedef unsigned char  uchar;
-typedef unsigned int   uint32;
-typedef unsigned long  uint64;
-typedef unsigned long  uintptr;
+typedef unsigned char uchar;
+typedef unsigned int uint32;
+typedef unsigned long uint64;
+typedef unsigned long uintptr;
 
+#ifdef __cplusplus
+}
+#endif
 #endif // XV6_TYPES_H

--- a/src-headers/user.h
+++ b/src-headers/user.h
@@ -1,2 +1,8 @@
 #pragma once
+#ifdef __cplusplus
+extern "C" {
+#endif
 // placeholder user-space headers
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/uv_spinlock.h
+++ b/src-headers/uv_spinlock.h
@@ -1,35 +1,41 @@
 #pragma once
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 #include <stdint.h>
 
 /* Simple spinlock implementation inspired by libuv's uv_spinlock_t. */
 
 typedef struct {
-    _Atomic int lock;
+  _Atomic int lock;
 } uv_spinlock_t;
 
 static inline void uv_spinlock_init(uv_spinlock_t *sl) {
-    __atomic_store_n(&sl->lock, 0, __ATOMIC_RELAXED);
+  __atomic_store_n(&sl->lock, 0, __ATOMIC_RELAXED);
 }
 
 static inline int uv_spinlock_trylock(uv_spinlock_t *sl) {
-    int expected = 0;
-    return __atomic_compare_exchange_n(&sl->lock, &expected, 1, 0,
-                                       __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
+  int expected = 0;
+  return __atomic_compare_exchange_n(&sl->lock, &expected, 1, 0,
+                                     __ATOMIC_ACQUIRE, __ATOMIC_RELAXED);
 }
 
 static inline void uv_spinlock_lock(uv_spinlock_t *sl) {
-    while (!uv_spinlock_trylock(sl)) {
+  while (!uv_spinlock_trylock(sl)) {
 #ifdef __x86_64__
-        __asm__ volatile("pause" ::: "memory");
+    __asm__ volatile("pause" ::: "memory");
 #else
-        __asm__ volatile("" ::: "memory");
+    __asm__ volatile("" ::: "memory");
 #endif
-    }
+  }
 }
 
 static inline void uv_spinlock_unlock(uv_spinlock_t *sl) {
-    __atomic_store_n(&sl->lock, 0, __ATOMIC_RELEASE);
+  __atomic_store_n(&sl->lock, 0, __ATOMIC_RELEASE);
 }
 
-#define UV_SPINLOCK_INITIALIZER { 0 }
+#define UV_SPINLOCK_INITIALIZER {0}
+#ifdef __cplusplus
+}
+#endif

--- a/src-headers/x86.h
+++ b/src-headers/x86.h
@@ -1,50 +1,48 @@
 #ifndef XV6_X86_H
 #define XV6_X86_H
 
-static inline uchar
-inb(ushort port)
-{
+#ifdef __cplusplus
+extern "C" {
+#endif
+static inline uchar inb(ushort port) {
   uchar data;
   __asm__ volatile("inb %1,%0" : "=a"(data) : "d"(port));
   return data;
 }
 
-static inline void
-outb(ushort port, uchar data)
-{
+static inline void outb(ushort port, uchar data) {
   __asm__ volatile("outb %0,%1" : : "a"(data), "d"(port));
 }
 
-static inline void
-insl(int port, void *addr, int cnt)
-{
-  __asm__ volatile("cld; rep insl" :
-                   "=D"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
-                   "memory");
+static inline void insl(int port, void *addr, int cnt) {
+  __asm__ volatile("cld; rep insl"
+                   : "=D"(addr), "=c"(cnt)
+                   : "d"(port), "0"(addr), "1"(cnt)
+                   : "memory");
 }
 
-static inline void
-outsl(int port, const void *addr, int cnt)
-{
-  __asm__ volatile("cld; rep outsl" :
-                   "=S"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
-                   "memory");
+static inline void outsl(int port, const void *addr, int cnt) {
+  __asm__ volatile("cld; rep outsl"
+                   : "=S"(addr), "=c"(cnt)
+                   : "d"(port), "0"(addr), "1"(cnt)
+                   : "memory");
 }
 
-static inline void
-stosb(void *addr, int data, int cnt)
-{
-  __asm__ volatile("cld; rep stosb" :
-                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
-                   "memory");
+static inline void stosb(void *addr, int data, int cnt) {
+  __asm__ volatile("cld; rep stosb"
+                   : "=D"(addr), "=c"(cnt)
+                   : "0"(addr), "1"(cnt), "a"(data)
+                   : "memory");
 }
 
-static inline void
-stosl(void *addr, int data, int cnt)
-{
-  __asm__ volatile("cld; rep stosl" :
-                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
-                   "memory");
+static inline void stosl(void *addr, int data, int cnt) {
+  __asm__ volatile("cld; rep stosl"
+                   : "=D"(addr), "=c"(cnt)
+                   : "0"(addr), "1"(cnt), "a"(data)
+                   : "memory");
 }
 
+#ifdef __cplusplus
+}
+#endif
 #endif // XV6_X86_H


### PR DESCRIPTION
## Summary
- ensure all public headers are wrapped in `extern "C"` guards for C++ compatibility
- keep C/C++ compatibility across nested includes

## Testing
- `pytest -q`