### PR TITLE
Add strict warning flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ file(GLOB_RECURSE KERNEL_SOURCES
 )
 
 add_executable(kernel ${KERNEL_SOURCES})
+target_compile_options(kernel PRIVATE -Wall -Werror)
 
 # QEMU executable used for run targets
 find_program(QEMU_EXECUTABLE

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,5 @@
 project('xv6', 'c', default_options: ['c_std=c23'])
+add_project_arguments('-Wall', '-Werror', language: ['c', 'cpp'])
 
 clang_tidy = find_program('clang-tidy', required: false)
 bison = find_program('bison', required: false)

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -55,7 +55,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c2x",
+            "gcc", "-std=c2x", "-Wall", "-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_entry_cpp.py
+++ b/tests/test_cap_entry_cpp.py
@@ -17,7 +17,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(CPP_CODE)
         subprocess.check_call([
-            "g++","-std=c++17",
+            "g++","-std=c++17","-Wall","-Werror",
             "-iquote", str(ROOT),
             "-iquote", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_cap_newtypes.py
+++ b/tests/test_cap_newtypes.py
@@ -47,7 +47,7 @@ def compile_and_run():
         (pathlib.Path(td)/"mmu.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -48,7 +48,7 @@ def compile_and_run():
         (pathlib.Path(td)/"mmu.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_cap_types.py
+++ b/tests/test_cap_types.py
@@ -48,7 +48,7 @@ def compile_and_run():
         (pathlib.Path(td)/"mmu.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -44,7 +44,7 @@ def compile_and_run() -> None:
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(C_CODE)
-        subprocess.check_call(["gcc", "-std=c2x", str(src), "-o", str(exe)])
+        subprocess.check_call(["gcc", "-std=c2x", "-Wall", "-Werror", str(src), "-o", str(exe)])
         subprocess.check_call([str(exe)])
 
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -39,6 +39,8 @@ def compile_and_run() -> None:
             [
                 "gcc",
                 "-std=c2x",
+                "-Wall",
+                "-Werror",
                 "-I",
                 str(ROOT),
                 "-I",

--- a/tests/test_exo_ipc_direct.py
+++ b/tests/test_exo_ipc_direct.py
@@ -80,7 +80,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
         )
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_exo_recv_timed.py
+++ b/tests/test_exo_recv_timed.py
@@ -65,7 +65,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
         )
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_iommu.py
+++ b/tests/test_iommu.py
@@ -49,7 +49,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc", "-std=c2x",
+            "gcc", "-std=c2x", "-Wall", "-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -54,7 +54,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -59,7 +59,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c2x","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c2x","-Wall","-Werror","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_lockstress.py
+++ b/tests/test_lockstress.py
@@ -85,7 +85,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            "gcc","-std=c2x","-pthread","-DSPINLOCK_NO_STUBS",
+            "gcc","-std=c2x","-Wall","-Werror","-pthread","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers/libos"),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_mailbox_isolation.py
+++ b/tests/test_mailbox_isolation.py
@@ -68,7 +68,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
         )
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_ptrace_concurrent.py
+++ b/tests/test_ptrace_concurrent.py
@@ -52,7 +52,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             str(src),
             "-o", str(exe)
         ])

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -22,7 +22,7 @@ def compile_and_run(use_stub):
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "src-headers/libos/spinlock.h"\n')
         cmd = [
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_sys_ipc.py
+++ b/tests/test_sys_ipc.py
@@ -71,7 +71,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
         subprocess.check_call([
-            "gcc", "-std=c2x",
+            "gcc", "-std=c2x", "-Wall", "-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),

--- a/tests/test_uv_spinlock_processes.py
+++ b/tests/test_uv_spinlock_processes.py
@@ -53,7 +53,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_uv_spinlock_threads.py
+++ b/tests/test_uv_spinlock_threads.py
@@ -40,7 +40,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            "gcc","-std=c2x","-pthread",
+            "gcc","-std=c2x","-Wall","-Werror","-pthread",
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -55,7 +55,7 @@ def compile_and_run(body):
         (pathlib.Path(td)/"mmu.h").write_text('#include "src-headers/types.h"\n#include "src-headers/mmu.h"\n')
         (pathlib.Path(td)/"memlayout.h").write_text('#include "src-headers/memlayout.h"\n')
         subprocess.check_call([
-            "gcc","-std=c2x",
+            "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             str(src),


### PR DESCRIPTION
## Summary
- use `-Wall -Werror` for kernel build in CMake
- set equivalent flags in meson build
- compile tests with `-Wall -Werror`

## Testing
- `pytest -q` *(fails: warnings treated as errors)*