### PR TITLE
Refactor to standard integer types

### DIFF
--- a/exo.h
+++ b/exo.h
@@ -3,28 +3,28 @@
 #include "types.h"
 
 typedef struct hash256 {
-  uint64 parts[4];
+  uint64_t parts[4];
 } hash256_t;
 
 typedef struct exo_cap {
-  uint pa;
-  uint id;
-  uint rights;
-  uint owner;
+  uint32_t pa;
+  uint32_t id;
+  uint32_t rights;
+  uint32_t owner;
   hash256_t auth_tag;
 } exo_cap;
 
 typedef struct exo_blockcap {
-  uint dev;
-  uint blockno;
-  uint rights;
-  uint owner;
+  uint32_t dev;
+  uint32_t blockno;
+  uint32_t rights;
+  uint32_t owner;
 } exo_blockcap;
 
 #ifdef EXO_KERNEL
 exo_cap exo_alloc_page(void);
 [[nodiscard]] int exo_unbind_page(exo_cap c);
-exo_cap cap_new(uint id, uint rights, uint owner);
+exo_cap cap_new(uint32_t id, uint32_t rights, uint32_t owner);
 int cap_verify(exo_cap c);
 #endif
 

--- a/libos/fs.c
+++ b/libos/fs.c
@@ -16,7 +16,7 @@ int fs_write_block(struct exo_blockcap cap, const void *src) {
   return exo_write_disk(cap, src, 0, BSIZE);
 }
 
-int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap) {
+int fs_alloc_block(uint32_t dev, uint32_t rights, struct exo_blockcap *cap) {
   return exo_alloc_block(dev, rights, cap);
 }
 

--- a/mkfs.c
+++ b/mkfs.c
@@ -29,34 +29,34 @@ int nblocks;  // Number of data blocks
 int fsfd;
 struct superblock sb;
 char zeroes[BSIZE];
-uint freeinode = 1;
-uint freeblock;
+uint32_t freeinode = 1;
+uint32_t freeblock;
 
 
 void balloc(int);
-void wsect(uint, void*);
-void winode(uint, struct dinode*);
-void rinode(uint inum, struct dinode *ip);
-void rsect(uint sec, void *buf);
-uint ialloc(ushort type);
-void iappend(uint inum, void *p, int n);
+void wsect(uint32_t, void*);
+void winode(uint32_t, struct dinode*);
+void rinode(uint32_t inum, struct dinode *ip);
+void rsect(uint32_t sec, void *buf);
+uint32_t ialloc(uint16_t type);
+void iappend(uint32_t inum, void *p, int n);
 
 // convert to intel byte order
-ushort
-xshort(ushort x)
+uint16_t
+xshort(uint16_t x)
 {
-  ushort y;
-  uchar *a = (uchar*)&y;
+  uint16_t y;
+  uint8_t *a = (uint8_t*)&y;
   a[0] = x;
   a[1] = x >> 8;
   return y;
 }
 
-uint
-xint(uint x)
+uint32_t
+xint(uint32_t x)
 {
-  uint y;
-  uchar *a = (uchar*)&y;
+  uint32_t y;
+  uint8_t *a = (uint8_t*)&y;
   a[0] = x;
   a[1] = x >> 8;
   a[2] = x >> 16;
@@ -68,7 +68,7 @@ int
 main(int argc, char *argv[])
 {
   int i, cc, fd;
-  uint rootino, inum, off;
+  uint32_t rootino, inum, off;
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 }
 
 void
-wsect(uint sec, void *buf)
+wsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -181,10 +181,10 @@ wsect(uint sec, void *buf)
 }
 
 void
-winode(uint inum, struct dinode *ip)
+winode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -195,10 +195,10 @@ winode(uint inum, struct dinode *ip)
 }
 
 void
-rinode(uint inum, struct dinode *ip)
+rinode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -208,7 +208,7 @@ rinode(uint inum, struct dinode *ip)
 }
 
 void
-rsect(uint sec, void *buf)
+rsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -220,10 +220,10 @@ rsect(uint sec, void *buf)
   }
 }
 
-uint
-ialloc(ushort type)
+uint32_t
+ialloc(uint16_t type)
 {
-  uint inum = freeinode++;
+  uint32_t inum = freeinode++;
   struct dinode din;
 
   bzero(&din, sizeof(din));
@@ -237,7 +237,7 @@ ialloc(ushort type)
 void
 balloc(int used)
 {
-  uchar buf[BSIZE];
+  uint8_t buf[BSIZE];
   int i;
 
   printf("balloc: first %d blocks have been allocated\n", used);
@@ -253,14 +253,14 @@ balloc(int used)
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
 void
-iappend(uint inum, void *xp, int n)
+iappend(uint32_t inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint fbn, off, n1;
+  uint32_t fbn, off, n1;
   struct dinode din;
   char buf[BSIZE];
-  uint indirect[NINDIRECT];
-  uint x;
+  uint32_t indirect[NINDIRECT];
+  uint32_t x;
 
   rinode(inum, &din);
   off = xint(din.size);

--- a/src-headers/arbitrate.h
+++ b/src-headers/arbitrate.h
@@ -3,9 +3,9 @@
 #include <spinlock.h>
 
 struct arbitrate_entry {
-    uint type;
-    uint resource_id;
-    uint owner;
+    uint32_t type;
+    uint32_t resource_id;
+    uint32_t owner;
 };
 
 struct arbitrate_table {
@@ -13,10 +13,10 @@ struct arbitrate_table {
     struct arbitrate_entry entries[16];
 };
 
-typedef int (*arbitrate_policy_t)(uint type, uint resource_id,
-                                   uint current_owner, uint new_owner);
+typedef int (*arbitrate_policy_t)(uint32_t type, uint32_t resource_id,
+                                   uint32_t current_owner, uint32_t new_owner);
 
 void arbitrate_init(arbitrate_policy_t policy);
 void arbitrate_use_table(struct arbitrate_table *t);
 void arbitrate_register_policy(arbitrate_policy_t policy);
-int arbitrate_request(uint type, uint resource_id, uint owner);
+int arbitrate_request(uint32_t type, uint32_t resource_id, uint32_t owner);

--- a/src-headers/buf.h
+++ b/src-headers/buf.h
@@ -2,15 +2,15 @@
 
 struct buf {
   int flags;
-  uint dev;
-  uint blockno;
+  uint32_t dev;
+  uint32_t blockno;
   struct sleeplock lock;
   size_t refcnt;
   size_t rcref; // number of read-side references
   struct buf *prev; // LRU cache list
   struct buf *next;
   struct buf *qnext; // disk queue
-  uchar data[BSIZE];
+  uint8_t data[BSIZE];
 };
 #define B_VALID 0x2  // buffer has been read from disk
 #define B_DIRTY 0x4  // buffer needs to be written to disk

--- a/src-headers/cap.h
+++ b/src-headers/cap.h
@@ -16,9 +16,9 @@ struct cap_entry {
     uint16_t type;
     uint16_t refcnt;
     uint16_t epoch;
-    uint resource;
-    uint rights;
-    uint owner;
+    uint32_t resource;
+    uint32_t rights;
+    uint32_t owner;
 };
 // The capability table layout is part of the public ABI.  All translation
 // units (C and C++) rely on this size and alignment.  Expected size: 20 bytes
@@ -29,18 +29,18 @@ static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
 _Static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
 #endif
 
-extern uint global_epoch;
+extern uint32_t global_epoch;
 
 void cap_table_init(void);
-int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner);
-int cap_table_lookup(uint id, struct cap_entry *out);
-void cap_table_inc(uint id);
-void cap_table_dec(uint id);
-int cap_table_remove(uint id);
+int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights, uint32_t owner);
+int cap_table_lookup(uint32_t id, struct cap_entry *out);
+void cap_table_inc(uint32_t id);
+void cap_table_dec(uint32_t id);
+int cap_table_remove(uint32_t id);
 /*
  * Revoke the capability identified by 'id'. The function increments the
  * internal epoch counter encoded in the upper 16 bits of the identifier and
  * marks the entry free. Revocation fails if incrementing would cause the
  * epoch to wrap past 0xffff.
  */
-int cap_revoke(uint id);
+int cap_revoke(uint32_t id);

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -5,21 +5,21 @@
 
 exo_cap cap_alloc_page(void);
 [[nodiscard]] int cap_unbind_page(exo_cap cap);
-[[nodiscard]] int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap);
+[[nodiscard]] int cap_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap);
 [[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write);
 void cap_flush_block(exo_blockcap *cap, void *data);
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len);
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len);
 [[nodiscard]] int cap_set_timer(void (*handler)(void));
-[[nodiscard]] int cap_set_gas(uint64 amount);
+[[nodiscard]] int cap_set_gas(uint64_t amount);
 [[nodiscard]] int cap_get_gas(void);
 [[nodiscard]] int cap_out_of_gas(void);
 void cap_yield_to(context_t **old, context_t *target);
 [[nodiscard]] int cap_yield_to_cap(exo_cap target);
-[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64 off,
-                                uint64 n);
-[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64 off,
-                                 uint64 n);
+[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64_t off,
+                                uint64_t n);
+[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64_t off,
+                                 uint64_t n);
 [[nodiscard]] int cap_ipc_echo_demo(void);
 [[nodiscard]] int cap_inc(uint16_t id);
 [[nodiscard]] int cap_dec(uint16_t id);

--- a/src-headers/date.h
+++ b/src-headers/date.h
@@ -1,10 +1,10 @@
 #pragma once
 
 struct rtcdate {
-  uint second;
-  uint minute;
-  uint hour;
-  uint day;
-  uint month;
-  uint year;
+  uint32_t second;
+  uint32_t minute;
+  uint32_t hour;
+  uint32_t day;
+  uint32_t month;
+  uint32_t year;
 };

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -45,7 +45,7 @@ extern struct ptable ptable;
 
 // bio.c
 void binit(void);
-struct buf *bread(uint, uint);
+struct buf *bread(uint32_t, uint32_t);
 void brelse(struct buf *);
 void bwrite(struct buf *);
 
@@ -70,9 +70,9 @@ int filewrite(struct file *, char *, size_t n);
 
 // fs.c
 void readsb(int dev, struct superblock *sb);
-int dirlink(struct inode *, char *, uint);
-struct inode *dirlookup(struct inode *, char *, uint *);
-struct inode *ialloc(uint, short);
+int dirlink(struct inode *, char *, uint32_t);
+struct inode *dirlookup(struct inode *, char *, uint32_t *);
+struct inode *ialloc(uint32_t, short);
 struct inode *idup(struct inode *);
 void iinit(int dev);
 void ilock(struct inode *);
@@ -83,9 +83,9 @@ void iupdate(struct inode *);
 int namecmp(const char *, const char *);
 struct inode *namei(char *);
 struct inode *nameiparent(char *, char *);
-int readi(struct inode *, char *, uint, size_t);
+int readi(struct inode *, char *, uint32_t, size_t);
 void stati(struct inode *, struct stat *);
-int writei(struct inode *, char *, uint, size_t);
+int writei(struct inode *, char *, uint32_t, size_t);
 
 // ide.c
 void ideinit(void);
@@ -94,7 +94,7 @@ void iderw(struct buf *);
 
 // ioapic.c
 void ioapicenable(int irq, int cpu);
-extern uchar ioapicid;
+extern uint8_t ioapicid;
 void ioapicinit(void);
 
 // kalloc.c
@@ -109,10 +109,10 @@ void kbdintr(void);
 // lapic.c
 void cmostime(struct rtcdate *r);
 int lapicid(void);
-extern volatile uint *lapic;
+extern volatile uint32_t *lapic;
 void lapiceoi(void);
 void lapicinit(void);
-void lapicstartap(uchar, uint);
+void lapicstartap(uint8_t, uint32_t);
 void microdelay(int);
 
 // log.c
@@ -156,7 +156,7 @@ void userinit(void);
 int wait(void);
 void wakeup(void *);
 void yield(void);
-struct proc *pctr_lookup(uint);
+struct proc *pctr_lookup(uint32_t);
 struct proc *allocproc(void);
 
 // swtch.S
@@ -164,7 +164,7 @@ void swtch(context_t **, context_t *);
 
 // spinlock.c
 void acquire(struct spinlock *);
-void getcallerpcs(void *, uint *);
+void getcallerpcs(void *, uint32_t *);
 int holding(struct spinlock *);
 void initlock(struct spinlock *, char *);
 void release(struct spinlock *);
@@ -203,7 +203,7 @@ void timerinit(void);
 
 // trap.c
 void idtinit(void);
-extern uint ticks;
+extern uint32_t ticks;
 void tvinit(void);
 extern struct spinlock tickslock;
 void exo_pctr_transfer(struct trapframe *);
@@ -221,42 +221,42 @@ pde_t *setupkvm(void);
 pml4e_t *setupkvm64(void);
 #endif
 char *uva2ka(pde_t *, char *);
-int allocuvm(pde_t *, uint, uint);
-int deallocuvm(pde_t *, uint, uint);
+int allocuvm(pde_t *, uint32_t, uint32_t);
+int deallocuvm(pde_t *, uint32_t, uint32_t);
 void freevm(pde_t *);
-void inituvm(pde_t *, char *, uint);
-int loaduvm(pde_t *, char *, struct inode *, uint, uint);
-pde_t *copyuvm(pde_t *, uint);
+void inituvm(pde_t *, char *, uint32_t);
+int loaduvm(pde_t *, char *, struct inode *, uint32_t, uint32_t);
+pde_t *copyuvm(pde_t *, uint32_t);
 void switchuvm(struct proc *);
 void switchkvm(void);
 #ifdef __x86_64__
