### PR TITLE
Add exo_ipc_status enum and update IPC return types

### DIFF
--- a/doc/IPC.md
+++ b/doc/IPC.md
@@ -1,0 +1,23 @@
+# IPC API
+
+The Phoenix IPC subsystem exposes two primary calls:
+
+```c
+enum exo_ipc_status exo_send(exo_cap dest, const void *buf, uint64_t len);
+enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);
+```
+
+The return type `exo_ipc_status` indicates success or the reason for
+failure:
+
+```c
+enum exo_ipc_status {
+    EXO_IPC_OK = 0,
+    EXO_IPC_TIMEOUT = -1,
+    EXO_IPC_INVALID = -2,
+    EXO_IPC_OVERFLOW = -3,
+};
+```
+
+`EXO_IPC_OK` means the operation completed successfully. All other
+values represent error conditions.

--- a/libos/capwrap.c
+++ b/libos/capwrap.c
@@ -5,12 +5,12 @@ exo_cap capwrap_alloc_page(void) {
     return c;
 }
 
-int capwrap_send(exo_cap dest, const void *buf, size_t len) {
+enum exo_ipc_status capwrap_send(exo_cap dest, const void *buf, size_t len) {
     (void)dest; (void)buf; (void)len;
-    return -1;
+    return EXO_IPC_INVALID;
 }
 
-int capwrap_recv(exo_cap src, void *buf, size_t len) {
+enum exo_ipc_status capwrap_recv(exo_cap src, void *buf, size_t len) {
     (void)src; (void)buf; (void)len;
-    return -1;
+    return EXO_IPC_INVALID;
 }

--- a/libos/ddekit.c
+++ b/libos/ddekit.c
@@ -20,10 +20,10 @@ void ddekit_yield(void) { yield(); }
 
 exo_cap ddekit_cap_alloc_page(void) { return capwrap_alloc_page(); }
 
-int ddekit_cap_send(exo_cap dest, const void *buf, size_t len) {
+enum exo_ipc_status ddekit_cap_send(exo_cap dest, const void *buf, size_t len) {
     return capwrap_send(dest, buf, len);
 }
 
-int ddekit_cap_recv(exo_cap src, void *buf, size_t len) {
+enum exo_ipc_status ddekit_cap_recv(exo_cap src, void *buf, size_t len) {
     return capwrap_recv(src, buf, len);
 }

--- a/libos/driver.c
+++ b/libos/driver.c
@@ -10,6 +10,6 @@
   return pid;
 }
 
-[[nodiscard]] int driver_connect(int pid, exo_cap ep) {
+[[nodiscard]] enum exo_ipc_status driver_connect(int pid, exo_cap ep) {
   return cap_send(ep, &pid, sizeof(pid));
 }

--- a/libos/include/capwrap.h
+++ b/libos/include/capwrap.h
@@ -3,5 +3,5 @@
 #include "caplib.h"
 
 exo_cap capwrap_alloc_page(void);
-int capwrap_send(exo_cap dest, const void *buf, size_t len);
-int capwrap_recv(exo_cap src, void *buf, size_t len);
+enum exo_ipc_status capwrap_send(exo_cap dest, const void *buf, size_t len);
+enum exo_ipc_status capwrap_recv(exo_cap src, void *buf, size_t len);

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -8,8 +8,9 @@ exo_cap cap_alloc_page(void);
 [[nodiscard]] int cap_alloc_block(uint dev, uint rights, exo_blockcap *cap);
 [[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write);
 void cap_flush_block(exo_blockcap *cap, void *data);
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len);
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] enum exo_ipc_status cap_send(exo_cap dest, const void *buf,
+                                           uint64 len);
+[[nodiscard]] enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64 len);
 [[nodiscard]] int cap_set_timer(void (*handler)(void));
 [[nodiscard]] int cap_set_gas(uint64 amount);
 [[nodiscard]] int cap_get_gas(void);

--- a/src-headers/chan.h
+++ b/src-headers/chan.h
@@ -15,10 +15,11 @@ typedef struct chan {
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len);
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len);
+[[nodiscard]] enum exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                                     const void *msg,
+                                                     size_t len);
+[[nodiscard]] enum exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src,
+                                                     void *msg, size_t len);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
@@ -32,15 +33,18 @@ void chan_destroy(chan_t *c);
     return (name##_t *)chan_create(&name##_typedesc);                          \
   }                                                                            \
   static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
