### PR TITLE
Return ENOSPC on full IRQ queue

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -251,7 +251,7 @@ void exo_flush_block(struct exo_blockcap *, void *);
 exo_cap exo_alloc_irq(uint irq, uint rights);
 int exo_irq_wait(exo_cap cap, uint *irq);
 int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint irq);
+int irq_trigger(uint irq);
 exo_cap exo_alloc_ioport(uint port);
 exo_cap exo_bind_irq(uint irq);
 exo_cap exo_alloc_dma(uint chan);

--- a/src-headers/exo_irq.h
+++ b/src-headers/exo_irq.h
@@ -10,7 +10,7 @@ extern "C" {
 exo_cap exo_alloc_irq(uint irq, uint rights);
 [[nodiscard]] int exo_irq_wait(exo_cap cap, uint *irq);
 [[nodiscard]] int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint irq);
+[[nodiscard]] int irq_trigger(uint irq);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary
- return `-ENOSPC` from `irq_trigger` when IRQ queue is full
- update prototypes accordingly
- check return value in IRQ tests
- test overflow behaviour using clang with C23

## Testing
- `pytest -q`