-int copyout(pde_t *, uint64, void *, uint);
+int copyout(pde_t *, uint64_t, void *, uint32_t);
 #else
-int copyout(pde_t *, uint, void *, uint);
+int copyout(pde_t *, uint32_t, void *, uint32_t);
 #endif
 
 void clearpteu(pde_t *pgdir, char *uva);
 #ifdef __x86_64__
-int insert_pte(pde_t *, void *, uint64, int);
+int insert_pte(pde_t *, void *, uint64_t, int);
 #else
-int insert_pte(pde_t *, void *, uint, int);
+int insert_pte(pde_t *, void *, uint32_t, int);
 #endif
 exo_cap exo_alloc_page(void);
 int exo_unbind_page(exo_cap);
-exo_cap cap_new(uint id, uint rights, uint owner);
+exo_cap cap_new(uint32_t id, uint32_t rights, uint32_t owner);
 int cap_verify(exo_cap);
-struct exo_blockcap exo_alloc_block(uint dev, uint rights);
+struct exo_blockcap exo_alloc_block(uint32_t dev, uint32_t rights);
 int exo_bind_block(struct exo_blockcap *, struct buf *, int);
 void exo_flush_block(struct exo_blockcap *, void *);
-exo_cap exo_alloc_irq(uint irq, uint rights);
-int exo_irq_wait(exo_cap cap, uint *irq);
+exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights);
+int exo_irq_wait(exo_cap cap, uint32_t *irq);
 int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint irq);
-exo_cap exo_alloc_ioport(uint port);
-exo_cap exo_bind_irq(uint irq);
-exo_cap exo_alloc_dma(uint chan);
+void irq_trigger(uint32_t irq);
+exo_cap exo_alloc_ioport(uint32_t port);
+exo_cap exo_bind_irq(uint32_t irq);
+exo_cap exo_alloc_dma(uint32_t chan);
 void cap_table_init(void);
-int cap_table_alloc(uint16_t, uint, uint, uint);
+int cap_table_alloc(uint16_t, uint32_t, uint32_t, uint32_t);
 int cap_table_lookup(uint16_t, struct cap_entry *);
 void cap_table_inc(uint16_t);
 void cap_table_dec(uint16_t);

--- a/src-headers/elf.h
+++ b/src-headers/elf.h
@@ -6,33 +6,33 @@
 
 // File header
 struct elfhdr {
-  uint magic;  // must equal ELF_MAGIC
-  uchar elf[12];
-  ushort type;
-  ushort machine;
-  uint version;
-  uint entry;
-  uint phoff;
-  uint shoff;
-  uint flags;
-  ushort ehsize;
-  ushort phentsize;
-  ushort phnum;
-  ushort shentsize;
-  ushort shnum;
-  ushort shstrndx;
+  uint32_t magic;  // must equal ELF_MAGIC
+  uint8_t elf[12];
+  uint16_t type;
+  uint16_t machine;
+  uint32_t version;
+  uint32_t entry;
+  uint32_t phoff;
+  uint32_t shoff;
+  uint32_t flags;
+  uint16_t ehsize;
+  uint16_t phentsize;
+  uint16_t phnum;
+  uint16_t shentsize;
+  uint16_t shnum;
+  uint16_t shstrndx;
 };
 
 // Program section header
 struct proghdr {
-  uint type;
-  uint off;
-  uint vaddr;
-  uint paddr;
-  uint filesz;
-  uint memsz;
-  uint flags;
-  uint align;
+  uint32_t type;
+  uint32_t off;
+  uint32_t vaddr;
+  uint32_t paddr;
+  uint32_t filesz;
+  uint32_t memsz;
+  uint32_t flags;
+  uint32_t align;
 };
 
 // Values for Proghdr type

--- a/src-headers/endpoint.h
+++ b/src-headers/endpoint.h
@@ -5,14 +5,14 @@
 struct endpoint {
   struct spinlock lock;
   zipc_msg_t *q;
-  uint size;
-  uint r, w;
+  uint32_t size;
+  uint32_t r, w;
   int inited;
   const struct msg_type_desc *desc;
 };
 
 void endpoint_init(struct endpoint *ep);
-void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint32_t size,
                      const struct msg_type_desc *desc);
 void endpoint_send(struct endpoint *ep, zipc_msg_t *m);
 [[nodiscard]] int endpoint_recv(struct endpoint *ep, zipc_msg_t *m);

--- a/src-headers/exo_cpu.h
+++ b/src-headers/exo_cpu.h
@@ -16,38 +16,38 @@
 #define EXO_CONTEXT_T
 #if defined(__x86_64__)
 struct context64 {
-  uint64 r15;
-  uint64 r14;
-  uint64 r13;
-  uint64 r12;
-  uint64 rbx;
-  uint64 rbp;
-  uint64 rip;
+  uint64_t r15;
+  uint64_t r14;
+  uint64_t r13;
+  uint64_t r12;
+  uint64_t rbx;
+  uint64_t rbp;
+  uint64_t rip;
 };
 typedef struct context64 context_t;
 #elif defined(__aarch64__)
 struct context64 {
-  uint64 x19;
-  uint64 x20;
-  uint64 x21;
-  uint64 x22;
-  uint64 x23;
-  uint64 x24;
-  uint64 x25;
-  uint64 x26;
-  uint64 x27;
-  uint64 x28;
-  uint64 fp;
-  uint64 lr;
+  uint64_t x19;
+  uint64_t x20;
+  uint64_t x21;
+  uint64_t x22;
+  uint64_t x23;
+  uint64_t x24;
+  uint64_t x25;
+  uint64_t x26;
+  uint64_t x27;
+  uint64_t x28;
+  uint64_t fp;
+  uint64_t lr;
 };
 typedef struct context64 context_t;
 #else
 struct context {
-  uint edi;
-  uint esi;
-  uint ebx;
-  uint ebp;
-  uint eip;
+  uint32_t edi;
+  uint32_t esi;
+  uint32_t ebx;
+  uint32_t ebp;
+  uint32_t eip;
 };
 typedef struct context context_t;
 #endif

--- a/src-headers/exo_irq.h
+++ b/src-headers/exo_irq.h
@@ -7,10 +7,10 @@
 extern "C" {
 #endif
 
-exo_cap exo_alloc_irq(uint irq, uint rights);
-[[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq);
+exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights);
+[[nodiscard]] int exo_irq_wait(exo_cap cap, uint32_t *irq);
 [[nodiscard]] int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint irq);
+void irq_trigger(uint32_t irq);
 
 #ifdef __cplusplus
 }

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -9,7 +9,7 @@
 #define EXO_RIGHT_X 0x4
 #define EXO_RIGHT_CTL 0x8
 
-static inline int cap_has_rights(uint rights, uint need) {
+static inline int cap_has_rights(uint32_t rights, uint32_t need) {
   return (rights & need) == need;
 }
 
@@ -31,7 +31,7 @@ exo_cap exo_alloc_page(void);
 
 /* Allocate a disk block capability for device 'dev'.  On success the
  * capability is stored in *cap and zero is returned. */
-[[nodiscard]] int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap);
+[[nodiscard]] int exo_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap);
 
 /* Bind the block capability to the buffer 'data'.  If 'write' is non-zero the
  * contents of the buffer are written to disk; otherwise the block is read into
@@ -39,13 +39,13 @@ exo_cap exo_alloc_page(void);
 [[nodiscard]] int exo_bind_block(exo_blockcap *cap, void *data, int write);
 
 /* Allocate a capability referencing an I/O port. */
-exo_cap exo_alloc_ioport(uint port);
+exo_cap exo_alloc_ioport(uint32_t port);
 
 /* Allocate a capability for an IRQ line. */
-exo_cap exo_bind_irq(uint irq);
+exo_cap exo_bind_irq(uint32_t irq);
 
 /* Allocate a DMA buffer page and return a capability for channel 'chan'. */
