### PR TITLE
Add optional Bison parser build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,15 @@ if(CLANG_TIDY_EXE)
   set(CMAKE_C_CLANG_TIDY "${CLANG_TIDY_EXE}")
 endif()
 
+find_package(BISON)
+if(BISON_FOUND)
+  BISON_TARGET(example_parser
+    proto/example.y
+    ${CMAKE_CURRENT_BINARY_DIR}/example_parser.c
+    DEFINES_FILE ${CMAKE_CURRENT_BINARY_DIR}/example_parser.h)
+  add_custom_target(example_bison DEPENDS ${BISON_example_parser_OUTPUTS})
+endif()
+
 file(GLOB_RECURSE KERNEL_SOURCES
   src-kernel/*.c
   src-uland/*.c

--- a/README
+++ b/README
@@ -67,6 +67,8 @@ cross-compiler toolchain capable of producing x86 ELF binaries
 (see https://pdos.csail.mit.edu/6.828/).  A cross-compiler may not be
 necessary on a 64-bit Linux host since the toolchain can produce 32-bit
 binaries.
+``bison`` is detected automatically and only required when building the
+optional example parser included in the build scripts.
 
 Step-by-step build and run commands::
 

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,13 @@
 project('xv6', 'c', default_options: ['c_std=c23'])
 
 clang_tidy = find_program('clang-tidy', required: false)
+bison = find_program('bison', required: false)
+if bison.found()
+  example_parser = custom_target('example_parser',
+    input: 'proto/example.y',
+    output: ['example_parser.c', 'example_parser.h'],
+    command: [bison, '--defines=@OUTPUT1@', '-o', '@OUTPUT0@', '@INPUT@'])
+endif
 
 # User-space runtime library
 mock_capnpc = find_program('scripts/mock_capnpc.sh')

--- a/proto/example.y
+++ b/proto/example.y
@@ -1,0 +1,10 @@
+%{
+/* Example Bison grammar */
+%}
+
+%start input
+%%
+input:
+    /* empty */
+    ;
+%%


### PR DESCRIPTION
## Summary
- CMakeLists: detect Bison and generate example parser
- meson.build: build parser when bison is present
- document optional dependency in README
- add simple example grammar

## Testing
- `pytest -q`