### PR TITLE
Fix door IPC status handling

### DIFF
--- a/libos/driver.c
+++ b/libos/driver.c
@@ -1,5 +1,6 @@
 #include "driver.h"
 #include "user.h"
+#include "exo_ipc.h"
 
 [[nodiscard]] int driver_spawn(const char *path, char *const argv[]) {
   int pid = fork();
@@ -11,5 +12,6 @@
 }
 
 [[nodiscard]] int driver_connect(int pid, exo_cap ep) {
-  return cap_send(ep, &pid, sizeof(pid));
+  exo_ipc_status st = cap_send(ep, &pid, sizeof(pid));
+  return st == IPC_STATUS_SUCCESS ? 0 : -1;
 }

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -3,6 +3,13 @@
 #include "exo_mem.h"
 #include "../exo.h"
 
+typedef enum {
+  IPC_STATUS_SUCCESS = 0,
+  IPC_STATUS_TIMEOUT,
+  IPC_STATUS_AGAIN,
+  IPC_STATUS_BADDEST,
+} exo_ipc_status;
+
 struct exo_ipc_ops {
   int (*send)(exo_cap dest, const void *buf, uint64_t len);
   int (*recv)(exo_cap src, void *buf, uint64_t len);

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -56,3 +56,51 @@ def compile_and_run() -> None:
 
 def test_door_call() -> None:
     compile_and_run()
+
+
+C_CODE_FAIL = textwrap.dedent(
+    """
+#include <assert.h>
+#include <stdint.h>
+#include "src-headers/exo_ipc.h"
+#include "src-headers/door.h"
+
+int cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return IPC_STATUS_SUCCESS; }
+int cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return IPC_STATUS_TIMEOUT; }
+
+int main(void) {
+    door_t d = door_create_remote((exo_cap){0});
+    zipc_msg_t m = {0};
+    assert(door_call(&d, &m) == -1);
+    return 0;
+}
+"""
+)
+
+
+def compile_and_run_fail() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td) / "test.c"
+        exe = pathlib.Path(td) / "test"
+        src.write_text(C_CODE_FAIL)
+        subprocess.check_call(
+            [
+                "gcc",
+                "-std=c2x",
+                "-Wall",
+                "-Werror",
+                "-I",
+                str(ROOT),
+                "-I",
+                str(ROOT / "src-headers"),
+                str(src),
+                str(ROOT / "src-uland/door.c"),
+                "-o",
+                str(exe),
+            ]
+        )
+        subprocess.check_call([str(exe)])
+
+
+def test_door_call_failure() -> None:
+    compile_and_run_fail()


### PR DESCRIPTION
## Summary
- add `exo_ipc_status` enum describing IPC result codes
- fail `door_call` when send/recv return a non-success status
- validate send result in `driver_connect`
- test both success and failure cases for door calls

## Testing
- `pytest tests/test_door.py -q`