### PR TITLE
Make Bison optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,9 @@ if(CLANG_TIDY_EXE)
   set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 
+# Optional parser generator support
+find_package(BISON)
+
 file(GLOB_RECURSE KERNEL_SOURCES
   src-kernel/*.c
   src-uland/*.c
@@ -34,6 +37,13 @@ file(GLOB_RECURSE KERNEL_SOURCES
 add_executable(kernel ${KERNEL_SOURCES})
 
 set(CPUFLAGS "" CACHE STRING "Additional CPU specific compile flags")
+
+if(BISON_FOUND)
+  # Sample rule for future grammars
+  # BISON_TARGET(example ${CMAKE_SOURCE_DIR}/path/to/example.y
+  #               ${CMAKE_CURRENT_BINARY_DIR}/example.tab.c)
+  # add_library(example_parser ${BISON_example_OUTPUTS})
+endif()
 
 target_include_directories(kernel PRIVATE
   ${CMAKE_SOURCE_DIR}

--- a/README
+++ b/README
@@ -83,6 +83,10 @@ new binaries.
 The QEMU PC simulator is installed automatically by ``setup.sh``.
 Bochs is optional but also supported via ``ninja -C build bochs``.
 
+Bison is optional as well and only required when grammar ``.y`` files are
+present. The build system automatically detects ``bison`` and skips grammar
+generation if it is missing.
+
 A few headers used solely by the kernel have been moved under
 ``src-kernel/include``.  Files like ``spinlock.h`` and ``sleeplock.h``
 reside here instead of ``src-headers``.  The CMake build adds this

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,7 @@
 project('xv6', 'c', default_options: ['c_std=c23'])
 
 clang_tidy = find_program('clang-tidy', required: false)
+bison = find_program('bison', required : false)
 
 src_dirs = ['src-kernel', 'src-uland', 'src-uland/user', 'libos']
 
@@ -20,6 +21,14 @@ executable('kernel', sources,
 if clang_tidy.found()
   run_target('clang-tidy', command: [clang_tidy, sources],
              depends: sources)
+endif
+
+if bison.found()
+  # Sample grammar rule for future .y files
+  # sample = custom_target('sample.tab.c',
+  #   command: [bison, '-d', '@INPUT@'],
+  #   input: 'path/to/sample.y',
+  #   output: ['sample.tab.c', 'sample.tab.h'])
 endif
 
 subdir('libnstr_graph')


### PR DESCRIPTION
## Summary
- detect Bison with `find_package()` in CMake
- show sample `BISON_TARGET()` rule
- detect `bison` in Meson builds and sample target
- document optional Bison in README

## Testing
- `pytest -q`