### PR TITLE
Add per-process mailboxes

### DIFF
--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,5 +1,21 @@
 #pragma once
 #include "exo_ipc.h"
+#include "uv_spinlock.h"
 
-int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
-int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+#define IPC_BUFSZ 64
+
+struct ipc_entry {
+    zipc_msg_t msg;
+    exo_cap frame;
+};
+
+struct exo_mailbox {
+    uv_spinlock_t lock;
+    struct ipc_entry buf[IPC_BUFSZ];
+    unsigned r, w;
+};
+
+int ipc_queue_send(struct exo_mailbox *mb, exo_cap dest, const void *buf,
+                   uint64_t len);
+int ipc_queue_recv(struct exo_mailbox *mb, exo_cap src, void *buf,
+                   uint64_t len);

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -151,6 +151,10 @@ found:
 
   release(&ptable.lock);
 
+  // Initialize per-process mailbox
+  initlock(&p->mbox.lock, "mbox");
+  p->mbox.r = p->mbox.w = 0;
+
   // Allocate kernel stack.
   if((p->kstack = kalloc()) == 0){
     p->state = UNUSED;


### PR DESCRIPTION
## Summary
- introduce mailbox and attach one to each `struct proc`
- queue IPC messages in each process mailbox instead of global state
- update user-space IPC queue helpers

## Testing
- `pytest -q`