### PR TITLE
Add ticket lock build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,8 @@ endif()
 
 project(xv6 LANGUAGES C CXX)
 
+option(USE_TICKET_LOCK "Use ticket-based spinlocks" OFF)
+
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 23)
@@ -42,6 +44,10 @@ file(GLOB_RECURSE KERNEL_SOURCES
 )
 
 add_executable(kernel ${KERNEL_SOURCES})
+
+if(USE_TICKET_LOCK)
+  target_compile_definitions(kernel PRIVATE USE_TICKET_LOCK)
+endif()
 
 # QEMU executable used for run targets
 find_program(QEMU_EXECUTABLE

--- a/README
+++ b/README
@@ -285,6 +285,21 @@ environment for Meson:
 ``SPINLOCK_DEBUG``
     Enable additional lock sanity checks.
 
+Example CMake usage::
+
+    cmake -S . -B build -DUSE_TICKET_LOCK=ON && ninja -C build
+
+Using Meson::
+
+    USE_TICKET_LOCK=1 meson setup build && ninja -C build
+
+To switch back to qspinlocks::
+
+    cmake -S . -B build -DUSE_TICKET_LOCK=OFF && ninja -C build
+
+Disable the option by setting ``OFF`` (or ``0`` for Meson).  The
+default build uses qspinlocks.
+
 CODE FORMATTING
 ---------------
 The project includes a ``.clang-format`` file configured for the LLVM

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,11 @@
 project('xv6', 'c', default_options: ['c_std=c23'])
 
+use_ticket_lock = get_option('use_ticket_lock')
+common_cargs = []
+if use_ticket_lock
+  common_cargs += ['-DUSE_TICKET_LOCK']
+endif
+
 clang_tidy = find_program('clang-tidy', required: false)
 bison = find_program('bison', required: false)
 if bison.found()
@@ -35,7 +41,8 @@ libos_sources = [
 ]
 
 libos = static_library('libos', libos_sources,
-    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'))
+    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'),
+    c_args: common_cargs)
 
 src_dirs = ['src-kernel', 'src-uland', 'src-uland/user', 'libos']
 
@@ -51,7 +58,8 @@ kernel = executable('kernel', sources,
                                             'proto',
                                             'libos/include',
                                             'libos/capnp'),
-           install: false)
+           install: false,
+           c_args: common_cargs)
 
 if clang_tidy.found()
   run_target('clang-tidy', command: [clang_tidy, sources],
@@ -112,7 +120,8 @@ foreach name, path : uprogs
   exe = executable('_' + name, path,
                    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'),
                    link_with: libos,
-                   install: false)
+                   install: false,
+                   c_args: common_cargs)
   uprogs_targets += exe
 endforeach
 

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('use_ticket_lock', type: 'boolean', value : false, description : 'Use ticket-based spinlocks instead of qspinlock')

--- a/src-headers/libos/spinlock.h
+++ b/src-headers/libos/spinlock.h
@@ -3,6 +3,12 @@
 #include <stddef.h>
 #include <stdint.h>
 
+struct spinlock; // forward declaration for prototypes below
+#if defined(SPINLOCK_NO_STUBS) && !defined(USE_TICKET_LOCK)
+void qspin_lock(struct spinlock *lk);
+void qspin_unlock(struct spinlock *lk);
+#endif
+
 struct ticketlock {
   _Atomic unsigned short head;
   _Atomic unsigned short tail;
@@ -27,6 +33,7 @@ static inline void initlock(struct spinlock *lk, const char *name) {
 }
 
 static inline void acquire(struct spinlock *lk) {
+#ifdef USE_TICKET_LOCK
   pushcli();
   if (holding(lk))
     panic("acquire");
@@ -39,9 +46,13 @@ static inline void acquire(struct spinlock *lk) {
   __sync_synchronize();
   lk->cpu = mycpu();
   getcallerpcs(&lk, lk->pcs);
+#else
+  qspin_lock(lk);
+#endif
 }
 
 static inline void release(struct spinlock *lk) {
+#ifdef USE_TICKET_LOCK
   if (!holding(lk))
     panic("release");
 
@@ -50,6 +61,9 @@ static inline void release(struct spinlock *lk) {
   __sync_synchronize();
   __atomic_fetch_add(&lk->ticket.head, 1, __ATOMIC_SEQ_CST);
   popcli();
+#else
+  qspin_unlock(lk);
+#endif
 }
 
 #else


### PR DESCRIPTION
## Summary
- support selecting ticket locks at build time
- mirror the setting for libOS spinlocks
- pass `-DUSE_TICKET_LOCK` from both CMake and Meson
- document how to toggle the option in the README

## Testing
- `pytest -q`