-  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+  static inline enum exo_ipc_status name##_send(name##_t *c, exo_cap dest,       \
+                                               const type *m) {                 \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
     type##_encode(m, buf);                                                     \
     return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
   }                                                                            \
-  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+  static inline enum exo_ipc_status name##_recv(name##_t *c, exo_cap src,       \
+                                               type *m) {                      \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
-    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
-    if (r == 0)                                                                \
+    enum exo_ipc_status r =                                                   \
+        chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);          \
+    if (r == EXO_IPC_OK)                                                      \
       type##_decode(m, buf);                                                   \
     return r;                                                                  \
   }

--- a/src-headers/ddekit.h
+++ b/src-headers/ddekit.h
@@ -14,5 +14,5 @@ void ddekit_process_exit(int code) __attribute__((noreturn));
 void ddekit_yield(void);
 
 exo_cap ddekit_cap_alloc_page(void);
-int ddekit_cap_send(exo_cap dest, const void *buf, size_t len);
-int ddekit_cap_recv(exo_cap src, void *buf, size_t len);
+enum exo_ipc_status ddekit_cap_send(exo_cap dest, const void *buf, size_t len);
+enum exo_ipc_status ddekit_cap_recv(exo_cap src, void *buf, size_t len);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -3,11 +3,19 @@
 #include "exo_mem.h"
 #include "../exo.h"
 
+enum exo_ipc_status {
+  EXO_IPC_OK = 0,
+  EXO_IPC_TIMEOUT = -1,
+  EXO_IPC_INVALID = -2,
+  EXO_IPC_OVERFLOW = -3,
+};
+
 struct exo_ipc_ops {
-  int (*send)(exo_cap dest, const void *buf, uint64_t len);
-  int (*recv)(exo_cap src, void *buf, uint64_t len);
+  enum exo_ipc_status (*send)(exo_cap dest, const void *buf, uint64_t len);
+  enum exo_ipc_status (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
 void exo_ipc_register(struct exo_ipc_ops *ops);
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                          uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -2,6 +2,7 @@
 #include "types.h"
 #include "exo.h"
 #include "syscall.h"
+#include "exo_ipc.h"
 
 /* Capability access rights. */
 #define EXO_RIGHT_R 0x1
@@ -54,11 +55,12 @@ exo_cap exo_alloc_dma(uint chan);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any queuing
  * or flow control is managed in user space. */
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64 len);
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                           uint64 len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64 len);
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64 len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
 [[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64 off,

--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "exo_ipc.h"
 
-int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
-int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+enum exo_ipc_status ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
+enum exo_ipc_status ipc_queue_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-kernel/chan.c
+++ b/src-kernel/chan.c
@@ -2,8 +2,9 @@
 #include "exo_ipc.h"
 
 // Kernel variant of chan_endpoint_send validating the message size
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                                     const void *msg,
+                                                     size_t len) {
   if (!c) {
     cprintf("chan_endpoint_send: null channel\n");
     return -1;
@@ -17,8 +18,8 @@
 }
 
 // Kernel variant of chan_endpoint_recv validating the message size
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src,
+                                                     void *msg, size_t len) {
   if (!c) {
     cprintf("chan_endpoint_recv: null channel\n");
     return -1;

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -6,14 +6,15 @@ static struct exo_ipc_ops ipc_ops;
 
 void exo_ipc_register(struct exo_ipc_ops *ops) { ipc_ops = *ops; }
 
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                           uint64_t len) {
   if (ipc_ops.send)
     return ipc_ops.send(dest, buf, len);
-  return -1;
+  return EXO_IPC_INVALID;
 }
 
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len) {
   if (ipc_ops.recv)
     return ipc_ops.recv(src, buf, len);
-  return -1;
+  return EXO_IPC_INVALID;
 }

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -31,10 +31,11 @@ static void ipc_init(void) {
   }
 }
 