-exo_cap exo_alloc_dma(uint chan);
+exo_cap exo_alloc_dma(uint32_t chan);
 
 /* Switch to the context referenced by 'target'.  The caller's context must be
  * saved in a user-managed structure.  The kernel does not choose the next
@@ -54,26 +54,26 @@ exo_cap exo_alloc_dma(uint chan);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any queuing
  * or flow control is managed in user space. */
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64 len);
+[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
-[[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64 off,
-                                uint64 n);
-[[nodiscard]] int exo_write_disk(exo_blockcap cap, const void *src, uint64 off,
-                                 uint64 n);
+[[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64_t off,
+                                uint64_t n);
+[[nodiscard]] int exo_write_disk(exo_blockcap cap, const void *src, uint64_t off,
+                                 uint64_t n);
 
 /* Allocate and wait/acknowledge interrupt events. */
-exo_cap exo_alloc_irq(uint irq, uint rights);
-[[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq);
+exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights);
+[[nodiscard]] int exo_irq_wait(exo_cap cap, uint32_t *irq);
 [[nodiscard]] int exo_irq_ack(exo_cap cap);
 /* Allocate capabilities for I/O ports, IRQs, and DMA channels. */
-exo_cap exo_alloc_ioport(uint port);
-exo_cap exo_bind_irq(uint irq);
-exo_cap exo_alloc_dma(uint chan);
+exo_cap exo_alloc_ioport(uint32_t port);
+exo_cap exo_bind_irq(uint32_t irq);
+exo_cap exo_alloc_dma(uint32_t chan);
 #endif /* EXO_KERNEL */
 
 /* Enumeration of syscall numbers for the primitives. */

--- a/src-headers/file.h
+++ b/src-headers/file.h
@@ -14,8 +14,8 @@ struct file {
 
 // in-memory copy of an inode
 struct inode {
-  uint dev;           // Device number
-  uint inum;          // Inode number
+  uint32_t dev;           // Device number
+  uint32_t inum;          // Inode number
   size_t ref;            // Reference count
   struct sleeplock lock; // protects everything below here
   int valid;          // inode has been read from disk?
@@ -25,7 +25,7 @@ struct inode {
   short minor;
   short nlink;
   size_t size;
-  uint addrs[NDIRECT+1];
+  uint32_t addrs[NDIRECT+1];
 };
 // Must match on-disk inode layout when compiled for 32-bit targets.
 #ifndef __x86_64__

--- a/src-headers/fs.h
+++ b/src-headers/fs.h
@@ -14,17 +14,17 @@
 // mkfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 struct superblock {
-  uint size;         // Size of file system image (blocks)
-  uint nblocks;      // Number of data blocks
-  uint ninodes;      // Number of inodes.
-  uint nlog;         // Number of log blocks
-  uint logstart;     // Block number of first log block
-  uint inodestart;   // Block number of first inode block
-  uint bmapstart;    // Block number of first free map block
+  uint32_t size;         // Size of file system image (blocks)
+  uint32_t nblocks;      // Number of data blocks
+  uint32_t ninodes;      // Number of inodes.
+  uint32_t nlog;         // Number of log blocks
+  uint32_t logstart;     // Block number of first log block
+  uint32_t inodestart;   // Block number of first inode block
+  uint32_t bmapstart;    // Block number of first free map block
 };
 
 #define NDIRECT 12
-#define NINDIRECT (BSIZE / sizeof(uint))
+#define NINDIRECT (BSIZE / sizeof(uint32_t))
 #define MAXFILE (NDIRECT + NINDIRECT*1024)
 
 // On-disk inode structure
@@ -33,8 +33,8 @@ struct dinode {
   short major;          // Major device number (T_DEV only)
   short minor;          // Minor device number (T_DEV only)
   short nlink;          // Number of links to inode in file system
-  uint size;            // Size of file (bytes)
-  uint addrs[NDIRECT+1];   // Data block addresses
+  uint32_t size;            // Size of file (bytes)
+  uint32_t addrs[NDIRECT+1];   // Data block addresses
 };
 
 // Inodes per block.
@@ -53,7 +53,7 @@ struct dinode {
 #define DIRSIZ 14
 
 struct dirent {
-  ushort inum;
+  uint16_t inum;
   char name[DIRSIZ];
 };
 

--- a/src-headers/kbd.h
+++ b/src-headers/kbd.h
@@ -33,7 +33,7 @@
 // C('A') == Control-A
 #define C(x) (x - '@')
 
-static uchar shiftcode[256] =
+static uint8_t shiftcode[256] =
 {
   [0x1D] CTL,
   [0x2A] SHIFT,
@@ -43,14 +43,14 @@ static uchar shiftcode[256] =
   [0xB8] ALT
 };
 
-static uchar togglecode[256] =
+static uint8_t togglecode[256] =
 {
   [0x3A] CAPSLOCK,
   [0x45] NUMLOCK,
   [0x46] SCROLLLOCK
 };
 
-static uchar normalmap[256] =
+static uint8_t normalmap[256] =
 {
   NO,   0x1B, '1',  '2',  '3',  '4',  '5',  '6',  // 0x00
   '7',  '8',  '9',  '0',  '-',  '=',  '\b', '\t',
@@ -72,7 +72,7 @@ static uchar normalmap[256] =
   [0xD2] KEY_INS,   [0xD3] KEY_DEL
 };
 
-static uchar shiftmap[256] =
+static uint8_t shiftmap[256] =
 {
   NO,   033,  '!',  '@',  '#',  '$',  '%',  '^',  // 0x00
   '&',  '*',  '(',  ')',  '_',  '+',  '\b', '\t',
@@ -94,7 +94,7 @@ static uchar shiftmap[256] =
   [0xD2] KEY_INS,   [0xD3] KEY_DEL
 };
 
-static uchar ctlmap[256] =
+static uint8_t ctlmap[256] =
 {
   NO,      NO,      NO,      NO,      NO,      NO,      NO,      NO,
   NO,      NO,      NO,      NO,      NO,      NO,      NO,      NO,

--- a/src-headers/libfs.h
+++ b/src-headers/libfs.h
@@ -5,5 +5,5 @@
 
 int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);
-int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
+int fs_alloc_block(uint32_t dev, uint32_t rights, struct exo_blockcap *cap);
 int fs_bind_block(struct exo_blockcap *cap, void *data, int write);

--- a/src-headers/libos/file.h
+++ b/src-headers/libos/file.h
@@ -13,8 +13,8 @@ struct file {
 
 // in-memory copy of an inode
 struct inode {
-  uint dev;              // Device number
-  uint inum;             // Inode number
+  uint32_t dev;              // Device number
+  uint32_t inum;             // Inode number
   size_t ref;            // Reference count
   struct sleeplock lock; // protects everything below here
   int valid;             // inode has been read from disk?
@@ -24,7 +24,7 @@ struct inode {
   short minor;
   short nlink;
   size_t size;
-  uint addrs[NDIRECT + 1];
+  uint32_t addrs[NDIRECT + 1];
 };
 
 // table mapping major device number to

--- a/src-headers/libos/fs.h
+++ b/src-headers/libos/fs.h
@@ -14,17 +14,17 @@
 // mkfs computes the super block and builds an initial file system. The
 // super block describes the disk layout:
 struct superblock {
-  uint size;         // Size of file system image (blocks)
-  uint nblocks;      // Number of data blocks
-  uint ninodes;      // Number of inodes.
-  uint nlog;         // Number of log blocks
-  uint logstart;     // Block number of first log block
-  uint inodestart;   // Block number of first inode block
-  uint bmapstart;    // Block number of first free map block
+  uint32_t size;         // Size of file system image (blocks)
+  uint32_t nblocks;      // Number of data blocks
+  uint32_t ninodes;      // Number of inodes.
+  uint32_t nlog;         // Number of log blocks
+  uint32_t logstart;     // Block number of first log block
+  uint32_t inodestart;   // Block number of first inode block
+  uint32_t bmapstart;    // Block number of first free map block
 };
 
 #define NDIRECT 12
-#define NINDIRECT (BSIZE / sizeof(uint))
+#define NINDIRECT (BSIZE / sizeof(uint32_t))
 #define MAXFILE (NDIRECT + NINDIRECT*1024)
 
 // On-disk inode structure
@@ -33,8 +33,8 @@ struct dinode {
   short major;          // Major device number (T_DEV only)
   short minor;          // Minor device number (T_DEV only)
   short nlink;          // Number of links to inode in file system
-  uint size;            // Size of file (bytes)
-  uint addrs[NDIRECT+1];   // Data block addresses
+  uint32_t size;            // Size of file (bytes)
+  uint32_t addrs[NDIRECT+1];   // Data block addresses
 };
 
 // Inodes per block.
@@ -53,6 +53,6 @@ struct dinode {
 #define DIRSIZ 14
 
 struct dirent {
-  ushort inum;
+  uint16_t inum;
   char name[DIRSIZ];
 };

--- a/src-headers/libos/libfs.h
+++ b/src-headers/libos/libfs.h
@@ -5,7 +5,7 @@
 
 int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);
-int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
+int fs_alloc_block(uint32_t dev, uint32_t rights, struct exo_blockcap *cap);
 int fs_bind_block(struct exo_blockcap *cap, void *data, int write);
 void libfs_init(void);
 struct file *libfs_open(const char *path, int flags);

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct ticketlock {
   _Atomic unsigned short head;
@@ -13,7 +14,7 @@ struct spinlock {
   struct ticketlock ticket;
   char *name;
   struct cpu *cpu;
-  unsigned int pcs[10];
+  uint32_t pcs[10];
 };
 
 #ifdef SPINLOCK_NO_STUBS

--- a/src-headers/math_core.h
+++ b/src-headers/math_core.h
@@ -2,6 +2,6 @@
 #include "types.h"
 
 double phi(void);
-uint64 fib(uint n);
-uint64 gcd(uint64 a, uint64 b);
+uint64_t fib(uint32_t n);
+uint64_t gcd(uint64_t a, uint64_t b);
 size_t phi_align(size_t n);

--- a/src-headers/memlayout.h
+++ b/src-headers/memlayout.h
@@ -29,10 +29,10 @@
 #endif
 
 #ifdef __x86_64__
-#define V2P(a) (((uint64)(a)) - KERNBASE)
-#define P2V(a) ((void *)((uint64)(a) + KERNBASE))
+#define V2P(a) (((uint64_t)(a)) - KERNBASE)
+#define P2V(a) ((void *)((uint64_t)(a) + KERNBASE))
 #else
-#define V2P(a) (((uint)(a)) - KERNBASE)
+#define V2P(a) (((uint32_t)(a)) - KERNBASE)
 #define P2V(a) ((void *)(((char *)(a)) + KERNBASE))
 #endif
 

--- a/src-headers/mmu.h
+++ b/src-headers/mmu.h
@@ -26,19 +26,19 @@
 #ifndef __ASSEMBLER__
 // Segment Descriptor
 struct segdesc {
-  uint lim_15_0 : 16;  // Low bits of segment limit
-  uint base_15_0 : 16; // Low bits of segment base address
-  uint base_23_16 : 8; // Middle bits of segment base address
-  uint type : 4;       // Segment type (see STS_ constants)
-  uint s : 1;          // 0 = system, 1 = application
-  uint dpl : 2;        // Descriptor Privilege Level
-  uint p : 1;          // Present
-  uint lim_19_16 : 4;  // High bits of segment limit
-  uint avl : 1;        // Unused (available for software use)
-  uint rsv1 : 1;       // Reserved
-  uint db : 1;         // 0 = 16-bit segment, 1 = 32-bit segment
-  uint g : 1;          // Granularity: limit scaled by 4K when set
-  uint base_31_24 : 8; // High bits of segment base address
+  uint32_t lim_15_0 : 16;  // Low bits of segment limit
+  uint32_t base_15_0 : 16; // Low bits of segment base address
+  uint32_t base_23_16 : 8; // Middle bits of segment base address
+  uint32_t type : 4;       // Segment type (see STS_ constants)
+  uint32_t s : 1;          // 0 = system, 1 = application
+  uint32_t dpl : 2;        // Descriptor Privilege Level
+  uint32_t p : 1;          // Present
+  uint32_t lim_19_16 : 4;  // High bits of segment limit
+  uint32_t avl : 1;        // Unused (available for software use)
+  uint32_t rsv1 : 1;       // Reserved
+  uint32_t db : 1;         // 0 = 16-bit segment, 1 = 32-bit segment
+  uint32_t g : 1;          // Granularity: limit scaled by 4K when set
+  uint32_t base_31_24 : 8; // High bits of segment base address
 };
 // Ensure the descriptor is exactly 8 bytes so assembly structures match
 _Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
@@ -46,32 +46,32 @@ _Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
 // Normal segment
 #define SEG(type, base, lim, dpl)                                              \
   (struct segdesc){((lim) >> 12) & 0xffff,                                     \
-                   (uint)(base) & 0xffff,                                      \
-                   ((uint)(base) >> 16) & 0xff,                                \
+                   (uint32_t)(base) & 0xffff,                                      \
+                   ((uint32_t)(base) >> 16) & 0xff,                                \
                    type,                                                       \
                    1,                                                          \
                    dpl,                                                        \
                    1,                                                          \
-                   (uint)(lim) >> 28,                                          \
+                   (uint32_t)(lim) >> 28,                                          \
                    0,                                                          \
                    0,                                                          \
                    1,                                                          \
                    1,                                                          \
-                   (uint)(base) >> 24}
+                   (uint32_t)(base) >> 24}
 #define SEG16(type, base, lim, dpl)                                            \
   (struct segdesc){(lim) & 0xffff,                                             \
-                   (uint)(base) & 0xffff,                                      \
-                   ((uint)(base) >> 16) & 0xff,                                \
+                   (uint32_t)(base) & 0xffff,                                      \
+                   ((uint32_t)(base) >> 16) & 0xff,                                \
                    type,                                                       \
                    1,                                                          \
                    dpl,                                                        \
                    1,                                                          \
-                   (uint)(lim) >> 16,                                          \
+                   (uint32_t)(lim) >> 16,                                          \
                    0,                                                          \
                    0,                                                          \
                    1,                                                          \
                    0,                                                          \
-                   (uint)(base) >> 24}
+                   (uint32_t)(base) >> 24}
 #endif
 
 #define DPL_USER 0x3 // User DPL
@@ -96,22 +96,22 @@ _Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
 
 // page directory index
 #ifdef __x86_64__
-#define PML4(va) (((uint64)(va) >> PML4SHIFT) & 0x1FF)
-#define PDPX(va) (((uint64)(va) >> PDPSHIFT) & 0x1FF)
-#define PDX(va) (((uint64)(va) >> PDSHIFT) & 0x1FF)
-#define PTX(va) (((uint64)(va) >> PTSHIFT) & 0x1FF)
+#define PML4(va) (((uint64_t)(va) >> PML4SHIFT) & 0x1FF)
+#define PDPX(va) (((uint64_t)(va) >> PDPSHIFT) & 0x1FF)
+#define PDX(va) (((uint64_t)(va) >> PDSHIFT) & 0x1FF)
+#define PTX(va) (((uint64_t)(va) >> PTSHIFT) & 0x1FF)
 #else
-#define PDX(va) (((uint)(va) >> PDXSHIFT) & 0x3FF)
-#define PTX(va) (((uint)(va) >> PTXSHIFT) & 0x3FF)
+#define PDX(va) (((uint32_t)(va) >> PDXSHIFT) & 0x3FF)
+#define PTX(va) (((uint32_t)(va) >> PTXSHIFT) & 0x3FF)
 #endif
 
 // construct virtual address from indexes and offset
 #ifdef __x86_64__
 #define PGADDR(l4, l3, l2, l1, o)                                              \
-  ((uint64)((l4) << PML4SHIFT | (l3) << PDPSHIFT | (l2) << PDSHIFT |           \
+  ((uint64_t)((l4) << PML4SHIFT | (l3) << PDPSHIFT | (l2) << PDSHIFT |           \
             (l1) << PTSHIFT | (o)))
 #else
-#define PGADDR(d, t, o) ((uint)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
+#define PGADDR(d, t, o) ((uint32_t)((d) << PDXSHIFT | (t) << PTXSHIFT | (o)))
 #endif
 
 // Page directory and page table constants.
@@ -150,74 +150,74 @@ _Static_assert(sizeof(struct segdesc) == 8, "struct segdesc size incorrect");
 
 // Address in page table or page directory entry
 #ifdef __x86_64__
-#define PTE_ADDR(pte) ((uint64)(pte) & ~0xFFF)
-#define PTE_FLAGS(pte) ((uint64)(pte) & 0xFFF)
+#define PTE_ADDR(pte) ((uint64_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint64_t)(pte) & 0xFFF)
 #else
-#define PTE_ADDR(pte) ((uint)(pte) & ~0xFFF)
-#define PTE_FLAGS(pte) ((uint)(pte) & 0xFFF)
+#define PTE_ADDR(pte) ((uint32_t)(pte) & ~0xFFF)
+#define PTE_FLAGS(pte) ((uint32_t)(pte) & 0xFFF)
 #endif
 
 #ifndef __ASSEMBLER__
 #ifdef __x86_64__
-typedef uint64 pte_t;
-typedef uint64 pdpe_t;
-typedef uint64 pml4e_t;
+typedef uint64_t pte_t;
+typedef uint64_t pdpe_t;
+typedef uint64_t pml4e_t;
 #else
-typedef uint pte_t;
+typedef uint32_t pte_t;
 #endif
 
 // Task state segment format
 struct taskstate {
-  uint link;  // Old ts selector
-  uint esp0;  // Stack pointers and segment selectors
-  ushort ss0; //   after an increase in privilege level
-  ushort padding1;
-  uint *esp1;
-  ushort ss1;
-  ushort padding2;
-  uint *esp2;
-  ushort ss2;
-  ushort padding3;
+  uint32_t link;  // Old ts selector
+  uint32_t esp0;  // Stack pointers and segment selectors
+  uint16_t ss0; //   after an increase in privilege level
+  uint16_t padding1;
+  uint32_t *esp1;
+  uint16_t ss1;
+  uint16_t padding2;
+  uint32_t *esp2;
+  uint16_t ss2;
+  uint16_t padding3;
   void *cr3; // Page directory base
-  uint *eip; // Saved state from last task switch
-  uint eflags;
-  uint eax; // More saved state (registers)
-  uint ecx;
-  uint edx;
-  uint ebx;
-  uint *esp;
-  uint *ebp;
-  uint esi;
-  uint edi;
-  ushort es; // Even more saved state (segment selectors)
-  ushort padding4;
-  ushort cs;
-  ushort padding5;
-  ushort ss;
-  ushort padding6;
-  ushort ds;
-  ushort padding7;
-  ushort fs;
-  ushort padding8;
-  ushort gs;
-  ushort padding9;
-  ushort ldt;
-  ushort padding10;
-  ushort t;    // Trap on task switch
-  ushort iomb; // I/O map base address
+  uint32_t *eip; // Saved state from last task switch
+  uint32_t eflags;
+  uint32_t eax; // More saved state (registers)
+  uint32_t ecx;
+  uint32_t edx;
+  uint32_t ebx;
+  uint32_t *esp;
+  uint32_t *ebp;
+  uint32_t esi;
+  uint32_t edi;
+  uint16_t es; // Even more saved state (segment selectors)
+  uint16_t padding4;
+  uint16_t cs;
+  uint16_t padding5;
+  uint16_t ss;
+  uint16_t padding6;
+  uint16_t ds;
+  uint16_t padding7;
+  uint16_t fs;
+  uint16_t padding8;
+  uint16_t gs;
+  uint16_t padding9;
+  uint16_t ldt;
+  uint16_t padding10;
+  uint16_t t;    // Trap on task switch
+  uint16_t iomb; // I/O map base address
 };
 
 // Gate descriptors for interrupts and traps
 struct gatedesc {
-  uint off_15_0 : 16;  // low 16 bits of offset in segment
-  uint cs : 16;        // code segment selector
-  uint args : 5;       // # args, 0 for interrupt/trap gates
-  uint rsv1 : 3;       // reserved(should be zero I guess)
-  uint type : 4;       // type(STS_{IG32,TG32})
-  uint s : 1;          // must be 0 (system)
-  uint dpl : 2;        // descriptor(meaning new) privilege level
-  uint p : 1;          // Present
-  uint off_31_16 : 16; // high bits of offset in segment
+  uint32_t off_15_0 : 16;  // low 16 bits of offset in segment
+  uint32_t cs : 16;        // code segment selector
+  uint32_t args : 5;       // # args, 0 for interrupt/trap gates
+  uint32_t rsv1 : 3;       // reserved(should be zero I guess)
+  uint32_t type : 4;       // type(STS_{IG32,TG32})
+  uint32_t s : 1;          // must be 0 (system)
+  uint32_t dpl : 2;        // descriptor(meaning new) privilege level
+  uint32_t p : 1;          // Present
+  uint32_t off_31_16 : 16; // high bits of offset in segment
 };
 
 // Set up a normal interrupt/trap gate descriptor.
@@ -230,7 +230,7 @@ struct gatedesc {
 //        this interrupt/trap gate explicitly using an int instruction.
 #define SETGATE(gate, istrap, sel, off, d)                                     \
   {                                                                            \
-    (gate).off_15_0 = (uint)(off) & 0xffff;                                    \
+    (gate).off_15_0 = (uint32_t)(off) & 0xffff;                                    \
     (gate).cs = (sel);                                                         \
     (gate).args = 0;                                                           \
     (gate).rsv1 = 0;                                                           \
@@ -238,7 +238,7 @@ struct gatedesc {
     (gate).s = 0;                                                              \
     (gate).dpl = (d);                                                          \
     (gate).p = 1;                                                              \
-    (gate).off_31_16 = (uint)(off) >> 16;                                      \
+    (gate).off_31_16 = (uint32_t)(off) >> 16;                                      \
   }
 
 #endif

--- a/src-headers/mp.h
+++ b/src-headers/mp.h
@@ -3,48 +3,48 @@
 // See MultiProcessor Specification Version 1.[14]
 
 struct mp {             // floating pointer
-  uchar signature[4];           // "_MP_"
-  uint physaddr;                // phys addr of MP config table
-  uchar length;                 // 1
-  uchar specrev;                // [14]
-  uchar checksum;               // all bytes must add up to 0
-  uchar type;                   // MP system config type
-  uchar imcrp;
-  uchar reserved[3];
+  uint8_t signature[4];           // "_MP_"
+  uint32_t physaddr;                // phys addr of MP config table
+  uint8_t length;                 // 1
+  uint8_t specrev;                // [14]
+  uint8_t checksum;               // all bytes must add up to 0
+  uint8_t type;                   // MP system config type
+  uint8_t imcrp;
+  uint8_t reserved[3];
 } __attribute__((packed));
 
 struct mpconf {         // configuration table header
-  uchar signature[4];           // "PCMP"
-  ushort length;                // total table length
-  uchar version;                // [14]
-  uchar checksum;               // all bytes must add up to 0
-  uchar product[20];            // product id
-  uint *oemtable;               // OEM table pointer
-  ushort oemlength;             // OEM table length
-  ushort entry;                 // entry count
-  uint *lapicaddr;              // address of local APIC
-  ushort xlength;               // extended table length
-  uchar xchecksum;              // extended table checksum
-  uchar reserved;
+  uint8_t signature[4];           // "PCMP"
+  uint16_t length;                // total table length
+  uint8_t version;                // [14]
+  uint8_t checksum;               // all bytes must add up to 0
+  uint8_t product[20];            // product id
+  uint32_t *oemtable;               // OEM table pointer
+  uint16_t oemlength;             // OEM table length
+  uint16_t entry;                 // entry count
+  uint32_t *lapicaddr;              // address of local APIC
+  uint16_t xlength;               // extended table length
+  uint8_t xchecksum;              // extended table checksum
+  uint8_t reserved;
 } __attribute__((packed));
 
 struct mpproc {         // processor table entry
-  uchar type;                   // entry type (0)
-  uchar apicid;                 // local APIC id
-  uchar version;                // local APIC verison
-  uchar flags;                  // CPU flags
+  uint8_t type;                   // entry type (0)
+  uint8_t apicid;                 // local APIC id
+  uint8_t version;                // local APIC verison
+  uint8_t flags;                  // CPU flags
     #define MPBOOT 0x02           // This proc is the bootstrap processor.
-  uchar signature[4];           // CPU signature
-  uint feature;                 // feature flags from CPUID instruction
-  uchar reserved[8];
+  uint8_t signature[4];           // CPU signature
+  uint32_t feature;                 // feature flags from CPUID instruction
+  uint8_t reserved[8];
 } __attribute__((packed));
 
 struct mpioapic {       // I/O APIC table entry
-  uchar type;                   // entry type (2)
-  uchar apicno;                 // I/O APIC id
-  uchar version;                // I/O APIC version
-  uchar flags;                  // I/O APIC flags
-  uint *addr;                  // I/O APIC address
+  uint8_t type;                   // entry type (2)
+  uint8_t apicno;                 // I/O APIC id
+  uint8_t version;                // I/O APIC version
+  uint8_t flags;                  // I/O APIC flags
+  uint32_t *addr;                  // I/O APIC address
 } __attribute__((packed));
 
 // Table entry types

--- a/src-headers/proc.h
+++ b/src-headers/proc.h
@@ -16,13 +16,13 @@ typedef struct context context_t;
 
 // Per-CPU state
 struct cpu {
-  uchar apicid;                // Local APIC ID
+  uint8_t apicid;                // Local APIC ID
   context_t *scheduler;        // swtch() here to enter scheduler
 #ifndef __aarch64__
   struct taskstate ts;         // Used by x86 to find stack for interrupt
   struct segdesc gdt[NSEGS];   // x86 global descriptor table
 #endif
-  volatile uint started;       // Has the CPU started?
+  volatile uint32_t started;       // Has the CPU started?
   int ncli;                    // Depth of pushcli nesting.
   int intena;                  // Were interrupts enabled before pushcli?
   struct proc *proc;           // The process running on this cpu or null
@@ -43,11 +43,11 @@ extern int ncpu;
 // at the "Switch stacks" comment. Switch doesn't save eip explicitly,
 // but it is on the stack and allocproc() manipulates it.
 struct context {
-  uint edi;
-  uint esi;
-  uint ebx;
-  uint ebp;
-  uint eip;
+  uint32_t edi;
+  uint32_t esi;
+  uint32_t ebx;
+  uint32_t ebp;
+  uint32_t eip;
 };
 // Check that context saved by swtch.S matches this layout (5 registers)
 _Static_assert(sizeof(struct context) == 20, "struct context size incorrect");
@@ -99,9 +99,9 @@ struct proc {
   struct file *ofile[NOFILE];    // Open files
   struct inode *cwd;             // Current directory
   char name[16];                 // Process name (debugging)
-  uint pctr_cap;                 // Capability for exo_pctr_transfer
-  volatile uint pctr_signal;     // Signal counter for exo_pctr_transfer
-  uint64 gas_remaining;          // Remaining CPU budget
+  uint32_t pctr_cap;                 // Capability for exo_pctr_transfer
+  volatile uint32_t pctr_signal;     // Signal counter for exo_pctr_transfer
+  uint64_t gas_remaining;          // Remaining CPU budget
   int preferred_node;            // NUMA allocation preference
   int out_of_gas;                // Flag set when gas runs out
 };

--- a/src-headers/spinlock.h
+++ b/src-headers/spinlock.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 struct ticketlock {
   _Atomic unsigned short head;
@@ -13,7 +14,7 @@ struct spinlock {
   struct ticketlock ticket;
   char *name;
   struct cpu *cpu;
-  unsigned pcs[10];
+  uint32_t pcs[10];
 };
 
 #ifndef SPINLOCK_NO_STUBS

--- a/src-headers/types.h
+++ b/src-headers/types.h
@@ -1,9 +1,9 @@
 #pragma once
+#include <stdint.h>
 
-typedef unsigned int   uint;
-typedef unsigned short ushort;
-typedef unsigned char  uchar;
-typedef unsigned int   uint32;
-typedef unsigned long  uint64;
-typedef unsigned long  uintptr;
-
+typedef uint8_t  uchar;
+typedef uint16_t ushort;
+typedef uint32_t uint;
+typedef uint32_t uint32;
+typedef uint64_t uint64;
+typedef uintptr_t uintptr;

--- a/src-headers/x86.h
+++ b/src-headers/x86.h
@@ -1,15 +1,15 @@
 #pragma once
 
-static inline uchar
-inb(ushort port)
+static inline uint8_t
+inb(uint16_t port)
 {
-  uchar data;
+  uint8_t data;
   __asm__ volatile("inb %1,%0" : "=a"(data) : "d"(port));
   return data;
 }
 
 static inline void
-outb(ushort port, uchar data)
+outb(uint16_t port, uint8_t data)
 {
   __asm__ volatile("outb %0,%1" : : "a"(data), "d"(port));
 }

--- a/src-kernel/arbitrate.c
+++ b/src-kernel/arbitrate.c
@@ -11,7 +11,7 @@ static struct arbitrate_table default_table;
 static int initialized;
 static struct arbitrate_table *tbl = &default_table;
 
-static int default_policy(uint type, uint res, uint cur, uint newo) {
+static int default_policy(uint32_t type, uint32_t res, uint32_t cur, uint32_t newo) {
     (void)type; (void)res; (void)cur; (void)newo;
     return 0; // keep current owner
 }
@@ -45,7 +45,7 @@ arbitrate_register_policy(arbitrate_policy_t p)
 }
 
 int
-arbitrate_request(uint type, uint resource_id, uint owner)
+arbitrate_request(uint32_t type, uint32_t resource_id, uint32_t owner)
 {
     if(!initialized)
         arbitrate_init(policy);
@@ -88,7 +88,7 @@ arbitrate_request(uint type, uint resource_id, uint owner)
 
     int allow = policy ? policy(type, resource_id, match->owner, owner) : 0;
     if(allow){
-        uint old = match->owner;
+        uint32_t old = match->owner;
         match->owner = owner;
         release(&tbl->lock);
         cprintf("arbitrate: replace %u/%u %u -> %u\n", type, resource_id, old, owner);

--- a/src-kernel/beatty_sched.c
+++ b/src-kernel/beatty_sched.c
@@ -11,7 +11,7 @@ static struct exo_stream beatty_stream;
 
 static exo_cap task_a;
 static exo_cap task_b;
-static uint64 na, nb;
+static uint64_t na, nb;
 static double alpha;
 static double beta;
 
@@ -31,7 +31,7 @@ static void beatty_yield(void) {
   double va = alpha * (double)na;
   double vb = beta * (double)nb;
   exo_cap next;
-  if ((uint64)va < (uint64)vb) {
+  if ((uint64_t)va < (uint64_t)vb) {
     next = task_a;
     na++;
   } else {

--- a/src-kernel/bio.c
+++ b/src-kernel/bio.c
@@ -63,7 +63,7 @@ binit(void)
 // If not found, allocate a buffer.
 // In either case, return locked buffer.
 static struct buf*
-bget(uint dev, uint blockno)
+bget(uint32_t dev, uint32_t blockno)
 {
   struct buf *b;
 
@@ -98,7 +98,7 @@ bget(uint dev, uint blockno)
 
 // Return a locked buf with the contents of the indicated block.
 struct buf*
-bread(uint dev, uint blockno)
+bread(uint32_t dev, uint32_t blockno)
 {
   struct buf *b;
   rcu_read_lock();

--- a/src-kernel/bootmain.c
+++ b/src-kernel/bootmain.c
@@ -13,7 +13,7 @@
 
 #define SECTSIZE  512
 
-void readseg(uchar*, uint, uint);
+void readseg(uint8_t*, uint32_t, uint32_t);
 
 void
 bootmain(void)
@@ -21,22 +21,22 @@ bootmain(void)
   struct elfhdr *elf;
   struct proghdr *ph, *eph;
   void (*entry)(void);
-  uchar* pa;
+  uint8_t* pa;
 
   elf = (struct elfhdr*)0x10000;  // scratch space
 
   // Read 1st page off disk
-  readseg((uchar*)elf, 4096, 0);
+  readseg((uint8_t*)elf, 4096, 0);
 
   // Is this an ELF executable?
   if(elf->magic != ELF_MAGIC)
     return;  // let bootasm.S handle error
 
   // Load each program segment (ignores ph flags).
-  ph = (struct proghdr*)((uchar*)elf + elf->phoff);
+  ph = (struct proghdr*)((uint8_t*)elf + elf->phoff);
   eph = ph + elf->phnum;
   for(; ph < eph; ph++){
-    pa = (uchar*)(uintptr_t)ph->paddr;
+    pa = (uint8_t*)(uintptr_t)ph->paddr;
     readseg(pa, ph->filesz, ph->off);
     if(ph->memsz > ph->filesz)
       stosb(pa + ph->filesz, 0, ph->memsz - ph->filesz);
@@ -58,7 +58,7 @@ waitdisk(void)
 
 // Read a single sector at offset into dst.
 void
-readsect(void *dst, uint offset)
+readsect(void *dst, uint32_t offset)
 {
   // Issue command.
   waitdisk();
@@ -77,9 +77,9 @@ readsect(void *dst, uint offset)
 // Read 'count' bytes at 'offset' from kernel into physical address 'pa'.
 // Might copy more than asked.
 void
-readseg(uchar* pa, uint count, uint offset)
+readseg(uint8_t* pa, uint32_t count, uint32_t offset)
 {
-  uchar* epa;
+  uint8_t* epa;
 
   epa = pa + count;
 

--- a/src-kernel/cap.c
+++ b/src-kernel/cap.c
@@ -15,11 +15,11 @@ static const uint8_t cap_secret[32] = {
 };
 
 /* 64-bit FNV-1a hash used by the HMAC implementation */
-static uint64
-fnv64(const uint8_t *data, size_t len, uint64 seed)
+static uint64_t
+fnv64(const uint8_t *data, size_t len, uint64_t seed)
 {
-    const uint64 prime = 1099511628211ULL;
-    uint64 h = seed;
+    const uint64_t prime = 1099511628211ULL;
+    uint64_t h = seed;
     for(size_t i = 0; i < len; i++) {
         h ^= data[i];
         h *= prime;
@@ -31,16 +31,16 @@ fnv64(const uint8_t *data, size_t len, uint64 seed)
 static void
 hash256(const uint8_t *data, size_t len, hash256_t *out)
 {
-    const uint64 basis = 14695981039346656037ULL;
+    const uint64_t basis = 14695981039346656037ULL;
     for(int i = 0; i < 4; i++)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 
 /* Derive the authentication tag for a capability. */
 static void
-compute_tag(uint id, uint rights, uint owner, hash256_t *out)
+compute_tag(uint32_t id, uint32_t rights, uint32_t owner, hash256_t *out)
 {
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+    struct { uint32_t id; uint32_t rights; uint32_t owner; } tmp = { id, rights, owner };
     uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
 
     memmove(buf, cap_secret, sizeof(cap_secret));
@@ -49,7 +49,7 @@ compute_tag(uint id, uint rights, uint owner, hash256_t *out)
 }
 
 exo_cap
-cap_new(uint id, uint rights, uint owner)
+cap_new(uint32_t id, uint32_t rights, uint32_t owner)
 {
     exo_cap c;
     c.id = id;
@@ -69,14 +69,14 @@ cap_verify(exo_cap c)
 
 /* Allocate capabilities for additional resource types. */
 exo_cap
-exo_alloc_ioport(uint port)
+exo_alloc_ioport(uint32_t port)
 {
     int id = cap_table_alloc(CAP_TYPE_IOPORT, port, 0, myproc()->pid);
-    return cap_new(id >= 0 ? (uint)id : 0, 0, myproc()->pid);
+    return cap_new(id >= 0 ? (uint32_t)id : 0, 0, myproc()->pid);
 }
 
 exo_cap
-exo_bind_irq(uint irq)
+exo_bind_irq(uint32_t irq)
 {
     int id = cap_table_alloc(CAP_TYPE_IRQ, irq, 0, myproc()->pid);
 
@@ -84,7 +84,7 @@ exo_bind_irq(uint irq)
 }
 
 exo_cap
-exo_alloc_dma(uint chan)
+exo_alloc_dma(uint32_t chan)
 {
     int id = cap_table_alloc(CAP_TYPE_DMA, chan, 0, myproc()->pid);
     return cap_new(id >= 0 ? id : 0, 0, myproc()->pid);

--- a/src-kernel/cap_table.c
+++ b/src-kernel/cap_table.c
@@ -7,7 +7,7 @@
 
 static struct spinlock cap_lock;
 static struct cap_entry cap_table[CAP_MAX];
-uint global_epoch;
+uint32_t global_epoch;
 
 void cap_table_init(void) {
     initlock(&cap_lock, "captbl");
@@ -15,7 +15,7 @@ void cap_table_init(void) {
     global_epoch = 0;
 }
 
-int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
+int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights, uint32_t owner) {
     if(type == CAP_TYPE_NONE || type > CAP_TYPE_DMA)
         return -1;
     acquire(&cap_lock);
@@ -26,7 +26,7 @@ int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
             cap_table[i].rights = rights;
             cap_table[i].owner = owner;
             cap_table[i].refcnt = 1;
-            uint id = ((uint)cap_table[i].epoch << 16) | i;
+            uint32_t id = ((uint32_t)cap_table[i].epoch << 16) | i;
             release(&cap_lock);
             return id;
         }
@@ -35,7 +35,7 @@ int cap_table_alloc(uint16_t type, uint resource, uint rights, uint owner) {
     return -1;
 }
 
-int cap_table_lookup(uint id, struct cap_entry *out) {
+int cap_table_lookup(uint32_t id, struct cap_entry *out) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -50,7 +50,7 @@ int cap_table_lookup(uint id, struct cap_entry *out) {
     return 0;
 }
 
-void cap_table_inc(uint id) {
+void cap_table_inc(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -60,7 +60,7 @@ void cap_table_inc(uint id) {
     release(&cap_lock);
 }
 
-void cap_table_dec(uint id) {
+void cap_table_dec(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -72,7 +72,7 @@ void cap_table_dec(uint id) {
     release(&cap_lock);
 }
 
-int cap_table_remove(uint id) {
+int cap_table_remove(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);
@@ -86,7 +86,7 @@ int cap_table_remove(uint id) {
     return 0;
 }
 
-int cap_revoke(uint id) {
+int cap_revoke(uint32_t id) {
     uint16_t idx = id & 0xffff;
     uint16_t epoch = id >> 16;
     acquire(&cap_lock);

--- a/src-kernel/console.c
+++ b/src-kernel/console.c
@@ -32,7 +32,7 @@ printint(int xx, int base, int sign)
   static char digits[] = "0123456789abcdef";
   char buf[16];
   int i;
-  uint x;
+  uint32_t x;
 
   if(sign && (sign = xx < 0))
     x = -xx;
@@ -109,7 +109,7 @@ void
 panic(char *s)
 {
   int i;
-  uint pcs[10];
+  uint32_t pcs[10];
 
   cli();
   cons.locking = 0;
@@ -128,7 +128,7 @@ panic(char *s)
 //PAGEBREAK: 50
 #define BACKSPACE 0x100
 #define CRTPORT 0x3d4
-static ushort *crt = (ushort*)P2V(0xb8000);  // CGA memory
+static uint16_t *crt = (uint16_t*)P2V(0xb8000);  // CGA memory
 
 static void
 cgaputc(int c)

--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -15,7 +15,7 @@ void endpoint_init(struct endpoint *ep) {
   }
 }
 
-void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint size,
+void endpoint_config(struct endpoint *ep, zipc_msg_t *buf, uint32_t size,
                      const struct msg_type_desc *desc) {
   endpoint_init(ep);
   acquire(&ep->lock);
@@ -31,7 +31,7 @@ void endpoint_send(struct endpoint *ep, zipc_msg_t *m) {
   acquire(&ep->lock);
   if (ep->q && ep->size && ep->w - ep->r < ep->size) {
     size_t sz = msg_desc_size(ep->desc);
-    const uchar *p = (const uchar *)m;
+    const uint8_t *p = (const uint8_t *)m;
     for (size_t i = sz; i < sizeof(zipc_msg_t); i++)
       if (p[i]) {
         release(&ep->lock);

--- a/src-kernel/exec.c
+++ b/src-kernel/exec.c
@@ -12,7 +12,7 @@ exec(char *path, char **argv)
 {
   char *s, *last;
   int i, off;
-  uint argc, sz, sp, ustack[3+MAXARG+1];
+  uint32_t argc, sz, sp, ustack[3+MAXARG+1];
   struct elfhdr elf;
   struct inode *ip;
   struct proghdr ph;

--- a/src-kernel/exo.c
+++ b/src-kernel/exo.c
@@ -12,7 +12,7 @@
 extern struct ptable ptable;
 
 void exo_pctr_transfer(struct trapframe *tf) {
-  uint cap = tf->eax;
+  uint32_t cap = tf->eax;
   struct proc *p;
 
   acquire(&ptable.lock);

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -18,8 +18,8 @@ struct ipc_entry {
 static struct {
   struct spinlock lock;
   struct ipc_entry buf[IPC_BUFSZ];
-  uint r;
-  uint w;
+  uint32_t r;
+  uint32_t w;
   int inited;
 } ipcs;
 

--- a/src-kernel/fastipc.c
+++ b/src-kernel/fastipc.c
@@ -9,7 +9,7 @@
 static struct {
     struct spinlock lock;
     zipc_msg_t buf[FASTIPC_BUFSZ];
-    uint r, w;
+    uint32_t r, w;
     int inited;
 } fastipc;
 
@@ -43,7 +43,7 @@ sys_ipc_fast(void)
     fastipc_init();
     acquire(&fastipc.lock);
     if(fastipc.r == fastipc.w){
-        p->tf->rsi = (uint64)-1;
+        p->tf->rsi = (uint64_t)-1;
         p->tf->rdx = p->tf->rcx = p->tf->r8 = 0;
     } else {
         zipc_msg_t m = fastipc.buf[fastipc.r % FASTIPC_BUFSZ];

--- a/src-kernel/include/sleeplock.h
+++ b/src-kernel/include/sleeplock.h
@@ -2,7 +2,7 @@
 
 // Long-term locks for processes
 struct sleeplock {
-  uint locked;       // Is the lock held?
+  uint32_t locked;       // Is the lock held?
   struct spinlock lk; // spinlock protecting this sleep lock
   
   // For debugging:

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -16,7 +16,7 @@ struct spinlock {
   // For debugging:
   char *name;      // Name of lock.
   struct cpu *cpu; // The cpu holding the lock.
-  uint pcs[10];    // The call stack (an array of program counters)
+  uint32_t pcs[10];    // The call stack (an array of program counters)
                    // that locked the lock.
 };
 

--- a/src-kernel/ioapic.c
+++ b/src-kernel/ioapic.c
@@ -26,12 +26,12 @@ volatile struct ioapic *ioapic;
 
 // IO APIC MMIO structure: write reg, then read or write data.
 struct ioapic {
-  uint reg;
-  uint pad[3];
-  uint data;
+  uint32_t reg;
+  uint32_t pad[3];
+  uint32_t data;
 };
 
-static uint
+static uint32_t
 ioapicread(int reg)
 {
   ioapic->reg = reg;
@@ -39,7 +39,7 @@ ioapicread(int reg)
 }
 
 static void
-ioapicwrite(int reg, uint data)
+ioapicwrite(int reg, uint32_t data)
 {
   ioapic->reg = reg;
   ioapic->data = data;

--- a/src-kernel/kbd.c
+++ b/src-kernel/kbd.c
@@ -6,11 +6,11 @@
 int
 kbdgetc(void)
 {
-  static uint shift;
-  static uchar *charcode[4] = {
+  static uint32_t shift;
+  static uint8_t *charcode[4] = {
     normalmap, shiftmap, ctlmap, ctlmap
   };
-  uint st, data, c;
+  uint32_t st, data, c;
 
   st = inb(KBSTATP);
   if((st & KBS_DIB) == 0)

--- a/src-kernel/lapic.c
+++ b/src-kernel/lapic.c
@@ -10,7 +10,7 @@
 #include "mmu.h"
 #include "x86.h"
 
-// Local APIC registers, divided by 4 for use as uint[] indices.
+// Local APIC registers, divided by 4 for use as uint32_t[] indices.
 #define ID      (0x0020/4)   // ID
 #define VER     (0x0030/4)   // Version
 #define TPR     (0x0080/4)   // Task Priority
@@ -41,7 +41,7 @@
 #define TCCR    (0x0390/4)   // Timer Current Count
 #define TDCR    (0x03E0/4)   // Timer Divide Configuration
 
-volatile uint *lapic;  // Initialized in mp.c
+volatile uint32_t *lapic;  // Initialized in mp.c
 
 //PAGEBREAK!
 static void
@@ -126,17 +126,17 @@ microdelay(int us)
 // Start additional processor running entry code at addr.
 // See Appendix B of MultiProcessor Specification.
 void
-lapicstartap(uchar apicid, uint addr)
+lapicstartap(uint8_t apicid, uint32_t addr)
 {
   int i;
-  ushort *wrv;
+  uint16_t *wrv;
 
   // "The BSP must initialize CMOS shutdown code to 0AH
   // and the warm reset vector (DWORD based at 40:67) to point at
   // the AP startup code prior to the [universal startup algorithm]."
   outb(CMOS_PORT, 0xF);  // offset 0xF is shutdown code
   outb(CMOS_PORT+1, 0x0A);
-  wrv = (ushort*)P2V((0x40<<4 | 0x67));  // Warm reset vector
+  wrv = (uint16_t*)P2V((0x40<<4 | 0x67));  // Warm reset vector
   wrv[0] = 0;
   wrv[1] = addr >> 4;
 
@@ -171,8 +171,8 @@ lapicstartap(uchar apicid, uint addr)
 #define MONTH   0x08
 #define YEAR    0x09
 
-static uint
-cmos_read(uint reg)
+static uint32_t
+cmos_read(uint32_t reg)
 {
   outb(CMOS_PORT,  reg);
   microdelay(200);

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -72,11 +72,11 @@ pde_t entrypgdir[]; // For entry.S
 // Start the non-boot (AP) processors.
 static void startothers(void) {
 #ifdef __x86_64__
-  extern uchar _binary_entryother64_start[], _binary_entryother64_size[];
+  extern uint8_t _binary_entryother64_start[], _binary_entryother64_size[];
 #else
-  extern uchar _binary_entryother_start[], _binary_entryother_size[];
+  extern uint8_t _binary_entryother_start[], _binary_entryother_size[];
 #endif
-  uchar *code;
+  uint8_t *code;
   struct cpu *c;
   char *stack;
 
@@ -89,7 +89,7 @@ static void startothers(void) {
   memmove(code, _binary_entryother64_start, (size_t)_binary_entryother64_size);
 
 #else
-  memmove(code, _binary_entryother_start, (uint)_binary_entryother_size);
+  memmove(code, _binary_entryother_start, (uint32_t)_binary_entryother_size);
 #endif
 
   for (c = cpus; c < cpus + ncpu; c++) {
@@ -103,7 +103,7 @@ static void startothers(void) {
     if (stack == 0)
       panic("startothers: out of memory");
 #ifdef __x86_64__
-    *(uint64 *)(code - 8) = (uint64)stack + KSTACKSIZE;
+    *(uint64_t *)(code - 8) = (uint64_t)stack + KSTACKSIZE;
     *(void (**)(void))(code - 16) = mpenter;
 #else
     *(void **)(code - 4) = stack + KSTACKSIZE;

--- a/src-kernel/memide.c
+++ b/src-kernel/memide.c
@@ -13,16 +13,16 @@
 #include "fs.h"
 #include "buf.h"
 
-extern uchar _binary_fs_img_start[], _binary_fs_img_size[];
+extern uint8_t _binary_fs_img_start[], _binary_fs_img_size[];
 
 static int disksize;
-static uchar *memdisk;
+static uint8_t *memdisk;
 
 void
 ideinit(void)
 {
   memdisk = _binary_fs_img_start;
-  disksize = (uint)_binary_fs_img_size/BSIZE;
+  disksize = (uint32_t)_binary_fs_img_size/BSIZE;
 }
 
 // Interrupt handler.
@@ -38,7 +38,7 @@ ideintr(void)
 void
 iderw(struct buf *b)
 {
-  uchar *p;
+  uint8_t *p;
 
   if(!holdingsleep(&b->lock))
     panic("iderw: buf not locked");

--- a/src-kernel/mkfs.c
+++ b/src-kernel/mkfs.c
@@ -29,34 +29,34 @@ int nblocks;  // Number of data blocks
 int fsfd;
 struct superblock sb;
 char zeroes[BSIZE];
-uint freeinode = 1;
-uint freeblock;
+uint32_t freeinode = 1;
+uint32_t freeblock;
 
 
 void balloc(int);
-void wsect(uint, void*);
-void winode(uint, struct dinode*);
-void rinode(uint inum, struct dinode *ip);
-void rsect(uint sec, void *buf);
-uint ialloc(ushort type);
-void iappend(uint inum, void *p, int n);
+void wsect(uint32_t, void*);
+void winode(uint32_t, struct dinode*);
+void rinode(uint32_t inum, struct dinode *ip);
+void rsect(uint32_t sec, void *buf);
+uint32_t ialloc(uint16_t type);
+void iappend(uint32_t inum, void *p, int n);
 
 // convert to intel byte order
-ushort
-xshort(ushort x)
+uint16_t
+xshort(uint16_t x)
 {
-  ushort y;
-  uchar *a = (uchar*)&y;
+  uint16_t y;
+  uint8_t *a = (uint8_t*)&y;
   a[0] = x;
   a[1] = x >> 8;
   return y;
 }
 
-uint
-xint(uint x)
+uint32_t
+xint(uint32_t x)
 {
-  uint y;
-  uchar *a = (uchar*)&y;
+  uint32_t y;
+  uint8_t *a = (uint8_t*)&y;
   a[0] = x;
   a[1] = x >> 8;
   a[2] = x >> 16;
@@ -68,7 +68,7 @@ int
 main(int argc, char *argv[])
 {
   int i, cc, fd;
-  uint rootino, inum, off;
+  uint32_t rootino, inum, off;
   struct dirent de;
   char buf[BSIZE];
   struct dinode din;
@@ -168,7 +168,7 @@ main(int argc, char *argv[])
 }
 
 void
-wsect(uint sec, void *buf)
+wsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -181,10 +181,10 @@ wsect(uint sec, void *buf)
 }
 
 void
-winode(uint inum, struct dinode *ip)
+winode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -195,10 +195,10 @@ winode(uint inum, struct dinode *ip)
 }
 
 void
-rinode(uint inum, struct dinode *ip)
+rinode(uint32_t inum, struct dinode *ip)
 {
   char buf[BSIZE];
-  uint bn;
+  uint32_t bn;
   struct dinode *dip;
 
   bn = IBLOCK(inum, sb);
@@ -208,7 +208,7 @@ rinode(uint inum, struct dinode *ip)
 }
 
 void
-rsect(uint sec, void *buf)
+rsect(uint32_t sec, void *buf)
 {
   if(lseek(fsfd, sec * BSIZE, 0) != sec * BSIZE){
     perror("lseek");
@@ -220,10 +220,10 @@ rsect(uint sec, void *buf)
   }
 }
 
-uint
-ialloc(ushort type)
+uint32_t
+ialloc(uint16_t type)
 {
-  uint inum = freeinode++;
+  uint32_t inum = freeinode++;
   struct dinode din;
 
   bzero(&din, sizeof(din));
@@ -237,7 +237,7 @@ ialloc(ushort type)
 void
 balloc(int used)
 {
-  uchar buf[BSIZE];
+  uint8_t buf[BSIZE];
   int i;
 
   printf("balloc: first %d blocks have been allocated\n", used);
@@ -253,14 +253,14 @@ balloc(int used)
 #define min(a, b) ((a) < (b) ? (a) : (b))
 
 void
-iappend(uint inum, void *xp, int n)
+iappend(uint32_t inum, void *xp, int n)
 {
   char *p = (char*)xp;
-  uint fbn, off, n1;
+  uint32_t fbn, off, n1;
   struct dinode din;
   char buf[BSIZE];
-  uint indirect[NINDIRECT];
-  uint x;
+  uint32_t indirect[NINDIRECT];
+  uint32_t x;
 
   rinode(inum, &din);
   off = xint(din.size);

--- a/src-kernel/mmu64.c
+++ b/src-kernel/mmu64.c
@@ -51,13 +51,13 @@ walkpml4(pml4e_t *pml4, const void *va, int alloc)
 }
 
 static int
-mappages64(pml4e_t *pml4, void *va, uint size, uint64 pa, int perm)
+mappages64(pml4e_t *pml4, void *va, uint32_t size, uint64_t pa, int perm)
 {
   char *a, *last;
   pte_t *pte;
 
-  a = (char*)PGROUNDDOWN((uint64)va);
-  last = (char*)PGROUNDDOWN(((uint64)va) + size - 1);
+  a = (char*)PGROUNDDOWN((uint64_t)va);
+  last = (char*)PGROUNDDOWN(((uint64_t)va) + size - 1);
   for(;;){
     if((pte = walkpml4(pml4, a, 1)) == 0)
       return -1;
@@ -76,7 +76,7 @@ pml4e_t*
 setupkvm64(void)
 {
   pml4e_t *pml4;
-  struct kmap { void *virt; uint phys_start; uint phys_end; int perm; };
+  struct kmap { void *virt; uint32_t phys_start; uint32_t phys_end; int perm; };
   static struct kmap kmap[] = {
     { (void*)KERNBASE, 0,             EXTMEM,    PTE_W},
     { (void*)KERNLINK, V2P(KERNLINK), V2P(data), 0},
@@ -92,7 +92,7 @@ setupkvm64(void)
     panic("PHYSTOP too high");
   for(k = kmap; k < &kmap[NELEM(kmap)]; k++)
     if(mappages64(pml4, k->virt, k->phys_end - k->phys_start,
-                  (uint64)k->phys_start, k->perm) < 0) {
+                  (uint64_t)k->phys_start, k->perm) < 0) {
       kfree((char*)pml4);
       return 0;
     }

--- a/src-kernel/mp.c
+++ b/src-kernel/mp.c
@@ -13,10 +13,10 @@
 
 struct cpu cpus[NCPU];
 int ncpu;
-uchar ioapicid;
+uint8_t ioapicid;
 
-static uchar
-sum(uchar *addr, int len)
+static uint8_t
+sum(uint8_t *addr, int len)
 {
   int i, sum;
 
@@ -28,9 +28,9 @@ sum(uchar *addr, int len)
 
 // Look for an MP structure in the len bytes at addr.
 static struct mp*
-mpsearch1(uint a, int len)
+mpsearch1(uint32_t a, int len)
 {
-  uchar *e, *p, *addr;
+  uint8_t *e, *p, *addr;
 
   addr = P2V(a);
   e = addr+len;
@@ -48,11 +48,11 @@ mpsearch1(uint a, int len)
 static struct mp*
 mpsearch(void)
 {
-  uchar *bda;
-  uint p;
+  uint8_t *bda;
+  uint32_t p;
   struct mp *mp;
 
-  bda = (uchar *) P2V(0x400);
+  bda = (uint8_t *) P2V(0x400);
   if((p = ((bda[0x0F]<<8)| bda[0x0E]) << 4)){
     if((mp = mpsearch1(p, 1024)))
       return mp;
@@ -82,7 +82,7 @@ mpconfig(struct mp **pmp)
     return 0;
   if(conf->version != 1 && conf->version != 4)
     return 0;
-  if(sum((uchar*)conf, conf->length) != 0)
+  if(sum((uint8_t*)conf, conf->length) != 0)
     return 0;
   *pmp = mp;
   return conf;
@@ -91,7 +91,7 @@ mpconfig(struct mp **pmp)
 void
 mpinit(void)
 {
-  uchar *p, *e;
+  uint8_t *p, *e;
   int ismp;
   struct mp *mp;
   struct mpconf *conf;
@@ -101,8 +101,8 @@ mpinit(void)
   if((conf = mpconfig(&mp)) == 0)
     panic("Expect to run on an SMP");
   ismp = 1;
-  lapic = (uint*)conf->lapicaddr;
-  for(p=(uchar*)(conf+1), e=(uchar*)conf+conf->length; p<e; ){
+  lapic = (uint32_t*)conf->lapicaddr;
+  for(p=(uint8_t*)(conf+1), e=(uint8_t*)conf+conf->length; p<e; ){
     switch(*p){
     case MPPROC:
       proc = (struct mpproc*)p;

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -12,14 +12,14 @@ struct ptable ptable;
 static struct proc *initproc;
 
 int nextpid = 1;
-static uint nextpctr_cap = 1;
+static uint32_t nextpctr_cap = 1;
 extern void forkret(void);
 extern void trapret(void);
 
 // Map exo_pctr capabilities directly to owning processes.
 #define PCTR_HASHSIZE (NPROC * 2)
 struct pctr_entry {
-  uint cap;
+  uint32_t cap;
   struct proc *p;
 };
 static struct pctr_entry pctr_table[PCTR_HASHSIZE];
@@ -27,8 +27,8 @@ static struct pctr_entry pctr_table[PCTR_HASHSIZE];
 static void
 pctr_insert(struct proc *p)
 {
-  uint cap = p->pctr_cap;
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t cap = p->pctr_cap;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p)
     idx = (idx + 1) % PCTR_HASHSIZE;
   pctr_table[idx].cap = cap;
@@ -36,9 +36,9 @@ pctr_insert(struct proc *p)
 }
 
 static void
-pctr_remove(uint cap)
+pctr_remove(uint32_t cap)
 {
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p){
     if(pctr_table[idx].cap == cap){
       pctr_table[idx].p = 0;
@@ -59,9 +59,9 @@ pctr_remove(uint cap)
 }
 
 struct proc *
-pctr_lookup(uint cap)
+pctr_lookup(uint32_t cap)
 {
-  uint idx = cap % PCTR_HASHSIZE;
+  uint32_t idx = cap % PCTR_HASHSIZE;
   while(pctr_table[idx].p){
     if(pctr_table[idx].cap == cap)
       return pctr_table[idx].p;
@@ -172,7 +172,7 @@ found:
   *(unsigned long*)sp = (unsigned long)trapret;
 #else
   sp -= 4;
-  *(uint*)sp = (uint)trapret;
+  *(uint32_t*)sp = (uint32_t)trapret;
 #endif
 
   sp -= sizeof *p->context;
@@ -183,7 +183,7 @@ found:
 #elif defined(__aarch64__)
   p->context->lr = (unsigned long)forkret;
 #else
-  p->context->eip = (uint)forkret;
+  p->context->eip = (uint32_t)forkret;
 #endif
 
   return p;
@@ -233,7 +233,7 @@ userinit(void)
 int
 growproc(int n)
 {
-  uint sz;
+  uint32_t sz;
   struct proc *curproc = myproc();
 
   sz = curproc->sz;
@@ -617,7 +617,7 @@ procdump(void)
   int i;
   struct proc *p;
   char *state;
-  uint pc[10];
+  uint32_t pc[10];
 
   for(p = ptable.proc; p < &ptable.proc[NPROC]; p++){
     if(p->state == UNUSED)
@@ -633,7 +633,7 @@ procdump(void)
 #elif defined(__aarch64__)
       getcallerpcs((void*)p->context->fp + 2*sizeof(uintptr_t), pc);
 #else
-      getcallerpcs((uint*)p->context->ebp+2, pc);
+      getcallerpcs((uint32_t*)p->context->ebp+2, pc);
 #endif
       for(i=0; i<10 && pc[i] != 0; i++)
         cprintf(" %p", pc[i]);

--- a/src-kernel/spinlock.c
+++ b/src-kernel/spinlock.c
@@ -69,7 +69,7 @@ void release(struct spinlock *lk) { (void)lk; }
 #endif
 
 // Record the current call stack in pcs[] by following the %ebp chain.
-void getcallerpcs(void *v, uint pcs[]) {
+void getcallerpcs(void *v, uint32_t pcs[]) {
 #ifdef __x86_64__
   unsigned long *rbp;
   int i;
@@ -85,15 +85,15 @@ void getcallerpcs(void *v, uint pcs[]) {
   for (; i < 10; i++)
     pcs[i] = 0;
 #else
-  uint *ebp;
+  uint32_t *ebp;
   int i;
 
-  ebp = (uint *)v - 2;
+  ebp = (uint32_t *)v - 2;
   for (i = 0; i < 10; i++) {
-    if (ebp == 0 || ebp < (uint *)KERNBASE || ebp == (uint *)0xffffffff)
+    if (ebp == 0 || ebp < (uint32_t *)KERNBASE || ebp == (uint32_t *)0xffffffff)
       break;
     pcs[i] = ebp[1];      // saved %eip
-    ebp = (uint *)ebp[0]; // saved %ebp
+    ebp = (uint32_t *)ebp[0]; // saved %ebp
   }
   for (; i < 10; i++)
     pcs[i] = 0;

--- a/src-kernel/string.c
+++ b/src-kernel/string.c
@@ -15,7 +15,7 @@ memset(void *dst, int c, size_t n)
 int
 memcmp(const void *v1, const void *v2, size_t n)
 {
-  const uchar *s1, *s2;
+  const uint8_t *s1, *s2;
 
   s1 = v1;
   s2 = v2;
@@ -62,7 +62,7 @@ strncmp(const char *p, const char *q, size_t n)
     n--, p++, q++;
   if(n == 0)
     return 0;
-  return (uchar)*p - (uchar)*q;
+  return (uint8_t)*p - (uint8_t)*q;
 }
 
 char*

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -50,7 +50,7 @@ int argint(int n, int *ip) {
 #ifndef __x86_64__
   return fetchint((myproc()->tf->esp) + 4 + 4 * n, ip);
 #else
-  uint64 val;
+  uint64_t val;
   struct trapframe *tf = myproc()->tf;
   switch (n) {
   case 0:
@@ -90,12 +90,12 @@ argptr(int n, char **pp, size_t size)
   int i;
   if (argint(n, &i) < 0)
     return -1;
-  if (size < 0 || (uint)i >= curproc->sz || (uint)i + size > curproc->sz)
+  if (size < 0 || (uint32_t)i >= curproc->sz || (uint32_t)i + size > curproc->sz)
     return -1;
   *pp = (char *)i;
   return 0;
 #else
-  uint64 addr;
+  uint64_t addr;
   if (argint(n, (int *)&addr) < 0)
     return -1;
   if (size < 0 || addr >= curproc->sz || addr + size > curproc->sz)
@@ -116,7 +116,7 @@ int argstr(int n, char **pp) {
     return -1;
   return fetchstr(addr, pp);
 #else
-  uint64 addr;
+  uint64_t addr;
   if (argint(n, (int *)&addr) < 0)
     return -1;
   return fetchstr(addr, pp);

--- a/src-kernel/sysfile.c
+++ b/src-kernel/sysfile.c
@@ -187,7 +187,7 @@ sys_unlink(void)
   struct inode *ip, *dp;
   struct dirent de;
   char name[DIRSIZ], *path;
-  uint off;
+  uint32_t off;
 
   if(argstr(0, &path) < 0)
     return -1;
@@ -399,7 +399,7 @@ sys_exec(void)
 {
   char *path, *argv[MAXARG];
   int i;
-  uint uargv, uarg;
+  uint32_t uargv, uarg;
 
   if(argstr(0, &path) < 0 || argint(1, (int*)&uargv) < 0){
     return -1;

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -48,7 +48,7 @@ int sys_sbrk(void) {
 
 int sys_sleep(void) {
   int n;
-  uint ticks0;
+  uint32_t ticks0;
 
   if (argint(0, &n) < 0)
     return -1;
@@ -68,7 +68,7 @@ int sys_sleep(void) {
 // return how many clock tick interrupts have occurred
 // since start.
 int sys_uptime(void) {
-  uint xticks;
+  uint32_t xticks;
 
   acquire(&tickslock);
   xticks = ticks;
@@ -132,7 +132,7 @@ int sys_exo_alloc_ioport(void) {
   exo_cap *ucap;
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_ioport((uint)port);
+  exo_cap cap = exo_alloc_ioport((uint32_t)port);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -142,7 +142,7 @@ int sys_exo_bind_irq(void) {
   exo_cap *ucap;
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_bind_irq((uint)irq);
+  exo_cap cap = exo_bind_irq((uint32_t)irq);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -152,7 +152,7 @@ int sys_exo_alloc_dma(void) {
   exo_cap *ucap;
   if (argint(0, &chan) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_dma((uint)chan);
+  exo_cap cap = exo_alloc_dma((uint32_t)chan);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -212,7 +212,7 @@ int sys_exo_yield_to(void) {
 int sys_exo_read_disk(void) {
   struct exo_blockcap cap;
   char *dst;
-  uint off, n;
+  uint32_t off, n;
 
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
@@ -226,7 +226,7 @@ int sys_exo_read_disk(void) {
 int sys_exo_write_disk(void) {
   struct exo_blockcap cap;
   char *src;
-  uint off, n;
+  uint32_t off, n;
 
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argint(2, (int *)&off) < 0 ||
@@ -242,7 +242,7 @@ int sys_exo_alloc_ioport(void) {
   exo_cap *ucap;
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_ioport((uint)port);
+  exo_cap cap = exo_alloc_ioport((uint32_t)port);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -252,7 +252,7 @@ int sys_exo_bind_irq(void) {
   exo_cap *ucap;
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_bind_irq((uint)irq);
+  exo_cap cap = exo_bind_irq((uint32_t)irq);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
@@ -269,7 +269,7 @@ int sys_exo_alloc_dma(void) {
 int sys_exo_send(void) {
   exo_cap *ucap, cap;
   char *src;
-  uint n;
+  uint32_t n;
   if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)
@@ -283,7 +283,7 @@ int sys_exo_send(void) {
 int sys_exo_recv(void) {
   exo_cap *ucap, cap;
   char *dst;
-  uint n;
+  uint32_t n;
   if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
       argint(2, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
@@ -350,7 +350,7 @@ int sys_set_numa_node(void) {
 }
 
 int sys_set_gas(void) {
-  uint64 amount;
+  uint64_t amount;
   if (argint(0, (int *)&amount) < 0)
     return -1;
   myproc()->gas_remaining = amount;
@@ -380,7 +380,7 @@ int sys_cap_inc(void) {
   int id;
   if (argint(0, &id) < 0)
     return -1;
-  cap_table_inc((uint)id);
+  cap_table_inc((uint32_t)id);
   return 0;
 }
 
@@ -388,7 +388,7 @@ int sys_cap_dec(void) {
   int id;
   if (argint(0, &id) < 0)
     return -1;
-  cap_table_dec((uint)id);
+  cap_table_dec((uint32_t)id);
   return 0;
 }
 
@@ -398,14 +398,14 @@ int sys_exo_irq_alloc(void) {
   if (argint(0, &irq) < 0 || argint(1, &rights) < 0 ||
       argptr(2, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
-  exo_cap cap = exo_alloc_irq((uint)irq, (uint)rights);
+  exo_cap cap = exo_alloc_irq((uint32_t)irq, (uint32_t)rights);
   memmove(ucap, &cap, sizeof(cap));
   return 0;
 }
 
 int sys_exo_irq_wait(void) {
   exo_cap cap;
-  uint *irq_out;
+  uint32_t *irq_out;
   if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
       argptr(1, (void *)&irq_out, sizeof(*irq_out)) < 0)
     return -1;

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -10,9 +10,9 @@
 
 // Interrupt descriptor table (shared by all CPUs).
 struct gatedesc idt[256];
-extern uint vectors[]; // in vectors.S: array of 256 entry pointers
+extern uint32_t vectors[]; // in vectors.S: array of 256 entry pointers
 struct spinlock tickslock;
-uint ticks;
+uint32_t ticks;
 
 void tvinit(void) {
   int i;
@@ -66,12 +66,12 @@ void trap(struct trapframe *tf) {
     if (myproc() && myproc()->timer_upcall && (tf->cs & 3) == DPL_USER) {
 #ifndef __x86_64__
       tf->esp -= 4;
-      *(uint *)tf->esp = tf->eip;
-      tf->eip = (uint)myproc()->timer_upcall;
+      *(uint32_t *)tf->esp = tf->eip;
+      tf->eip = (uint32_t)myproc()->timer_upcall;
 #else
       tf->rsp -= 8;
-      *(uint64 *)tf->rsp = tf->rip;
-      tf->rip = (uint64)myproc()->timer_upcall;
+      *(uint64_t *)tf->rsp = tf->rip;
+      tf->rip = (uint64_t)myproc()->timer_upcall;
 #endif
     }
     break;

--- a/src-kernel/tty.c
+++ b/src-kernel/tty.c
@@ -11,9 +11,9 @@
 static struct {
   struct spinlock lock;
   char buf[INPUT_BUF];
-  uint r; // read index
-  uint w; // write index
-  uint e; // edit index
+  uint32_t r; // read index
+  uint32_t w; // write index
+  uint32_t e; // edit index
 } tty;
 
 void

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -6,7 +6,7 @@ exo_cap cap_alloc_page(void) { return exo_alloc_page(); }
 
 [[nodiscard]] int cap_unbind_page(exo_cap cap) { return exo_unbind_page(cap); }
 
-[[nodiscard]] int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
+[[nodiscard]] int cap_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
   return exo_alloc_block(dev, rights, cap);
 }
 
@@ -21,7 +21,7 @@ void cap_flush_block(exo_blockcap *cap, void *data) {
 [[nodiscard]] int cap_set_timer(void (*handler)(void)) {
   return set_timer_upcall(handler);
 }
-[[nodiscard]] int cap_set_gas(uint64 amount) { return set_gas(amount); }
+[[nodiscard]] int cap_set_gas(uint64_t amount) { return set_gas(amount); }
 [[nodiscard]] int cap_get_gas(void) { return get_gas(); }
 [[nodiscard]] int cap_out_of_gas(void) { return get_gas() <= 0; }
 
@@ -33,24 +33,24 @@ void cap_yield_to(context_t **old, context_t *target) {
   return exo_yield_to(target);
 }
 
-[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64 off,
-                                uint64 n) {
+[[nodiscard]] int cap_read_disk(exo_blockcap cap, void *dst, uint64_t off,
+                                uint64_t n) {
   return exo_read_disk(cap, dst, off, n);
 }
 
-[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64 off,
-                                 uint64 n) {
+[[nodiscard]] int cap_write_disk(exo_blockcap cap, const void *src, uint64_t off,
+                                 uint64_t n) {
   return exo_write_disk(cap, src, off, n);
 }
 
 extern int cap_revoke_syscall(void);
 int cap_revoke(void) { return cap_revoke_syscall(); }
 
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len) {
+[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len) {
   return exo_send(dest, buf, len);
 }
 
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len) {
+[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len) {
   return exo_recv(src, buf, len);
 }
 

--- a/src-uland/exo_unit_test.c
+++ b/src-uland/exo_unit_test.c
@@ -3,24 +3,24 @@
 #include <string.h>
 #include <assert.h>
 
-typedef uint32_t uint;
+typedef uint32_t uint32_t;
 
 typedef struct exo_cap {
-    uint pa;
-    uint id;
-    uint rights;
-    uint owner;
+    uint32_t pa;
+    uint32_t id;
+    uint32_t rights;
+    uint32_t owner;
 } exo_cap;
 
 typedef struct exo_blockcap {
-    uint dev;
-    uint blockno;
-    uint rights;
-    uint owner;
+    uint32_t dev;
+    uint32_t blockno;
+    uint32_t rights;
+    uint32_t owner;
 } exo_blockcap;
 
-static uint next_page = 1;
-static uint next_block = 1;
+static uint32_t next_page = 1;
+static uint32_t next_block = 1;
 static unsigned char diskbuf[512];
 
 int exo_alloc_page(exo_cap *cap) {
@@ -38,7 +38,7 @@ int exo_unbind_page(exo_cap *cap) {
     return 0;
 }
 
-int exo_alloc_block(uint dev, uint rights, exo_blockcap *cap) {
+int exo_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
     cap->dev = dev;
     cap->blockno = next_block++;
     cap->rights = rights;

--- a/src-uland/math_core.c
+++ b/src-uland/math_core.c
@@ -4,13 +4,13 @@
 double phi(void) { return 1.618033988749895; }
 
 // Compute the n-th Fibonacci number with F(0) = 0 and F(1) = 1.
-uint64 fib(uint n) {
+uint64_t fib(uint32_t n) {
   if (n == 0)
     return 0;
-  uint64 a = 0;
-  uint64 b = 1;
-  for (uint i = 1; i < n; i++) {
-    uint64 t = a + b;
+  uint64_t a = 0;
+  uint64_t b = 1;
+  for (uint32_t i = 1; i < n; i++) {
+    uint64_t t = a + b;
     a = b;
     b = t;
   }
@@ -18,7 +18,7 @@ uint64 fib(uint n) {
 }
 
 // Compute the greatest common divisor using Euclid's algorithm.
-uint64 gcd(uint64 a, uint64 b) {
+uint64_t gcd(uint64_t a, uint64_t b) {
   // Euclid's algorithm without division to avoid libgcc helpers
   while (a != b) {
     if (a > b)

--- a/src-uland/printf.c
+++ b/src-uland/printf.c
@@ -14,7 +14,7 @@ printint(int fd, int xx, int base, int sgn)
   static char digits[] = "0123456789ABCDEF";
   char buf[16];
   int i, neg;
-  uint x;
+  uint32_t x;
 
   neg = 0;
   if(sgn && xx < 0){

--- a/src-uland/rcrs.c
+++ b/src-uland/rcrs.c
@@ -31,7 +31,7 @@ struct driver {
   char *argv[MAX_ARGS];
   char *buf; // backing storage for argv strings
   int pid;
-  uint last_ping;
+  uint32_t last_ping;
   int awaiting_pong;
   int ping_timeout;
   int ping_interval;
@@ -148,14 +148,14 @@ int main(void) {
     drv[i].restarts = 0;
   }
 
-  uint last_report = uptime();
+  uint32_t last_report = uptime();
 
   for (;;) {
-    uint now = uptime();
+    uint32_t now = uptime();
 
     for (int i = 0; i < n; i++) {
       if (drv[i].pid > 0 && !drv[i].awaiting_pong &&
-          now - drv[i].last_ping >= (uint)drv[i].ping_interval) {
+          now - drv[i].last_ping >= (uint32_t)drv[i].ping_interval) {
         zipc_msg_t m = {0};
         m.w0 = PING;
         m.w1 = i;
@@ -167,14 +167,14 @@ int main(void) {
 
     zipc_msg_t m;
     while (read(p[0], &m, sizeof(m)) == sizeof(m)) {
-      if (m.w0 == PONG && m.w1 < (uint)n)
+      if (m.w0 == PONG && m.w1 < (uint32_t)n)
         drv[m.w1].awaiting_pong = 0;
     }
 
     now = uptime();
     for (int i = 0; i < n; i++) {
       if (drv[i].pid > 0 && drv[i].awaiting_pong &&
-          now - drv[i].last_ping > (uint)drv[i].ping_timeout) {
+          now - drv[i].last_ping > (uint32_t)drv[i].ping_timeout) {
         printf(1, "rcrs: restarting %s\n", drv[i].argv[0]);
         kill(drv[i].pid);
         wait();

--- a/src-uland/ulib.c
+++ b/src-uland/ulib.c
@@ -20,7 +20,7 @@ strcmp(const char *p, const char *q)
 {
   while(*p && *p == *q)
     p++, q++;
-  return (uchar)*p - (uchar)*q;
+  return (uint8_t)*p - (uint8_t)*q;
 }
 
 size_t

--- a/src-uland/usertests.c
+++ b/src-uland/usertests.c
@@ -768,7 +768,7 @@ concreate(void)
   int i, pid, n, fd;
   char fa[40];
   struct {
-    ushort inum;
+    uint16_t inum;
     char name[14];
   } de;
 
@@ -1441,7 +1441,7 @@ sbrktest(void)
 {
   int fds[2], pid, pids[10], ppid;
   char *a, *b, *c, *lastaddr, *oldbrk, *p, scratch;
-  uint amt;
+  uint32_t amt;
 
   printf(stdout, "sbrk test\n");
   oldbrk = sbrk(0);
@@ -1588,7 +1588,7 @@ void
 validatetest(void)
 {
   int hi, pid;
-  uint p;
+  uint32_t p;
 
   printf(stdout, "validate test\n");
   hi = 1100*1024;
@@ -1726,8 +1726,8 @@ uio()
   #define RTC_ADDR 0x70
   #define RTC_DATA 0x71
 
-  ushort port = 0;
-  uchar val = 0;
+  uint16_t port = 0;
+  uint8_t val = 0;
   int pid;
 
   printf(1, "uio test\n");

--- a/tests/microbench/cap_verify_bench.c
+++ b/tests/microbench/cap_verify_bench.c
@@ -4,11 +4,8 @@
 #include <string.h>
 #include <time.h>
 
-typedef unsigned int uint;
-typedef unsigned long uint64;
-
-typedef struct hash256 { uint64 parts[4]; } hash256_t;
-typedef struct exo_cap { uint pa; uint id; uint rights; uint owner; hash256_t auth_tag; } exo_cap;
+typedef struct hash256 { uint64_t parts[4]; } hash256_t;
+typedef struct exo_cap { uint32_t pa; uint32_t id; uint32_t rights; uint32_t owner; hash256_t auth_tag; } exo_cap;
 
 static const uint8_t cap_secret[32] = {
     0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
@@ -17,9 +14,9 @@ static const uint8_t cap_secret[32] = {
     0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
 };
 
-static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
-    const uint64 prime = 1099511628211ULL;
-    uint64 h = seed;
+static uint64_t fnv64(const uint8_t *data, size_t len, uint64_t seed) {
+    const uint64_t prime = 1099511628211ULL;
+    uint64_t h = seed;
     for(size_t i=0;i<len;i++) {
         h ^= data[i];
         h *= prime;
@@ -28,20 +25,20 @@ static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
 }
 
 static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
-    const uint64 basis = 14695981039346656037ULL;
+    const uint64_t basis = 14695981039346656037ULL;
     for(int i=0;i<4;i++)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 
-static void compute_tag(uint id, uint rights, uint owner, hash256_t *out) {
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+static void compute_tag(uint32_t id, uint32_t rights, uint32_t owner, hash256_t *out) {
+    struct { uint32_t id; uint32_t rights; uint32_t owner; } tmp = { id, rights, owner };
     uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
     memmove(buf, cap_secret, sizeof(cap_secret));
     memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
     hash256(buf, sizeof(buf), out);
 }
 
-static exo_cap cap_new(uint id, uint rights, uint owner) {
+static exo_cap cap_new(uint32_t id, uint32_t rights, uint32_t owner) {
     exo_cap c;
     c.pa = 0;
     c.id = id;

--- a/tests/microbench/exo_yield_to_bench.c
+++ b/tests/microbench/exo_yield_to_bench.c
@@ -4,11 +4,8 @@
 #include <string.h>
 #include <time.h>
 
-typedef unsigned int uint;
-typedef unsigned long uint64;
-
-typedef struct hash256 { uint64 parts[4]; } hash256_t;
-typedef struct exo_cap { uint pa; uint id; uint rights; uint owner; hash256_t auth_tag; } exo_cap;
+typedef struct hash256 { uint64_t parts[4]; } hash256_t;
+typedef struct exo_cap { uint32_t pa; uint32_t id; uint32_t rights; uint32_t owner; hash256_t auth_tag; } exo_cap;
 
 static const uint8_t cap_secret[32] = {
     0x01,0x23,0x45,0x67,0x89,0xab,0xcd,0xef,
@@ -17,9 +14,9 @@ static const uint8_t cap_secret[32] = {
     0x44,0x55,0x66,0x77,0x88,0x99,0xaa,0xbb
 };
 
-static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
-    const uint64 prime = 1099511628211ULL;
-    uint64 h = seed;
+static uint64_t fnv64(const uint8_t *data, size_t len, uint64_t seed) {
+    const uint64_t prime = 1099511628211ULL;
+    uint64_t h = seed;
     for(size_t i=0;i<len;i++) {
         h ^= data[i];
         h *= prime;
@@ -28,20 +25,20 @@ static uint64 fnv64(const uint8_t *data, size_t len, uint64 seed) {
 }
 
 static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
-    const uint64 basis = 14695981039346656037ULL;
+    const uint64_t basis = 14695981039346656037ULL;
     for(int i=0;i<4;i++)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 
-static void compute_tag(uint id, uint rights, uint owner, hash256_t *out) {
-    struct { uint id; uint rights; uint owner; } tmp = { id, rights, owner };
+static void compute_tag(uint32_t id, uint32_t rights, uint32_t owner, hash256_t *out) {
+    struct { uint32_t id; uint32_t rights; uint32_t owner; } tmp = { id, rights, owner };
     uint8_t buf[sizeof(cap_secret) + sizeof(tmp)];
     memmove(buf, cap_secret, sizeof(cap_secret));
     memmove(buf + sizeof(cap_secret), &tmp, sizeof(tmp));
     hash256(buf, sizeof(buf), out);
 }
 
-static exo_cap cap_new(uint id, uint rights, uint owner) {
+static exo_cap cap_new(uint32_t id, uint32_t rights, uint32_t owner) {
     exo_cap c;
     c.pa = 0;
     c.id = id;

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -21,7 +21,7 @@ static void cprintf(const char *f, ...){ (void)f; }
 
 #include "src-kernel/arbitrate.c"
 
-static int prefer_low(uint t, uint r, uint cur, uint newo){
+static int prefer_low(uint32_t t, uint32_t r, uint32_t cur, uint32_t newo){
     (void)t; (void)r;
     return newo < cur;
 }

--- a/tests/test_cap_newtypes.py
+++ b/tests/test_cap_newtypes.py
@@ -21,7 +21,7 @@ static void cprintf(const char *f, ...){ (void)f; }
 
 int main(void){
     cap_table_init();
-    uint id;
+    uint32_t id;
 
     id = cap_table_alloc(CAP_TYPE_IOPORT, 0x3f8, 0, 1);
     assert(id > 0);
@@ -45,14 +45,6 @@ def compile_and_run():
         (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock{int d;};")
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text(
-            "typedef unsigned int uint;\n"
-            "typedef unsigned short ushort;\n"
-            "typedef unsigned char uchar;\n"
-        )
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
-        )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
             "gcc","-std=c2x",

--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -25,7 +25,7 @@ static void cprintf(const char *f, ...){ (void)f; }
 
 int main(void){
     cap_table_init();
-    uint id = cap_table_alloc(CAP_TYPE_PAGE, 0x1000, 0, 1);
+    uint32_t id = cap_table_alloc(CAP_TYPE_PAGE, 0x1000, 0, 1);
     for(unsigned i=0; i < 0xffffu - 1; i++){
         assert(cap_revoke(id) == 0);
         id = cap_table_alloc(CAP_TYPE_PAGE, 0x1000, 0, 1);
@@ -46,14 +46,6 @@ def compile_and_run():
         (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock{int d;};")
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text(
-            "typedef unsigned int uint;\n"
-            "typedef unsigned short ushort;\n"
-            "typedef unsigned char uchar;\n"
-        )
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
-        )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
             "gcc","-std=c2x",

--- a/tests/test_cap_types.py
+++ b/tests/test_cap_types.py
@@ -21,7 +21,7 @@ static void cprintf(const char *f, ...){ (void)f; }
 
 int main(void){
     cap_table_init();
-    uint id;
+    uint32_t id;
 
     id = cap_table_alloc(CAP_TYPE_IOPORT, 0x3f8, 0, 1);
     assert(id > 0);
@@ -46,14 +46,6 @@ def compile_and_run():
         (pathlib.Path(td)/"spinlock.h").write_text("struct spinlock{int d;};")
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text(
-            "typedef unsigned int uint;\n"
-            "typedef unsigned short ushort;\n"
-            "typedef unsigned char uchar;\n"
-        )
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
-        )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
             "gcc","-std=c2x",

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -22,7 +22,7 @@ static void sleep(void *c, struct spinlock *l){ (void)c; (void)l; }
 static void wakeup(void *c){ (void)c; }
 static struct proc cur = {1};
 static struct proc* myproc(void){ return &cur; }
-static exo_cap cap_new(uint id, uint rights, uint owner){
+static exo_cap cap_new(uint32_t id, uint32_t rights, uint32_t owner){
     exo_cap c; c.pa=id; c.id=id; c.rights=rights; c.owner=owner; return c;
 }
 static int cap_verify(exo_cap c){ (void)c; return 1; }
@@ -53,17 +53,6 @@ def compile_and_run():
         (pathlib.Path(td)/"include/exokernel.h").write_text('#include "../src-headers/exokernel.h"')
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text(
-            "typedef unsigned int uint;\n"
-            "typedef unsigned short ushort;\n"
-            "typedef unsigned char uchar;\n"
-            "typedef unsigned int uint32;\n"
-            "typedef unsigned long uint64;\n"
-            "typedef unsigned long uintptr;\n"
-        )
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
-        )
         subprocess.check_call([
             "gcc","-std=c2x",
             "-I", str(td),

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -10,7 +10,6 @@ C_CODE = r"""
 #include <stdatomic.h>
 #include <stdlib.h>
 
-typedef unsigned int uint;
 
 struct spinlock;
 struct cpu;

--- a/tests/test_lockstress.py
+++ b/tests/test_lockstress.py
@@ -11,7 +11,6 @@ C_CODE = r"""
 #include <pthread.h>
 #include <stdlib.h>
 
-typedef unsigned int uint;
 
 struct spinlock;
 struct cpu;

--- a/tests/test_sys_ipc.py
+++ b/tests/test_sys_ipc.py
@@ -70,15 +70,6 @@ def compile_and_run():
         )
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
-        (pathlib.Path(td)/"types.h").write_text(
-            "typedef unsigned int uint;\n"
-            "typedef unsigned long uint64;\n"
-            "typedef unsigned short ushort;\n"
-            "typedef unsigned char uchar;\n"
-        )
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif"
-        )
         subprocess.check_call([
             "gcc", "-std=c2x",
             "-I", str(td),


### PR DESCRIPTION
## Summary
- use `<stdint.h>` in `types.h` and provide minimal aliases
- refactor kernel headers and sources to use `uint32_t`, `uint64_t`, etc.
- update capability and spinlock structures
- simplify tests to avoid their own typedefs

## Testing
- `pytest -q`