### PR TITLE
Add Meson build job to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
     strategy:
       matrix:
         arch: [i686, x86_64]
+        buildsys: [cmake, meson]
     steps:
     - uses: actions/checkout@v4
     - name: Install build dependencies
@@ -56,10 +57,18 @@ jobs:
         set -euxo pipefail
         make clean
       run: swift/build_swift.sh
-    - name: Configure
+    - name: Configure (CMake)
+      if: matrix.buildsys == 'cmake'
       run: cmake -S . -B build -G Ninja -DARCH=${{ matrix.arch }}
-    - name: Build
+    - name: Build (CMake)
+      if: matrix.buildsys == 'cmake'
       run: ninja -C build qemu-nox
+    - name: Configure (Meson)
+      if: matrix.buildsys == 'meson'
+      run: meson setup build --wipe
+    - name: Build (Meson)
+      if: matrix.buildsys == 'meson'
+      run: ninja -C build
     - name: Run unit tests
       run: pytest -q
     - name: Run fuzz smoke test


### PR DESCRIPTION
## Summary
- run CI with both CMake and Meson using a matrix entry

## Testing
- `pytest -q`
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*