### PR TITLE
Use standard memory helpers

### DIFF
--- a/src-kernel/endpoint.c
+++ b/src-kernel/endpoint.c
@@ -3,6 +3,7 @@
 #include "proc.h"
 #include "defs.h"
 #include "endpoint.h"
+#include <string.h>
 
 static struct endpoint global_ep;
 
@@ -38,7 +39,7 @@ void endpoint_send(struct endpoint *ep, zipc_msg_t *m) {
         return;
       }
     zipc_msg_t tmp = {0};
-    memmove(&tmp, m, sz);
+    memcpy(&tmp, m, sz);
     ep->q[ep->w % ep->size] = tmp;
     ep->w++;
     wakeup(&ep->r);
@@ -59,7 +60,7 @@ void endpoint_send(struct endpoint *ep, zipc_msg_t *m) {
   zipc_msg_t t = ep->q[ep->r % ep->size];
   ep->r++;
   size_t sz = msg_desc_size(ep->desc);
-  memmove(m, &t, sz);
+  memcpy(m, &t, sz);
   memset((char *)m + sz, 0, sizeof(zipc_msg_t) - sz);
   release(&ep->lock);
   return 0;
@@ -79,6 +80,6 @@ int sys_endpoint_recv(void) {
   if (argptr(0, (void *)&udst, sizeof(*udst)) < 0)
     return -1;
   endpoint_recv(&global_ep, &m);
-  memmove(udst, &m, sizeof(m));
+  memcpy(udst, &m, sizeof(m));
   return 0;
 }

--- a/src-kernel/exo_disk.c
+++ b/src-kernel/exo_disk.c
@@ -5,6 +5,7 @@
 #include "buf.h"
 #include "exo_disk.h"
 #include <errno.h>
+#include <string.h>
 #define EXO_KERNEL
 #include "include/exokernel.h"
 
@@ -31,7 +32,7 @@
       releasesleep(&b.lock);
       return r;
     }
-    memmove((char *)dst + tot, b.data + cur % BSIZE, m);
+    memcpy((char *)dst + tot, b.data + cur % BSIZE, m);
     releasesleep(&b.lock);
 
     tot += m;
@@ -56,7 +57,7 @@
     size_t m = MIN(n - tot, BSIZE - cur % BSIZE);
 
     acquiresleep(&b.lock);
