### PR TITLE
Integrate microbench with CMake build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,6 @@ jobs:
     - name: Run fuzz smoke test
       run: python3 scripts/swift_fuzz.py -runs=1
     - name: Run microbenchmarks
-      run: make -C tests/microbench run
+      run: ninja -C build microbench-run
     - name: Clean
       run: rm -rf build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,3 +50,6 @@ endif()
 target_link_libraries(kernel PRIVATE nstr_graph)
 
 add_subdirectory(libnstr_graph)
+
+# Build test utilities
+add_subdirectory(tests)

--- a/libos/procwrap.c
+++ b/libos/procwrap.c
@@ -1,29 +1,32 @@
 #include "procwrap.h"
 #include "user.h"
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+#include <errno.h>
 
 int proc_spawn(proc_handle_t *p, const char *path, char *const argv[]) {
-    int pid = fork();
-    if(pid == 0) {
-        exec((char *)path, (char **)argv);
-        exit();
+    pid_t pid = fork();
+    if (pid == 0) {
+        execvp(path, argv);
+        _exit(1);
     }
-    if(p)
+    if (p)
         p->pid = pid;
     return pid;
 }
 
 int proc_wait(proc_handle_t *p) {
-    if(!p)
+    if (!p)
         return -1;
-    int r;
-    while((r = wait()) >= 0) {
-        if(r == p->pid)
-            return 0;
-    }
-    return -1;
+    int status;
+    pid_t r;
+    do {
+        r = waitpid(p->pid, &status, 0);
+    } while (r == -1 && errno == EINTR);
+    return (r == p->pid) ? 0 : -1;
 }
 
 void proc_exit(int code) {
-    (void)code;
-    exit();
+    _exit(code);
 }

--- a/meson.build
+++ b/meson.build
@@ -23,3 +23,6 @@ if clang_tidy.found()
 endif
 
 subdir('libnstr_graph')
+
+# Build test utilities
+subdir('tests')

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 #include "exo.h"
 #include "exo_cpu.h"
 #include "exokernel.h"

--- a/src-headers/errno.h
+++ b/src-headers/errno.h
@@ -1,2 +1,3 @@
 #pragma once
 #define EPERM 1
+#include_next <errno.h>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(microbench)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,0 +1,1 @@
+subdir('microbench')

--- a/tests/microbench/CMakeLists.txt
+++ b/tests/microbench/CMakeLists.txt
@@ -1,0 +1,31 @@
+add_library(microbench_common OBJECT
+    ../../libos/procwrap.c
+    ../../libos/capwrap.c
+)
+
+target_include_directories(microbench_common PUBLIC
+    ${CMAKE_SOURCE_DIR}/libos/include
+    ${CMAKE_SOURCE_DIR}/src-headers
+)
+
+set(MICROBENCH_PROGS
+    cap_verify_bench
+    exo_yield_to_bench
+    proc_cap_test
+)
+
+foreach(prog ${MICROBENCH_PROGS})
+    add_executable(${prog} ${prog}.c $<TARGET_OBJECTS:microbench_common>)
+    target_include_directories(${prog} PRIVATE
+        ${CMAKE_SOURCE_DIR}/libos/include
+        ${CMAKE_SOURCE_DIR}/src-headers
+    )
+endforeach()
+
+add_custom_target(microbench-run
+    COMMAND $<TARGET_FILE:cap_verify_bench>
+    COMMAND $<TARGET_FILE:exo_yield_to_bench>
+    COMMAND $<TARGET_FILE:proc_cap_test>
+    DEPENDS cap_verify_bench exo_yield_to_bench proc_cap_test
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+)

--- a/tests/microbench/meson.build
+++ b/tests/microbench/meson.build
@@ -1,0 +1,34 @@
+incdir = include_directories('../../libos/include', '../../src-headers')
+
+microbench_common = static_library(
+    'microbench_common',
+    '../../libos/procwrap.c',
+    '../../libos/capwrap.c',
+    include_directories: incdir,
+    pic: false,
+)
+
+cap_verify_bench = executable('cap_verify_bench', 'cap_verify_bench.c',
+    include_directories: incdir,
+    link_with: microbench_common,
+    install: false)
+
+exo_yield_to_bench = executable('exo_yield_to_bench', 'exo_yield_to_bench.c',
+    include_directories: incdir,
+    link_with: microbench_common,
+    install: false)
+
+proc_cap_test = executable('proc_cap_test', 'proc_cap_test.c',
+    include_directories: incdir,
+    link_with: microbench_common,
+    install: false)
+
+run_cmd = ' && '.join([
+    join_paths(meson.current_build_dir(), 'cap_verify_bench'),
+    join_paths(meson.current_build_dir(), 'exo_yield_to_bench'),
+    join_paths(meson.current_build_dir(), 'proc_cap_test')
+])
+
+run_target('microbench-run',
+    command: ['sh', '-c', run_cmd],
+    depends: [cap_verify_bench, exo_yield_to_bench, proc_cap_test])

--- a/tests/microbench/proc_cap_test.c
+++ b/tests/microbench/proc_cap_test.c
@@ -1,4 +1,5 @@
 #include <stdio.h>
+#include <unistd.h>
 #include "procwrap.h"
 #include "capwrap.h"
 


### PR DESCRIPTION
## Summary
- build microbench executables with CMake and Meson
- provide host implementations for `procwrap` helpers
- include system errno definitions
- run microbench target in CI workflow

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build microbench-run`
- `meson setup build` *(fails: `meson: command not found`)*