### PR TITLE
Update irq_trigger return

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -253,7 +253,7 @@ void exo_flush_block(struct exo_blockcap *, void *);
 exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights);
 int exo_irq_wait(exo_cap cap, uint32_t *irq);
 int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint32_t irq);
+int irq_trigger(uint32_t irq);
 exo_cap exo_alloc_ioport(uint32_t port);
 exo_cap exo_bind_irq(uint32_t irq);
 exo_cap exo_alloc_dma(uint32_t chan);

--- a/src-headers/exo_irq.h
+++ b/src-headers/exo_irq.h
@@ -10,7 +10,7 @@ extern "C" {
 exo_cap exo_alloc_irq(uint32_t irq, uint32_t rights);
 [[nodiscard]] int exo_irq_wait(exo_cap cap, uint32_t *irq);
 [[nodiscard]] int exo_irq_ack(exo_cap cap);
-void irq_trigger(uint32_t irq);
+int irq_trigger(uint32_t irq);
 
 #ifdef __cplusplus
 }

--- a/src-kernel/irq.c
+++ b/src-kernel/irq.c
@@ -68,13 +68,18 @@ static int check_irq_cap(exo_cap cap, uint32_t need) {
   return 0;
 }
 
-void irq_trigger(uint32_t irq) {
+int irq_trigger(uint32_t irq) {
   irq_init();
   acquire(&irq_q.lock);
+  int ret = 0;
   if (irq_q.w - irq_q.r < IRQ_BUFSZ) {
     irq_q.buf[irq_q.w % IRQ_BUFSZ] = irq;
     irq_q.w++;
     wakeup(&irq_q.r);
+    ret = 0;
+  } else {
+    ret = -ENOSPC;
   }
   release(&irq_q.lock);
+  return ret;
 }


### PR DESCRIPTION
## Summary
- make `irq_trigger` return an `int`
- update declarations and tests

## Testing
- `black --check tests/test_irq.py`
- `pytest tests/test_irq.py::test_irq_event -q` *(fails: ENOSPC undeclared)*