### PR TITLE
Add cache line detection and UP spinlock options

### DIFF
--- a/README
+++ b/README
@@ -278,10 +278,12 @@ Optional flags control the spinlock implementation and debugging
 facilities.  Set them with ``-D<FLAG>=ON`` when invoking CMake or in the
 environment for Meson:
 
+``CONFIG_SMP``
+    Enable multi-core support. When OFF spinlocks compile to no-ops.
 ``USE_TICKET_LOCK``
     Use ticket-based spinlocks instead of the default.
 ``SPINLOCK_UNIPROCESSOR``
-    Optimize locks for single CPU systems.
+    Optimize locks for single CPU systems. Implies CONFIG_SMP=OFF.
 ``SPINLOCK_DEBUG``
     Enable additional lock sanity checks.
 

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -1,4 +1,7 @@
 #pragma once
+#ifndef CONFIG_SMP
+#define CONFIG_SMP 1
+#endif
 
 #include <stddef.h>
 #include <stdint.h>
@@ -17,7 +20,7 @@ struct spinlock {
   uint32_t pcs[10];
 };
 
-#ifdef SPINLOCK_NO_STUBS
+#if defined(SPINLOCK_NO_STUBS) && CONFIG_SMP && !defined(SPINLOCK_UNIPROCESSOR)
 
 static inline void initlock(struct spinlock *lk, const char *name) {
   lk->name = (char *)name;

--- a/src-headers/x86.h
+++ b/src-headers/x86.h
@@ -1,48 +1,46 @@
 #pragma once
 
-static inline uint8_t
-inb(uint16_t port)
-{
+static inline uint8_t inb(uint16_t port) {
   uint8_t data;
   __asm__ volatile("inb %1,%0" : "=a"(data) : "d"(port));
   return data;
 }
 
-static inline void
-outb(uint16_t port, uint8_t data)
-{
+static inline void outb(uint16_t port, uint8_t data) {
   __asm__ volatile("outb %0,%1" : : "a"(data), "d"(port));
 }
 
-static inline void
-insl(int port, void *addr, int cnt)
-{
-  __asm__ volatile("cld; rep insl" :
-                   "=D"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
-                   "memory");
+static inline void insl(int port, void *addr, int cnt) {
+  __asm__ volatile("cld; rep insl"
+                   : "=D"(addr), "=c"(cnt)
+                   : "d"(port), "0"(addr), "1"(cnt)
+                   : "memory");
 }
 
-static inline void
-outsl(int port, const void *addr, int cnt)
-{
-  __asm__ volatile("cld; rep outsl" :
-                   "=S"(addr), "=c"(cnt) : "d"(port), "0"(addr), "1"(cnt) :
-                   "memory");
+static inline void outsl(int port, const void *addr, int cnt) {
+  __asm__ volatile("cld; rep outsl"
+                   : "=S"(addr), "=c"(cnt)
+                   : "d"(port), "0"(addr), "1"(cnt)
+                   : "memory");
 }
 
-static inline void
-stosb(void *addr, int data, int cnt)
-{
-  __asm__ volatile("cld; rep stosb" :
-                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
-                   "memory");
+static inline void stosb(void *addr, int data, int cnt) {
+  __asm__ volatile("cld; rep stosb"
+                   : "=D"(addr), "=c"(cnt)
+                   : "0"(addr), "1"(cnt), "a"(data)
+                   : "memory");
 }
 
-static inline void
-stosl(void *addr, int data, int cnt)
-{
-  __asm__ volatile("cld; rep stosl" :
-                   "=D"(addr), "=c"(cnt) : "0"(addr), "1"(cnt), "a"(data) :
-                   "memory");
+static inline void stosl(void *addr, int data, int cnt) {
+  __asm__ volatile("cld; rep stosl"
+                   : "=D"(addr), "=c"(cnt)
+                   : "0"(addr), "1"(cnt), "a"(data)
+                   : "memory");
 }
 
+static inline void cpuid(uint32_t leaf, uint32_t *a, uint32_t *b, uint32_t *c,
+                         uint32_t *d) {
+  __asm__ volatile("cpuid"
+                   : "=a"(*a), "=b"(*b), "=c"(*c), "=d"(*d)
+                   : "0"(leaf));
+}

--- a/src-kernel/include/spinlock.h
+++ b/src-kernel/include/spinlock.h
@@ -14,13 +14,16 @@ struct spinlock {
   struct ticketlock ticket; // Ticket lock implementation
 
   // For debugging:
-  char *name;      // Name of lock.
-  struct cpu *cpu; // The cpu holding the lock.
-  uint32_t pcs[10];    // The call stack (an array of program counters)
-                   // that locked the lock.
+  char *name;       // Name of lock.
+  struct cpu *cpu;  // The cpu holding the lock.
+  uint32_t pcs[10]; // The call stack (an array of program counters)
+                    // that locked the lock.
 };
 
-#if CONFIG_SMP
+extern size_t cache_line_size;
+void detect_cache_line_size(void);
+
+#if CONFIG_SMP && !defined(SPINLOCK_UNIPROCESSOR)
 void initlock(struct spinlock *lk, char *name);
 void acquire(struct spinlock *lk);
 void release(struct spinlock *lk);
@@ -40,5 +43,5 @@ static inline int holding(struct spinlock *lk) {
 
 // Returns the recommended alignment for instances of struct spinlock.
 static inline size_t spinlock_optimal_alignment(void) {
-  return __alignof__(struct spinlock);
+  return cache_line_size;
 }

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -7,6 +7,7 @@
 #include "dag.h"
 #include "cap.h"
 #include "x86.h"
+#include "spinlock.h"
 #include "exo_stream.h"
 #include "exo_ipc.h"
 
@@ -25,22 +26,23 @@ extern char end[]; // first address after kernel loaded from ELF file
 int main(void) {
   kinit1(end, P2V(4 * 1024 * 1024)); // phys page allocator
   kvmalloc();                        // kernel page table
-  mpinit();                          // detect other processors
-  lapicinit();                       // interrupt controller
-  seginit();                         // segment descriptors
-  picinit();                         // disable pic
-  ioapicinit();                      // another interrupt controller
-  consoleinit();                     // console hardware
-  uartinit();                        // serial port
-  cap_table_init();                  // initialize capability table
-  rcuinit();                         // rcu subsystem
-  pinit();                           // process table
-  tvinit();                          // trap vectors
-  binit();                           // buffer cache
-  fileinit();                        // file table
-  ideinit();                         // disk
-  dag_sched_init();                  // initialize DAG scheduler
-  beatty_sched_init();               // initialize Beatty scheduler
+  detect_cache_line_size();
+  mpinit();                                   // detect other processors
+  lapicinit();                                // interrupt controller
+  seginit();                                  // segment descriptors
+  picinit();                                  // disable pic
+  ioapicinit();                               // another interrupt controller
+  consoleinit();                              // console hardware
+  uartinit();                                 // serial port
+  cap_table_init();                           // initialize capability table
+  rcuinit();                                  // rcu subsystem
+  pinit();                                    // process table
+  tvinit();                                   // trap vectors
+  binit();                                    // buffer cache
+  fileinit();                                 // file table
+  ideinit();                                  // disk
+  dag_sched_init();                           // initialize DAG scheduler
+  beatty_sched_init();                        // initialize Beatty scheduler
   startothers();                              // start other processors
   kinit2(P2V(4 * 1024 * 1024), P2V(PHYSTOP)); // must come after startothers()
   userinit();                                 // first user process


### PR DESCRIPTION
## Summary
- detect cache line size via CPUID and use for spinlock alignment
- support CONFIG_SMP and SPINLOCK_UNIPROCESSOR compile-time options
- call detection during early boot
- document build flags

## Testing
- `pytest -q`
