### PR TITLE
Introduce exo_ipc_status enumeration

### DIFF
--- a/doc/IPC.md
+++ b/doc/IPC.md
@@ -12,13 +12,16 @@ Timeouts are encoded as a `timeout_t` value passed to `sys_ipc`. When the wait p
 
 ## Status Codes
 
-`IPC_STATUS_SUCCESS`  – operation completed normally.
+`IPC_STATUS_SUCCESS`  – operation completed normally and the message buffer now
+contains valid data.
 
 `IPC_STATUS_TIMEOUT`  – receiver waited past the specified timeout.
 
 `IPC_STATUS_AGAIN`    – destination mailbox was full.
 
 `IPC_STATUS_BADDEST`  – the destination thread or process id was invalid.
+
+`IPC_STATUS_ERROR`    – unspecified failure such as invalid arguments.
 
 ## Typed Channels and Capabilities
 

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -264,8 +264,8 @@ provided in `caplib.h` and `libos/libfs.h`:
 ```c
 exo_cap cap_alloc_page(void);
 int cap_unbind_page(exo_cap cap);
-int cap_send(exo_cap dest, const void *buf, uint64 len);
-int cap_recv(exo_cap src, void *buf, uint64 len);
+exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64 len);
+exo_ipc_status cap_recv(exo_cap src, void *buf, uint64 len);
 int fs_alloc_block(uint dev, uint rights, struct exo_blockcap *cap);
 int fs_read_block(struct exo_blockcap cap, void *dst);
 int fs_write_block(struct exo_blockcap cap, const void *src);
@@ -315,7 +315,7 @@ connecting to drivers:
 
 ```c
 int driver_spawn(const char *path, char *const argv[]);
-int driver_connect(int pid, exo_cap ep);
+exo_ipc_status driver_connect(int pid, exo_cap ep);
 ```
 
 `driver_spawn` forks and executes the given program while

--- a/doc/track_technical.md
+++ b/doc/track_technical.md
@@ -48,8 +48,8 @@ services. Key entry points include:
 ```c
 exo_cap cap_alloc_page(void);
 int cap_unbind_page(exo_cap cap);