-    memmove(b.data + cur % BSIZE, (char *)src + tot, m);
+    memcpy(b.data + cur % BSIZE, (char *)src + tot, m);
     int r = exo_bind_block(&blk, &b, 1);
     if (r < 0) {
       releasesleep(&b.lock);

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -5,6 +5,7 @@
 #include "spinlock.h"
 #include "types.h"
 #include <errno.h>
+#include <string.h>
 #define EXO_KERNEL
 #include "include/exokernel.h"
 
@@ -33,21 +34,21 @@ static void ipc_init(void) {
 
 int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
   ipc_init();
-  if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
+  if (!cap_has_rights(dest.rights, EXO_RIGHT_W))
     return -EPERM;
   if (len > sizeof(zipc_msg_t) + sizeof(exo_cap))
     len = sizeof(zipc_msg_t) + sizeof(exo_cap);
 
   zipc_msg_t m = {0};
   size_t mlen = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
-  memmove(&m, buf, mlen);
+  memcpy(&m, buf, mlen);
 
   exo_cap fr = {0};
   if (len > sizeof(zipc_msg_t)) {
-    memmove(&fr, (const char *)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
+    memcpy(&fr, (const char *)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
     if (!cap_verify(fr))
       return -EPERM;
-    if(!cap_has_rights(fr.rights, EXO_RIGHT_R))
+    if (!cap_has_rights(fr.rights, EXO_RIGHT_R))
       return -EPERM;
     if (dest.owner)
       fr.owner = dest.owner;
@@ -68,7 +69,7 @@ int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
 }
 
 int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
-  if(!cap_has_rights(src.rights, EXO_RIGHT_R))
+  if (!cap_has_rights(src.rights, EXO_RIGHT_R))
     return -EPERM;
   ipc_init();
   acquire(&ipcs.lock);
@@ -81,8 +82,8 @@ int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
   wakeup(&ipcs.w);
   release(&ipcs.lock);
 
-  if (e.frame.pa && (!cap_verify(e.frame) ||
-                     !cap_has_rights(e.frame.rights, EXO_RIGHT_R)))
+  if (e.frame.pa &&
+      (!cap_verify(e.frame) || !cap_has_rights(e.frame.rights, EXO_RIGHT_R)))
     e.frame.pa = 0;
 
   size_t total = sizeof(zipc_msg_t);
@@ -95,16 +96,16 @@ int exo_ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
     len = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
 
   size_t cplen = len < sizeof(zipc_msg_t) ? len : sizeof(zipc_msg_t);
-  memmove(buf, &e.msg, cplen);
+  memcpy(buf, &e.msg, cplen);
   if (cplen < len) {
-    memmove((char *)buf + sizeof(zipc_msg_t), &e.frame,
-            len - sizeof(zipc_msg_t));
+    memcpy((char *)buf + sizeof(zipc_msg_t), &e.frame,
+           len - sizeof(zipc_msg_t));
   }
 
   return (int)len;
 }
 
 struct exo_ipc_ops exo_ipc_queue_ops = {
-  .send = exo_ipc_queue_send,
-  .recv = exo_ipc_queue_recv,
+    .send = exo_ipc_queue_send,
+    .recv = exo_ipc_queue_recv,
 };

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -3,6 +3,7 @@
 #include "date.h"
 #include "defs.h"
 #include "exo.h"
+#include <string.h>
 #include "fs.h"
 #include "sleeplock.h"
 #include "buf.h"
@@ -98,7 +99,7 @@ int sys_exo_alloc_page(void) {
   if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_page();
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -133,7 +134,7 @@ int sys_exo_alloc_ioport(void) {
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_ioport((uint32_t)port);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -143,7 +144,7 @@ int sys_exo_bind_irq(void) {
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_bind_irq((uint32_t)irq);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -153,7 +154,7 @@ int sys_exo_alloc_dma(void) {
   if (argint(0, &chan) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_dma((uint32_t)chan);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -172,10 +173,10 @@ int sys_exo_bind_block(void) {
   initsleeplock(&b.lock, "exoblk");
   acquiresleep(&b.lock);
   if (write)
-    memmove(b.data, data, BSIZE);
+    memcpy(b.data, data, BSIZE);
   int r = exo_bind_block(&cap, &b, write);
   if (!write)
-    memmove(data, b.data, BSIZE);
+    memcpy(data, b.data, BSIZE);
   releasesleep(&b.lock);
   return r;
 }
@@ -185,15 +186,14 @@ int sys_exo_flush_block(void) {
   char *data;
   struct buf b;
 
-  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
-      argptr(1, &data, BSIZE) < 0)
+  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 || argptr(1, &data, BSIZE) < 0)
     return -1;
 
   cap = *ucap;
   memset(&b, 0, sizeof(b));
   initsleeplock(&b.lock, "exoflush");
   acquiresleep(&b.lock);
-  memmove(b.data, data, BSIZE);
+  memcpy(b.data, data, BSIZE);
   int r = exo_bind_block(&cap, &b, 1);
   releasesleep(&b.lock);
   return r;
@@ -203,7 +203,7 @@ int sys_exo_yield_to(void) {
   exo_cap *ucap, cap;
   if (argptr(0, (void *)&ucap, sizeof(cap)) < 0)
     return -1;
-  memmove(&cap, ucap, sizeof(cap));
+  memcpy(&cap, ucap, sizeof(cap));
   if (!cap_verify(cap))
     return -1;
   return exo_yield_to(cap);
@@ -214,10 +214,8 @@ int sys_exo_read_disk(void) {
   char *dst;
   uint32_t off, n;
 
-  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
-      argint(2, (int *)&off) < 0 ||
-      argint(3, (int *)&n) < 0 ||
-      argptr(1, &dst, n) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 || argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 || argptr(1, &dst, n) < 0)
 
     return -1;
   return exo_read_disk(cap, dst, off, n);
@@ -228,10 +226,8 @@ int sys_exo_write_disk(void) {
   char *src;
   uint32_t off, n;
 
-  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 ||
-      argint(2, (int *)&off) < 0 ||
-      argint(3, (int *)&n) < 0 ||
-      argptr(1, &src, n) < 0)
+  if (argptr(0, (void *)&cap, sizeof(cap)) < 0 || argint(2, (int *)&off) < 0 ||
+      argint(3, (int *)&n) < 0 || argptr(1, &src, n) < 0)
 
     return -1;
   return exo_write_disk(cap, src, off, n);
@@ -243,7 +239,7 @@ int sys_exo_alloc_ioport(void) {
   if (argint(0, &port) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_ioport((uint32_t)port);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -253,7 +249,7 @@ int sys_exo_bind_irq(void) {
   if (argint(0, &irq) < 0 || argptr(1, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_bind_irq((uint32_t)irq);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -262,7 +258,7 @@ int sys_exo_alloc_dma(void) {
   if (argptr(0, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_dma();
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 
@@ -270,11 +266,10 @@ int sys_exo_send(void) {
   exo_cap *ucap, cap;
   char *src;
   uint32_t n;
-  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
-      argint(2, (int *)&n) < 0 ||
+  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 || argint(2, (int *)&n) < 0 ||
       argptr(1, &src, n) < 0)
     return -1;
-  memmove(&cap, ucap, sizeof(cap));
+  memcpy(&cap, ucap, sizeof(cap));
   if (!cap_verify(cap))
     return -1;
   return exo_send(cap, src, n);
@@ -284,11 +279,10 @@ int sys_exo_recv(void) {
   exo_cap *ucap, cap;
   char *dst;
   uint32_t n;
-  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
-      argint(2, (int *)&n) < 0 ||
+  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 || argint(2, (int *)&n) < 0 ||
       argptr(1, &dst, n) < 0)
     return -1;
-  memmove(&cap, ucap, sizeof(cap));
+  memcpy(&cap, ucap, sizeof(cap));
   if (!cap_verify(cap))
     return -1;
   return exo_recv(cap, dst, n);
@@ -359,9 +353,7 @@ int sys_set_gas(void) {
   return 0;
 }
 
-int sys_get_gas(void) {
-  return (int)myproc()->gas_remaining;
-}
+int sys_get_gas(void) { return (int)myproc()->gas_remaining; }
 
 int sys_sigsend(void) {
   int pid, sig;
@@ -399,7 +391,7 @@ int sys_exo_irq_alloc(void) {
       argptr(2, (void *)&ucap, sizeof(*ucap)) < 0)
     return -1;
   exo_cap cap = exo_alloc_irq((uint32_t)irq, (uint32_t)rights);
-  memmove(ucap, &cap, sizeof(cap));
+  memcpy(ucap, &cap, sizeof(cap));
   return 0;
 }
 

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -8,6 +8,7 @@
 #include "cap.h"
 #include "exo.h"
 #include "elf.h"
+#include <string.h>
 
 extern char data[]; // defined by kernel.ld
 #if defined(__x86_64__) || defined(__aarch64__)
@@ -59,7 +60,8 @@ static pte_t *walkpgdir(pde_t *pgdir, const void *va, int alloc) {
 // Create PTEs for virtual addresses starting at va that refer to
 // physical addresses starting at pa. va and size might not
 // be page-aligned.
-static int mappages(pde_t *pgdir, void *va, uint32_t size, uint32_t pa, int perm) {
+static int mappages(pde_t *pgdir, void *va, uint32_t size, uint32_t pa,
+                    int perm) {
   char *a, *last;
   pte_t *pte;
 
@@ -393,7 +395,7 @@ copyout(pde_t *pgdir, uint32_t va, void *p, size_t len)
     n = PGSIZE - (va - va0);
     if (n > len)
       n = len;
-    memmove(pa0 + (va - va0), buf, n);
+    memcpy(pa0 + (va - va0), buf, n);
     len -= n;
     buf += n;
     va = va0 + PGSIZE;

--- a/src-uland/ulib.c
+++ b/src-uland/ulib.c
@@ -2,105 +2,77 @@
 #include "stat.h"
 #include "fcntl.h"
 #include "user.h"
-#include "x86.h"
+#include <string.h>
 
-char*
-strcpy(char *s, const char *t)
-{
+char *strcpy(char *s, const char *t) {
   char *os;
 
   os = s;
-  while((*s++ = *t++) != 0)
+  while ((*s++ = *t++) != 0)
     ;
   return os;
 }
 
-int
-strcmp(const char *p, const char *q)
-{
-  while(*p && *p == *q)
+int strcmp(const char *p, const char *q) {
+  while (*p && *p == *q)
     p++, q++;
   return (uint8_t)*p - (uint8_t)*q;
 }
 
-size_t
-strlen(const char *s)
-{
+size_t strlen(const char *s) {
   int n;
 
-  for(n = 0; s[n]; n++)
+  for (n = 0; s[n]; n++)
     ;
   return n;
 }
 
-void*
-memset(void *dst, int c, size_t n)
-{
-  stosb(dst, c, n);
-  return dst;
-}
+void *memset(void *dst, int c, size_t n) { return __builtin_memset(dst, c, n); }
 
-char*
-strchr(const char *s, char c)
-{
-  for(; *s; s++)
-    if(*s == c)
-      return (char*)s;
+char *strchr(const char *s, char c) {
+  for (; *s; s++)
+    if (*s == c)
+      return (char *)s;
   return 0;
 }
 
-char*
-gets(char *buf, size_t max)
-{
+char *gets(char *buf, size_t max) {
   size_t i, cc;
   char c;
 
-  for(i=0; i+1 < max; ){
+  for (i = 0; i + 1 < max;) {
     cc = read(0, &c, 1);
-    if(cc < 1)
+    if (cc < 1)
       break;
     buf[i++] = c;
-    if(c == '\n' || c == '\r')
+    if (c == '\n' || c == '\r')
       break;
   }
   buf[i] = '\0';
   return buf;
 }
 
-int
-stat(const char *n, struct stat *st)
-{
+int stat(const char *n, struct stat *st) {
   int fd;
   int r;
 
   fd = open(n, O_RDONLY);
-  if(fd < 0)
+  if (fd < 0)
     return -1;
   r = fstat(fd, st);
   close(fd);
   return r;
 }
 
-int
-atoi(const char *s)
-{
+int atoi(const char *s) {
   int n;
 
   n = 0;
-  while('0' <= *s && *s <= '9')
-    n = n*10 + *s++ - '0';
+  while ('0' <= *s && *s <= '9')
+    n = n * 10 + *s++ - '0';
   return n;
 }
 
-void*
-memmove(void *vdst, const void *vsrc, size_t n)
-{
-  char *dst;
-  const char *src;
-
-  dst = vdst;
-  src = vsrc;
-  while(n-- > 0)
-    *dst++ = *src++;
-  return vdst;
+void *memmove(void *vdst, const void *vsrc, size_t n) {
+  return __builtin_memmove(vdst, vsrc, n);
 }


### PR DESCRIPTION
## Summary
- delegate user-space `memset`/`memmove` to compiler built‑ins
- include `<string.h>` in user library
- use `memcpy` in kernel boundary helpers
- include `<string.h>` in affected kernel code

## Testing
- `pytest -q`