### PR TITLE
Add ticket spinlock concurrency tests

### DIFF
--- a/tests/test_ticket_spinlock_processes.py
+++ b/tests/test_ticket_spinlock_processes.py
@@ -1,0 +1,80 @@
+import subprocess, tempfile, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = r"""
+#define _XOPEN_SOURCE 700
+#include <assert.h>
+#include <stdint.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+struct spinlock; struct cpu;
+static struct cpu* mycpu(void); static void getcallerpcs(void*, unsigned int*);
+static void panic(char*); static void pushcli(void); static void popcli(void);
+static int holding(struct spinlock*);
+
+#include "src-headers/libos/spinlock.h"
+
+struct cpu { int ncli; int intena; };
+static __thread struct cpu cpu0;
+static struct cpu* mycpu(void){ return &cpu0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; _exit(1); }
+static void pushcli(void){ cpu0.ncli++; }
+static void popcli(void){ cpu0.ncli--; }
+static int holding(struct spinlock *lk){ return lk->cpu == &cpu0; }
+
+struct shared {
+    struct spinlock sl;
+    int counter;
+};
+
+int main(){
+    struct shared *sh = mmap(NULL, sizeof(struct shared),
+                             PROT_READ|PROT_WRITE,
+                             MAP_ANON|MAP_SHARED, -1, 0);
+    assert(sh != MAP_FAILED);
+    initlock(&sh->sl, "sl");
+    sh->counter = 0;
+    const int N = 4;
+    pid_t pids[N];
+    for(int i=0;i<N;i++){
+        pid_t pid = fork();
+        if(pid==0){
+            for(int j=0;j<1000;j++){
+                acquire(&sh->sl);
+                sh->counter++;
+                release(&sh->sl);
+            }
+            _exit(0);
+        }
+        pids[i] = pid;
+    }
+    for(int i=0;i<N;i++)
+        waitpid(pids[i], NULL, 0);
+    assert(sh->counter == N*1000);
+    return 0;
+}
+"""
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE)
+        subprocess.check_call([
+            "gcc","-std=c2x","-DSPINLOCK_NO_STUBS",
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers/libos"),
+            "-I", str(ROOT/"src-headers"),
+            "-I", str(ROOT/"src-kernel/include"),
+            str(src),
+            "-o", str(exe)
+        ])
+        subprocess.check_call([str(exe)])
+
+
+def test_ticket_spinlock_processes():
+    compile_and_run()

--- a/tests/test_ticket_spinlock_threads.py
+++ b/tests/test_ticket_spinlock_threads.py
@@ -1,0 +1,99 @@
+import subprocess, tempfile, pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = r"""
+#define _XOPEN_SOURCE 700
+#include <assert.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <sched.h>
+#include <unistd.h>
+#include <pthread.h>
+
+struct spinlock; struct cpu;
+static struct cpu* mycpu(void); static void getcallerpcs(void*, unsigned int*);
+static void panic(char*); static void pushcli(void); static void popcli(void);
+static int holding(struct spinlock*);
+
+#include "src-headers/libos/spinlock.h"
+
+struct cpu { int ncli; int intena; };
+static __thread struct cpu cpu0;
+static struct cpu* mycpu(void){ return &cpu0; }
+static void getcallerpcs(void *v, unsigned int pcs[]){ (void)v; pcs[0]=0; }
+static void panic(char *msg){ (void)msg; exit(1); }
+static void pushcli(void){ cpu0.ncli++; }
+static void popcli(void){ cpu0.ncli--; }
+static int holding(struct spinlock *lk){ return lk->cpu == &cpu0; }
+
+
+#define NTHREADS 4
+#define ITER 1000
+#define MSG_TOTAL (NTHREADS*ITER)
+
+struct queue { struct spinlock lock; int head; int msgs[MSG_TOTAL]; } q;
+static unsigned short tickets[NTHREADS];
+static int order[MSG_TOTAL];
+
+
+void *worker(void *arg){
+    int id = (int)(intptr_t)arg;
+    usleep(id * 1000);
+    acquire(&q.lock);
+    unsigned short t = q.lock.ticket.head;
+    tickets[id] = t;
+    order[t] = id;
+    q.msgs[q.head] = id;
+    __atomic_fetch_add(&q.head, 1, __ATOMIC_SEQ_CST);
+    release(&q.lock);
+    for(int i=1;i<ITER;i++){
+        acquire(&q.lock);
+        q.msgs[q.head] = id;
+        __atomic_fetch_add(&q.head, 1, __ATOMIC_SEQ_CST);
+        release(&q.lock);
+    }
+    return 0;
+}
+
+int main(){
+    initlock(&q.lock, "lk");
+    q.head = 0;
+    pthread_t th[NTHREADS];
+    for(int i=0;i<NTHREADS;i++)
+        pthread_create(&th[i], 0, worker, (void*)(intptr_t)i);
+    for(int i=0;i<NTHREADS;i++)
+        pthread_join(th[i], 0);
+    assert(q.head == MSG_TOTAL);
+    int seen[MSG_TOTAL] = {0};
+    for(int i=0;i<NTHREADS;i++){
+        unsigned short t = tickets[i];
+        assert(t < MSG_TOTAL);
+        assert(!seen[t]);
+        seen[t] = 1;
+    }
+    for(int i=0;i<NTHREADS;i++)
+        assert(q.msgs[i] == order[i]);
+    return 0;
+}
+"""
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE)
+        subprocess.check_call([
+            "gcc","-std=c2x","-pthread","-DSPINLOCK_NO_STUBS",
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers/libos"),
+            "-I", str(ROOT/"src-headers"),
+            "-I", str(ROOT/"src-kernel/include"),
+            str(src),
+            "-o", str(exe)
+        ])
+        subprocess.check_call([str(exe)])
+
+
+def test_ticket_spinlock_threads():
+    compile_and_run()


### PR DESCRIPTION
## Summary
- add a thread-based ticket spinlock test stressing fairness and message passing
- add a process-based ticket spinlock test using shared memory

## Testing
- `pytest -q tests/test_ticket_spinlock_threads.py tests/test_ticket_spinlock_processes.py`