-int cap_send(exo_cap dest, const void *buf, uint64 len);
-int cap_recv(exo_cap src, void *buf, uint64 len);
+exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64 len);
+exo_ipc_status cap_recv(exo_cap src, void *buf, uint64 len);
 ```
 
 Typed channels declared with `CHAN_DECLARE` automatically serialise Cap'n

--- a/libos/affine_runtime.c
+++ b/libos/affine_runtime.c
@@ -18,22 +18,22 @@ affine_chan_create(const struct msg_type_desc *desc) {
 void affine_chan_destroy(affine_chan_t *c) { free(c); }
 
 // Send once through the channel
-[[nodiscard]] int affine_chan_send(affine_chan_t *c, exo_cap dest,
+[[nodiscard]] exo_ipc_status affine_chan_send(affine_chan_t *c, exo_cap dest,
                                    const void *msg, size_t len) {
   if (!c || c->used_send)
-    return -1;
-  int r = chan_endpoint_send(&c->base, dest, msg, len);
+    return IPC_STATUS_ERROR;
+  exo_ipc_status r = chan_endpoint_send(&c->base, dest, msg, len);
   if (r == 0)
     c->used_send = 1;
   return r;
 }
 
 // Receive once through the channel
-[[nodiscard]] int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg,
-                                   size_t len) {
+[[nodiscard]] exo_ipc_status affine_chan_recv(affine_chan_t *c, exo_cap src,
+                                   void *msg, size_t len) {
   if (!c || c->used_recv)
-    return -1;
-  int r = chan_endpoint_recv(&c->base, src, msg, len);
+    return IPC_STATUS_ERROR;
+  exo_ipc_status r = chan_endpoint_recv(&c->base, src, msg, len);
   if (r == 0)
     c->used_recv = 1;
   return r;

--- a/libos/ddekit.c
+++ b/libos/ddekit.c
@@ -20,10 +20,10 @@ void ddekit_yield(void) { yield(); }
 
 exo_cap ddekit_cap_alloc_page(void) { return capwrap_alloc_page(); }
 
-int ddekit_cap_send(exo_cap dest, const void *buf, size_t len) {
+exo_ipc_status ddekit_cap_send(exo_cap dest, const void *buf, size_t len) {
     return capwrap_send(dest, buf, len);
 }
 
-int ddekit_cap_recv(exo_cap src, void *buf, size_t len) {
+exo_ipc_status ddekit_cap_recv(exo_cap src, void *buf, size_t len) {
     return capwrap_recv(src, buf, len);
 }

--- a/libos/driver.c
+++ b/libos/driver.c
@@ -10,6 +10,6 @@
   return pid;
 }
 
-[[nodiscard]] int driver_connect(int pid, exo_cap ep) {
+[[nodiscard]] exo_ipc_status driver_connect(int pid, exo_cap ep) {
   return cap_send(ep, &pid, sizeof(pid));
 }

--- a/libos/ipc_queue.c
+++ b/libos/ipc_queue.c
@@ -27,10 +27,10 @@ static void ipc_init(void) {
     }
 }
 
-int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
+exo_ipc_status ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
     ipc_init();
     if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
-        return -EPERM;
+        return IPC_STATUS_ERROR;
     if(len > sizeof(zipc_msg_t) + sizeof(exo_cap))
         len = sizeof(zipc_msg_t) + sizeof(exo_cap);
 
@@ -42,7 +42,7 @@ int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
     if(len > sizeof(zipc_msg_t)) {
         memmove(&fr, (const char*)buf + sizeof(zipc_msg_t), sizeof(exo_cap));
         if(!cap_has_rights(fr.rights, EXO_RIGHT_R))
-            return -EPERM;
+            return IPC_STATUS_ERROR;
         if(dest.owner)
             fr.owner = dest.owner;
     }
@@ -60,23 +60,22 @@ int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
     return exo_send(dest, buf, len);
 }
 
-int ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
+exo_ipc_status ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
     if(!cap_has_rights(src.rights, EXO_RIGHT_R))
-        return -EPERM;
+        return IPC_STATUS_ERROR;
     ipc_init();
     uv_spinlock_lock(&ipcs.lock);
     while(ipcs.r == ipcs.w) {
         uv_spinlock_unlock(&ipcs.lock);
         char tmp[sizeof(zipc_msg_t) + sizeof(exo_cap)];
-        int r = exo_recv(src, tmp, sizeof(tmp));
-        if(r > 0) {
+        exo_ipc_status r = exo_recv(src, tmp, sizeof(tmp));
+        if(r == IPC_STATUS_SUCCESS) {
             uv_spinlock_lock(&ipcs.lock);
             struct ipc_entry *e = &ipcs.buf[ipcs.w % IPC_BUFSZ];
             memset(e, 0, sizeof(*e));
-            size_t cplen = r < sizeof(zipc_msg_t) ? r : sizeof(zipc_msg_t);
+            size_t cplen = sizeof(zipc_msg_t);
             memmove(&e->msg, tmp, cplen);
-            if(r > sizeof(zipc_msg_t))
-                memmove(&e->frame, tmp + sizeof(zipc_msg_t), r - sizeof(zipc_msg_t));
+            memmove(&e->frame, tmp + sizeof(zipc_msg_t), sizeof(exo_cap));
             ipcs.w++;
         } else {
             uv_spinlock_lock(&ipcs.lock);
@@ -99,5 +98,5 @@ int ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
     if(cplen < len)
         memmove((char*)buf + sizeof(zipc_msg_t), &e.frame, len - sizeof(zipc_msg_t));
 
-    return (int)len;
+    return IPC_STATUS_SUCCESS;
 }

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -2,14 +2,15 @@
 #include "exo.h"
 #include "exo_cpu.h"
 #include "exokernel.h"
+#include "exo_ipc.h"
 
 exo_cap cap_alloc_page(void);
 [[nodiscard]] int cap_unbind_page(exo_cap cap);
 [[nodiscard]] int cap_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap);
 [[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write);
 void cap_flush_block(exo_blockcap *cap, void *data);
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len);
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len);
 [[nodiscard]] int cap_set_timer(void (*handler)(void));
 [[nodiscard]] int cap_set_gas(uint64_t amount);
 [[nodiscard]] int cap_get_gas(void);

--- a/src-headers/chan.h
+++ b/src-headers/chan.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "types.h"
 #include "caplib.h"
+#include "exo_ipc.h"
 
 // Generic channel descriptor storing expected message size and type
 typedef struct chan {
@@ -15,10 +16,10 @@ typedef struct chan {
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len);
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len);
+[[nodiscard]] exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                                const void *msg, size_t len);
+[[nodiscard]] exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+                                                size_t len);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
@@ -32,14 +33,16 @@ void chan_destroy(chan_t *c);
     return (name##_t *)chan_create(&name##_typedesc);                          \
   }                                                                            \
   static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
-  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+  static inline exo_ipc_status name##_send(name##_t *c, exo_cap dest,            \
+                                          const type *m) {                      \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
     type##_encode(m, buf);                                                     \
     return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
   }                                                                            \
-  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+  static inline exo_ipc_status name##_recv(name##_t *c, exo_cap src, type *m) { \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
-    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
+    exo_ipc_status r =                                                      \
+        chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);          \
     if (r == 0)                                                                \
       type##_decode(m, buf);                                                   \
     return r;                                                                  \

--- a/src-headers/ddekit.h
+++ b/src-headers/ddekit.h
@@ -14,5 +14,5 @@ void ddekit_process_exit(int code) __attribute__((noreturn));
 void ddekit_yield(void);
 
 exo_cap ddekit_cap_alloc_page(void);
-int ddekit_cap_send(exo_cap dest, const void *buf, size_t len);
-int ddekit_cap_recv(exo_cap src, void *buf, size_t len);
+exo_ipc_status ddekit_cap_send(exo_cap dest, const void *buf, size_t len);
+exo_ipc_status ddekit_cap_recv(exo_cap src, void *buf, size_t len);

--- a/src-headers/door.h
+++ b/src-headers/door.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "ipc.h"
 #include "caplib.h"
+#include "exo_ipc.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -14,7 +15,7 @@ typedef struct door {
 
 door_t door_create_local(void (*handler)(zipc_msg_t *msg));
 door_t door_create_remote(exo_cap dest);
-[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg);
+[[nodiscard]] exo_ipc_status door_call(door_t *d, zipc_msg_t *msg);
 void door_server_loop(door_t *d);
 
 #ifdef __cplusplus

--- a/src-headers/driver.h
+++ b/src-headers/driver.h
@@ -3,4 +3,4 @@
 #include "caplib.h"
 
 [[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
-[[nodiscard]] int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] exo_ipc_status driver_connect(int pid, exo_cap ep);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -3,11 +3,19 @@
 #include "exo_mem.h"
 #include "../exo.h"
 
+typedef enum {
+  IPC_STATUS_SUCCESS = 0,
+  IPC_STATUS_TIMEOUT,
+  IPC_STATUS_AGAIN,
+  IPC_STATUS_BADDEST,
+  IPC_STATUS_ERROR = -1
+} exo_ipc_status;
+
 struct exo_ipc_ops {
-  int (*send)(exo_cap dest, const void *buf, uint64_t len);
-  int (*recv)(exo_cap src, void *buf, uint64_t len);
+  exo_ipc_status (*send)(exo_cap dest, const void *buf, uint64_t len);
+  exo_ipc_status (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
 void exo_ipc_register(struct exo_ipc_ops *ops);
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status exo_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -2,6 +2,7 @@
 #include "types.h"
 #include "exo.h"
 #include "syscall.h"
+#include "exo_ipc.h"
 
 /* Capability access rights. */
 #define EXO_RIGHT_R 0x1
@@ -54,11 +55,11 @@ exo_cap exo_alloc_dma(uint32_t chan);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any queuing
  * or flow control is managed in user space. */
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status exo_send(exo_cap dest, const void *buf, uint64_t len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
 [[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64_t off,

--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -3,4 +3,4 @@
 #include "caplib.h"
 
 [[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
-[[nodiscard]] int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] exo_ipc_status driver_connect(int pid, exo_cap ep);

--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "exo_ipc.h"
 
-int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
-int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+exo_ipc_status ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
+exo_ipc_status ipc_queue_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-kernel/chan.c
+++ b/src-kernel/chan.c
@@ -2,7 +2,8 @@
 #include "exo_ipc.h"
 
 // Kernel variant of chan_endpoint_send validating the message size
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
+[[nodiscard]] exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                     const void *msg,
                                      size_t len) {
   if (!c) {
     cprintf("chan_endpoint_send: null channel\n");
@@ -17,7 +18,7 @@
 }
 
 // Kernel variant of chan_endpoint_recv validating the message size
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+[[nodiscard]] exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
                                      size_t len) {
   if (!c) {
     cprintf("chan_endpoint_recv: null channel\n");

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -6,14 +6,14 @@ static struct exo_ipc_ops ipc_ops;
 
 void exo_ipc_register(struct exo_ipc_ops *ops) { ipc_ops = *ops; }
 
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+[[nodiscard]] exo_ipc_status exo_send(exo_cap dest, const void *buf, uint64_t len) {
   if (ipc_ops.send)
     return ipc_ops.send(dest, buf, len);
-  return -1;
+  return IPC_STATUS_ERROR;
 }
 
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len) {
+[[nodiscard]] exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len) {
   if (ipc_ops.recv)
     return ipc_ops.recv(src, buf, len);
-  return -1;
+  return IPC_STATUS_ERROR;
 }

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -46,11 +46,11 @@ void cap_yield_to(context_t **old, context_t *target) {
 extern int cap_revoke_syscall(void);
 int cap_revoke(void) { return cap_revoke_syscall(); }
 
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len) {
+[[nodiscard]] exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64_t len) {
   return exo_send(dest, buf, len);
 }
 
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len) {
+[[nodiscard]] exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len) {
   return exo_recv(src, buf, len);
 }
 

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -13,8 +13,8 @@
 
 void chan_destroy(chan_t *c) { free(c); }
 
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len) {
+[[nodiscard]] exo_ipc_status chan_endpoint_send(chan_t *c, exo_cap dest,
+                                                const void *msg, size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
            (int)c->msg_size);
@@ -23,8 +23,8 @@ void chan_destroy(chan_t *c) { free(c); }
   return cap_send(dest, msg, c->msg_size);
 }
 
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len) {
+[[nodiscard]] exo_ipc_status chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
+                                                size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
            (int)c->msg_size);

--- a/src-uland/door.c
+++ b/src-uland/door.c
@@ -1,4 +1,5 @@
 #include "door.h"
+#include "exo_ipc.h"
 #include <string.h>
 
 static void clear_cap(exo_cap *c) { memset(c, 0, sizeof(*c)); }
@@ -19,16 +20,16 @@ door_t door_create_remote(exo_cap dest) {
   return d;
 }
 
-[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg) {
+[[nodiscard]] exo_ipc_status door_call(door_t *d, zipc_msg_t *msg) {
   if (!d)
-    return -1;
+    return IPC_STATUS_ERROR;
   if (d->is_local) {
     if (d->handler)
       d->handler(msg);
-    return 0;
+    return IPC_STATUS_SUCCESS;
   }
-  if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
-    return -1;
+  if (cap_send(d->dest, msg, sizeof(*msg)) != IPC_STATUS_SUCCESS)
+    return IPC_STATUS_ERROR;
   return cap_recv(d->dest, msg, sizeof(*msg));
 }
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -12,8 +12,8 @@ C_CODE = textwrap.dedent(
 #include "src-headers/door.h"
 
 // stub implementations for caplib helpers
-int cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return 0; }
-int cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return 0; }
+exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return IPC_STATUS_SUCCESS; }
+exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return IPC_STATUS_SUCCESS; }
 
 static int called = 0;
 static void handler(zipc_msg_t *m) { called++; m->w0++; }


### PR DESCRIPTION
## Summary
- add `exo_ipc_status` enum to represent IPC return codes
- update IPC helper APIs for the new status type
- adjust door implementation and test
- update typed channel and driver helpers
- document IPC return codes

## Testing
- `pytest -k door -q`
- `pytest -q`