### PR TITLE
Add Cap’n Proto helper library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,7 @@ file(GLOB_RECURSE KERNEL_SOURCES
   src-uland/*.c
   src-uland/user/*.c
   libos/*.c
+  libos/capnp/*.c
 )
 
 add_executable(kernel ${KERNEL_SOURCES})
@@ -46,6 +47,7 @@ target_include_directories(kernel PRIVATE
   ${CMAKE_SOURCE_DIR}/src-kernel/include
   ${CMAKE_SOURCE_DIR}/proto
   ${CMAKE_SOURCE_DIR}/libos/include
+  ${CMAKE_SOURCE_DIR}/libos/capnp
 )
 
 if(CPUFLAGS)

--- a/libos/capnp/capnp_helpers.c
+++ b/libos/capnp/capnp_helpers.c
@@ -1,0 +1,12 @@
+#include "capnp_helpers.h"
+#include <string.h>
+
+size_t capnp_encode(const void *msg, size_t len, unsigned char *buf) {
+    memcpy(buf, msg, len);
+    return len;
+}
+
+size_t capnp_decode(void *msg, size_t len, const unsigned char *buf) {
+    memcpy(msg, buf, len);
+    return len;
+}

--- a/libos/capnp/capnp_helpers.h
+++ b/libos/capnp/capnp_helpers.h
@@ -1,0 +1,10 @@
+#pragma once
+#include <stddef.h>
+#ifdef __cplusplus
+extern "C" {
+#endif
+size_t capnp_encode(const void *msg, size_t len, unsigned char *buf);
+size_t capnp_decode(void *msg, size_t len, const unsigned char *buf);
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -24,10 +24,11 @@ libos_sources = [
   'libos/driver.c',
   'libos/affine_runtime.c',
   'libos/posix.c',
+  'libos/capnp/capnp_helpers.c',
 ]
 
 libos = static_library('libos', libos_sources,
-    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include'))
+    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'))
 
 src_dirs = ['src-kernel', 'src-uland', 'src-uland/user', 'libos']
 
@@ -41,7 +42,8 @@ kernel = executable('kernel', sources,
                                             'src-headers',
                                             'src-kernel/include',
                                             'proto',
-                                            'libos/include'),
+                                            'libos/include',
+                                            'libos/capnp'),
            install: false)
 
 if clang_tidy.found()
@@ -101,7 +103,7 @@ uprogs = {
 uprogs_targets = []
 foreach name, path : uprogs
   exe = executable('_' + name, path,
-                   include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include'),
+                   include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'),
                    link_with: libos,
                    install: false)
   uprogs_targets += exe

--- a/src-uland/pingdriver.c
+++ b/src-uland/pingdriver.c
@@ -1,6 +1,8 @@
 #include "types.h"
 #include "user.h"
 #include "ipc.h"
+#include "capnp_helpers.h"
+#include "proto/driver.capnp.h"
 
 #define PING 1
 #define PONG 2
@@ -13,8 +15,11 @@ main(int argc, char *argv[])
     for(;;){
         if(endpoint_recv(&m) < 0)
             continue;
-        if(m.w0 == PING){
-            m.w0 = PONG;
+        DriverPing req = {0};
+        capnp_decode(&req, sizeof(req), (unsigned char *)&m);
+        if(req.value == PING){
+            DriverPing resp = { .value = PONG };
+            capnp_encode(&resp, sizeof(resp), (unsigned char *)&m);
             endpoint_send(&m);
         }
     }

--- a/src-uland/user/affine_channel_demo.c
+++ b/src-uland/user/affine_channel_demo.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "affine_runtime.h"
+#include "capnp_helpers.h"
 #include "proto/driver.capnp.h"
 
 AFFINE_CHAN_DECLARE(aff_ping_chan, DriverPing);

--- a/src-uland/user/chan_beatty_rcrs_demo.c
+++ b/src-uland/user/chan_beatty_rcrs_demo.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "math_core.h"
 #include "libos/driver.h"
 #include "proto/driver.capnp.h"

--- a/src-uland/user/chan_dag_supervisor_demo.c
+++ b/src-uland/user/chan_dag_supervisor_demo.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "dag.h"
 #include "libos/driver.h"
 #include "proto/driver.capnp.h"

--- a/src-uland/user/hello_channel.c
+++ b/src-uland/user/hello_channel.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "caplib.h"
 #include "libsmk_cap.h"
 #include "proto/hello.capnp.h"

--- a/src-uland/user/typed_chan_demo.c
+++ b/src-uland/user/typed_chan_demo.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "proto/driver.capnp.h"
 
 CHAN_DECLARE(ping_chan, DriverPing);

--- a/src-uland/user/typed_chan_recv.c
+++ b/src-uland/user/typed_chan_recv.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "proto/driver.capnp.h"
 
 CHAN_DECLARE(ping_chan, DriverPing);

--- a/src-uland/user/typed_chan_send.c
+++ b/src-uland/user/typed_chan_send.c
@@ -1,6 +1,7 @@
 #include "types.h"
 #include "user.h"
 #include "chan.h"
+#include "capnp_helpers.h"
 #include "proto/driver.capnp.h"
 
 CHAN_DECLARE(ping_chan, DriverPing);


### PR DESCRIPTION
## Summary
- add `capnp_helpers` with simple encode/decode helpers
- build the new helper library and link it into user programs
- update user programs to include the helpers
- parse pingdriver requests using the helper functions

## Testing
- `pytest -q`