-int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
+enum exo_ipc_status exo_ipc_queue_send(exo_cap dest, const void *buf,
+                                       uint64_t len) {
   ipc_init();
   if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
-    return -EPERM;
+    return EXO_IPC_INVALID;
   if (len > sizeof(zipc_msg_t) + sizeof(exo_cap))
     len = sizeof(zipc_msg_t) + sizeof(exo_cap);
 
@@ -46,9 +47,9 @@ int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
   if (len > sizeof(zipc_msg_t)) {
     memmove(&fr, (const char *)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
     if (!cap_verify(fr))
-      return -EPERM;
+      return EXO_IPC_INVALID;
     if(!cap_has_rights(fr.rights, EXO_RIGHT_R))
-      return -EPERM;
+      return EXO_IPC_INVALID;
     if (dest.owner)
       fr.owner = dest.owner;
   }
@@ -64,12 +65,12 @@ int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
   wakeup(&ipcs.r);
   release(&ipcs.lock);
 
-  return (int)len;
+  return EXO_IPC_OK;
 }
 
-int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
+enum exo_ipc_status exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
   if(!cap_has_rights(src.rights, EXO_RIGHT_R))
-    return -EPERM;
+    return EXO_IPC_INVALID;
   ipc_init();
   acquire(&ipcs.lock);
   while (ipcs.r == ipcs.w) {
@@ -101,7 +102,7 @@ int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
             len - sizeof(zipc_msg_t));
   }
 
-  return (int)len;
+  return EXO_IPC_OK;
 }
 
 struct exo_ipc_ops exo_ipc_queue_ops = {

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -46,11 +46,12 @@ void cap_yield_to(context_t **old, context_t *target) {
 extern int cap_revoke_syscall(void);
 int cap_revoke(void) { return cap_revoke_syscall(); }
 
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64 len) {
+[[nodiscard]] enum exo_ipc_status cap_send(exo_cap dest, const void *buf,
+                                           uint64 len) {
   return exo_send(dest, buf, len);
 }
 
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64 len) {
+[[nodiscard]] enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64 len) {
   return exo_recv(src, buf, len);
 }
 

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -13,8 +13,8 @@
 
 void chan_destroy(chan_t *c) { free(c); }
 
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                                     const void *msg, size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
            (int)c->msg_size);
@@ -23,8 +23,8 @@ void chan_destroy(chan_t *c) { free(c); }
   return cap_send(dest, msg, c->msg_size);
 }
 
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src,
+                                                     void *msg, size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
            (int)c->msg_size);

--- a/src-uland/door.c
+++ b/src-uland/door.c
@@ -27,9 +27,9 @@ door_t door_create_remote(exo_cap dest) {
       d->handler(msg);
     return 0;
   }
-  if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
+  if (cap_send(d->dest, msg, sizeof(*msg)) != EXO_IPC_OK)
     return -1;
-  return cap_recv(d->dest, msg, sizeof(*msg));
+  return cap_recv(d->dest, msg, sizeof(*msg)) == EXO_IPC_OK ? 0 : -1;
 }
 
 void door_server_loop(door_t *d) {
@@ -37,7 +37,7 @@ void door_server_loop(door_t *d) {
     return;
   while (1) {
     zipc_msg_t msg;
-    if (cap_recv(d->dest, &msg, sizeof(msg)) < 0)
+    if (cap_recv(d->dest, &msg, sizeof(msg)) != EXO_IPC_OK)
       continue;
     d->handler(&msg);
     cap_send(d->dest, &msg, sizeof(msg));

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -10,10 +10,11 @@ C_CODE = textwrap.dedent(
 #include <assert.h>
 #include <stdint.h>
 #include "src-headers/door.h"
+#include "src-headers/exo_ipc.h"
 
 // stub implementations for caplib helpers
-int cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return 0; }
-int cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return 0; }
+enum exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return EXO_IPC_OK; }
+enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return EXO_IPC_OK; }
 
 static int called = 0;
 static void handler(zipc_msg_t *m) { called++; m->w0++; }


### PR DESCRIPTION
## Summary
- introduce `exo_ipc_status` and use it for IPC routines
- adjust IPC queue helpers and channel APIs for new type
- update door test for `exo_ipc_status`
- document IPC return codes in `doc/IPC.md`

## Testing
- `pytest -q`