### PR TITLE
Add exo_ipc_status enum

### DIFF
--- a/doc/IPC.md
+++ b/doc/IPC.md
@@ -12,6 +12,9 @@ Timeouts are encoded as a `timeout_t` value passed to `sys_ipc`. When the wait p
 
 ## Status Codes
 
+The following values are defined by the `exo_ipc_status` enumeration in
+`src-headers/exo_ipc.h`.
+
 `IPC_STATUS_SUCCESS`  – operation completed normally.
 
 `IPC_STATUS_TIMEOUT`  – receiver waited past the specified timeout.

--- a/libos/affine_runtime.c
+++ b/libos/affine_runtime.c
@@ -18,23 +18,23 @@ affine_chan_create(const struct msg_type_desc *desc) {
 void affine_chan_destroy(affine_chan_t *c) { free(c); }
 
 // Send once through the channel
-[[nodiscard]] int affine_chan_send(affine_chan_t *c, exo_cap dest,
-                                   const void *msg, size_t len) {
+[[nodiscard]] enum exo_ipc_status affine_chan_send(affine_chan_t *c, exo_cap dest,
+                                                   const void *msg, size_t len) {
   if (!c || c->used_send)
     return -1;
-  int r = chan_endpoint_send(&c->base, dest, msg, len);
-  if (r == 0)
+  enum exo_ipc_status r = chan_endpoint_send(&c->base, dest, msg, len);
+  if (r == IPC_STATUS_SUCCESS)
     c->used_send = 1;
   return r;
 }
 
 // Receive once through the channel
-[[nodiscard]] int affine_chan_recv(affine_chan_t *c, exo_cap src, void *msg,
-                                   size_t len) {
+[[nodiscard]] enum exo_ipc_status affine_chan_recv(affine_chan_t *c, exo_cap src,
+                                                   void *msg, size_t len) {
   if (!c || c->used_recv)
     return -1;
-  int r = chan_endpoint_recv(&c->base, src, msg, len);
-  if (r == 0)
+  enum exo_ipc_status r = chan_endpoint_recv(&c->base, src, msg, len);
+  if (r == IPC_STATUS_SUCCESS)
     c->used_recv = 1;
   return r;
 }

--- a/libos/driver.c
+++ b/libos/driver.c
@@ -10,6 +10,6 @@
   return pid;
 }
 
-[[nodiscard]] int driver_connect(int pid, exo_cap ep) {
+[[nodiscard]] enum exo_ipc_status driver_connect(int pid, exo_cap ep) {
   return cap_send(ep, &pid, sizeof(pid));
 }

--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -8,8 +8,9 @@ exo_cap cap_alloc_page(void);
 [[nodiscard]] int cap_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap);
 [[nodiscard]] int cap_bind_block(exo_blockcap *cap, void *data, int write);
 void cap_flush_block(exo_blockcap *cap, void *data);
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len);
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] enum exo_ipc_status cap_send(exo_cap dest, const void *buf,
+                                           uint64_t len);
+[[nodiscard]] enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len);
 [[nodiscard]] int cap_set_timer(void (*handler)(void));
 [[nodiscard]] int cap_set_gas(uint64_t amount);
 [[nodiscard]] int cap_get_gas(void);

--- a/src-headers/chan.h
+++ b/src-headers/chan.h
@@ -15,10 +15,10 @@ typedef struct chan {
 void chan_destroy(chan_t *c);
 
 // Send and receive through an exo capability endpoint
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len);
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len);
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len);
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
@@ -32,15 +32,18 @@ void chan_destroy(chan_t *c);
     return (name##_t *)chan_create(&name##_typedesc);                          \
   }                                                                            \
   static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
-  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+  static inline enum exo_ipc_status name##_send(name##_t *c, exo_cap dest,       \
+                                                const type *m) {                \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
     type##_encode(m, buf);                                                     \
     return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
   }                                                                            \
-  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+  static inline enum exo_ipc_status name##_recv(name##_t *c, exo_cap src,       \
+                                                type *m) {                      \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
-    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
-    if (r == 0)                                                                \
+    enum exo_ipc_status r =                                                   \
+        chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);           \
+    if (r == IPC_STATUS_SUCCESS)                                              \
       type##_decode(m, buf);                                                   \
     return r;                                                                  \
   }

--- a/src-headers/door.h
+++ b/src-headers/door.h
@@ -14,7 +14,7 @@ typedef struct door {
 
 door_t door_create_local(void (*handler)(zipc_msg_t *msg));
 door_t door_create_remote(exo_cap dest);
-[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg);
+[[nodiscard]] enum exo_ipc_status door_call(door_t *d, zipc_msg_t *msg);
 void door_server_loop(door_t *d);
 
 #ifdef __cplusplus

--- a/src-headers/driver.h
+++ b/src-headers/driver.h
@@ -3,4 +3,4 @@
 #include "caplib.h"
 
 [[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
-[[nodiscard]] int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] enum exo_ipc_status driver_connect(int pid, exo_cap ep);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -3,11 +3,19 @@
 #include "exo_mem.h"
 #include "../exo.h"
 
+enum exo_ipc_status {
+  IPC_STATUS_SUCCESS = 0,
+  IPC_STATUS_TIMEOUT,
+  IPC_STATUS_AGAIN,
+  IPC_STATUS_BADDEST,
+};
+
 struct exo_ipc_ops {
-  int (*send)(exo_cap dest, const void *buf, uint64_t len);
-  int (*recv)(exo_cap src, void *buf, uint64_t len);
+  enum exo_ipc_status (*send)(exo_cap dest, const void *buf, uint64_t len);
+  enum exo_ipc_status (*recv)(exo_cap src, void *buf, uint64_t len);
 };
 
 void exo_ipc_register(struct exo_ipc_ops *ops);
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                           uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -2,6 +2,7 @@
 #include "types.h"
 #include "exo.h"
 #include "syscall.h"
+#include "exo_ipc.h"
 
 /* Capability access rights. */
 #define EXO_RIGHT_R 0x1
@@ -54,11 +55,12 @@ exo_cap exo_alloc_dma(uint32_t chan);
 
 /* Send 'len' bytes from 'buf' to destination capability 'dest'.  Any queuing
  * or flow control is managed in user space. */
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                           uint64_t len);
 
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len);
 
 /* Read or write arbitrary byte ranges using a block capability. */
 [[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64_t off,

--- a/src-headers/libos/affine_runtime.h
+++ b/src-headers/libos/affine_runtime.h
@@ -43,15 +43,18 @@ int lambda_run(lambda_term_t *t, int fuel);
   static inline void name##_destroy(name##_t *c) {                             \
     affine_chan_destroy(&c->base);                                             \
   }                                                                            \
-  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+  static inline enum exo_ipc_status name##_send(name##_t *c, exo_cap dest,      \
+                                                const type *m) {               \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
     type##_encode(m, buf);                                                     \
     return affine_chan_send(&c->base, dest, buf, type##_MESSAGE_SIZE);         \
   }                                                                            \
-  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+  static inline enum exo_ipc_status name##_recv(name##_t *c, exo_cap src,       \
+                                                type *m) {                    \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
-    int r = affine_chan_recv(&c->base, src, buf, type##_MESSAGE_SIZE);         \
-    if (r == 0)                                                                \
+    enum exo_ipc_status r =                                                   \
+        affine_chan_recv(&c->base, src, buf, type##_MESSAGE_SIZE);            \
+    if (r == IPC_STATUS_SUCCESS)                                              \
       type##_decode(m, buf);                                                   \
     return r;                                                                  \
   }

--- a/src-headers/libos/driver.h
+++ b/src-headers/libos/driver.h
@@ -3,4 +3,4 @@
 #include "caplib.h"
 
 [[nodiscard]] int driver_spawn(const char *path, char *const argv[]);
-[[nodiscard]] int driver_connect(int pid, exo_cap ep);
+[[nodiscard]] enum exo_ipc_status driver_connect(int pid, exo_cap ep);

--- a/src-headers/libos/ipc_queue.h
+++ b/src-headers/libos/ipc_queue.h
@@ -1,5 +1,5 @@
 #pragma once
 #include "exo_ipc.h"
 
-int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
-int ipc_queue_recv(exo_cap src, void *buf, uint64_t len);
+enum exo_ipc_status ipc_queue_send(exo_cap dest, const void *buf, uint64_t len);
+enum exo_ipc_status ipc_queue_recv(exo_cap src, void *buf, uint64_t len);

--- a/src-kernel/chan.c
+++ b/src-kernel/chan.c
@@ -2,8 +2,8 @@
 #include "exo_ipc.h"
 
 // Kernel variant of chan_endpoint_send validating the message size
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
   if (!c) {
     cprintf("chan_endpoint_send: null channel\n");
     return -1;
@@ -17,8 +17,8 @@
 }
 
 // Kernel variant of chan_endpoint_recv validating the message size
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
   if (!c) {
     cprintf("chan_endpoint_recv: null channel\n");
     return -1;

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -6,14 +6,15 @@ static struct exo_ipc_ops ipc_ops;
 
 void exo_ipc_register(struct exo_ipc_ops *ops) { ipc_ops = *ops; }
 
-[[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status exo_send(exo_cap dest, const void *buf,
+                                           uint64_t len) {
   if (ipc_ops.send)
     return ipc_ops.send(dest, buf, len);
-  return -1;
+  return IPC_STATUS_BADDEST;
 }
 
-[[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status exo_recv(exo_cap src, void *buf, uint64_t len) {
   if (ipc_ops.recv)
     return ipc_ops.recv(src, buf, len);
-  return -1;
+  return IPC_STATUS_BADDEST;
 }

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -46,11 +46,12 @@ void cap_yield_to(context_t **old, context_t *target) {
 extern int cap_revoke_syscall(void);
 int cap_revoke(void) { return cap_revoke_syscall(); }
 
-[[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status cap_send(exo_cap dest, const void *buf,
+                                           uint64_t len) {
   return exo_send(dest, buf, len);
 }
 
-[[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len) {
+[[nodiscard]] enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len) {
   return exo_recv(src, buf, len);
 }
 

--- a/src-uland/chan.c
+++ b/src-uland/chan.c
@@ -13,8 +13,8 @@
 
 void chan_destroy(chan_t *c) { free(c); }
 
-[[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
            (int)c->msg_size);
@@ -23,8 +23,8 @@ void chan_destroy(chan_t *c) { free(c); }
   return cap_send(dest, msg, c->msg_size);
 }
 
-[[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
-                                     size_t len) {
+[[nodiscard]] enum exo_ipc_status
+chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
   if (len != c->msg_size) {
     printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
            (int)c->msg_size);

--- a/src-uland/door.c
+++ b/src-uland/door.c
@@ -19,7 +19,7 @@ door_t door_create_remote(exo_cap dest) {
   return d;
 }
 
-[[nodiscard]] int door_call(door_t *d, zipc_msg_t *msg) {
+[[nodiscard]] enum exo_ipc_status door_call(door_t *d, zipc_msg_t *msg) {
   if (!d)
     return -1;
   if (d->is_local) {
@@ -27,8 +27,8 @@ door_t door_create_remote(exo_cap dest) {
       d->handler(msg);
     return 0;
   }
-  if (cap_send(d->dest, msg, sizeof(*msg)) < 0)
-    return -1;
+  if (cap_send(d->dest, msg, sizeof(*msg)) != IPC_STATUS_SUCCESS)
+    return IPC_STATUS_BADDEST;
   return cap_recv(d->dest, msg, sizeof(*msg));
 }
 
@@ -37,7 +37,7 @@ void door_server_loop(door_t *d) {
     return;
   while (1) {
     zipc_msg_t msg;
-    if (cap_recv(d->dest, &msg, sizeof(msg)) < 0)
+    if (cap_recv(d->dest, &msg, sizeof(msg)) != IPC_STATUS_SUCCESS)
       continue;
     d->handler(&msg);
     cap_send(d->dest, &msg, sizeof(msg));

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -12,8 +12,8 @@ C_CODE = textwrap.dedent(
 #include "src-headers/door.h"
 
 // stub implementations for caplib helpers
-int cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return 0; }
-int cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return 0; }
+enum exo_ipc_status cap_send(exo_cap dest, const void *buf, uint64_t len) { (void)dest; (void)buf; (void)len; return IPC_STATUS_SUCCESS; }
+enum exo_ipc_status cap_recv(exo_cap src, void *buf, uint64_t len) { (void)src; (void)buf; (void)len; return IPC_STATUS_SUCCESS; }
 
 static int called = 0;
 static void handler(zipc_msg_t *m) { called++; m->w0++; }
@@ -21,7 +21,7 @@ static void handler(zipc_msg_t *m) { called++; m->w0++; }
 int main(void) {
     door_t d = door_create_local(handler);
     zipc_msg_t m = {0, 41, 0, 0, 0};
-    assert(door_call(&d, &m) == 0);
+    assert(door_call(&d, &m) == IPC_STATUS_SUCCESS);
     assert(called == 1);
     assert(m.w0 == 42);
     return 0;

--- a/tests/test_exo_ipc_direct.py
+++ b/tests/test_exo_ipc_direct.py
@@ -19,24 +19,24 @@ struct mailbox {
 };
 static struct mailbox *mb;
 
-static int send_impl(exo_cap dest, const void *buf, uint64_t len){
+static enum exo_ipc_status send_impl(exo_cap dest, const void *buf, uint64_t len){
     if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
-        return -1;
+        return IPC_STATUS_BADDEST;
     struct mailbox *m = &mb[dest.id];
     m->len = len < sizeof(m->buf) ? len : sizeof(m->buf);
     memcpy(m->buf, buf, m->len);
     m->has = 1;
-    return (int)m->len;
+    return IPC_STATUS_SUCCESS;
 }
-static int recv_impl(exo_cap src, void *buf, uint64_t len){
+static enum exo_ipc_status recv_impl(exo_cap src, void *buf, uint64_t len){
     if(!cap_has_rights(src.rights, EXO_RIGHT_R))
-        return -1;
+        return IPC_STATUS_BADDEST;
     struct mailbox *m = &mb[src.id];
-    if(!m->has) return 0;
+    if(!m->has) return IPC_STATUS_AGAIN;
     size_t n = m->len < len ? m->len : len;
     memcpy(buf, m->buf, n);
     m->has = 0;
-    return (int)n;
+    return IPC_STATUS_SUCCESS;
 }
 static struct exo_ipc_ops ops = { send_impl, recv_impl };
 
@@ -50,14 +50,14 @@ int main(void){
     if(pid==0){
         exo_cap src = { .id=0, .rights=EXO_RIGHT_R };
         char buf[8];
-        int r = exo_recv(src, buf, 2);
-        assert(r==2);
+        enum exo_ipc_status r = exo_recv(src, buf, 2);
+        assert(r==IPC_STATUS_SUCCESS);
         assert(buf[0]=='o' && buf[1]=='k');
         _exit(0);
     }
     exo_cap dst = { .id=0, .rights=EXO_RIGHT_W };
     char msg[3] = "ok";
-    assert(exo_send(dst, msg, 2)==2);
+    assert(exo_send(dst, msg, 2)==IPC_STATUS_SUCCESS);
     int st; waitpid(pid,&st,0);
     return st==0?0:1;
 }

--- a/tests/test_exo_recv_timed.py
+++ b/tests/test_exo_recv_timed.py
@@ -13,26 +13,26 @@ C_CODE = textwrap.dedent("""
 struct mailbox { int has; char buf[8]; size_t len; };
 static struct mailbox *mb;
 
-static int send_impl(exo_cap dest, const void *buf, uint64_t len){
-    (void)dest; (void)buf; (void)len; return -1;
+static enum exo_ipc_status send_impl(exo_cap dest, const void *buf, uint64_t len){
+    (void)dest; (void)buf; (void)len; return IPC_STATUS_BADDEST;
 }
-static int recv_impl(exo_cap src, void *buf, uint64_t len){
-    if(!cap_has_rights(src.rights, EXO_RIGHT_R)) return -1;
+static enum exo_ipc_status recv_impl(exo_cap src, void *buf, uint64_t len){
+    if(!cap_has_rights(src.rights, EXO_RIGHT_R)) return IPC_STATUS_BADDEST;
     struct mailbox *m = &mb[src.id];
-    if(!m->has) return 0;
+    if(!m->has) return IPC_STATUS_AGAIN;
     size_t n = m->len < len ? m->len : len;
     memcpy(buf, m->buf, n);
     m->has = 0;
-    return (int)n;
+    return IPC_STATUS_SUCCESS;
 }
 static struct exo_ipc_ops ops = { send_impl, recv_impl };
 
-static int exo_recv_timed(exo_cap src, void *buf, uint64_t len, unsigned to){
+static enum exo_ipc_status exo_recv_timed(exo_cap src, void *buf, uint64_t len, unsigned to){
     for(unsigned i=0;i<to;i++){
-        int r = exo_recv(src, buf, len);
-        if(r!=0) return r;
+        enum exo_ipc_status r = exo_recv(src, buf, len);
+        if(r!=IPC_STATUS_AGAIN) return r;
     }
-    return -1;
+    return IPC_STATUS_TIMEOUT;
 }
 
 int main(void){
@@ -43,7 +43,7 @@ int main(void){
     exo_ipc_register(&ops);
     exo_cap src = { .id=0, .rights=EXO_RIGHT_R };
     char buf[8];
-    assert(exo_recv_timed(src, buf, 8, 5) == -1);
+    assert(exo_recv_timed(src, buf, 8, 5) == IPC_STATUS_TIMEOUT);
     return 0;
 }
 """)

--- a/tests/test_mailbox_isolation.py
+++ b/tests/test_mailbox_isolation.py
@@ -13,22 +13,22 @@ C_CODE = textwrap.dedent("""
 struct mailbox { int has; char buf[8]; size_t len; };
 static struct mailbox *mb;
 
-static int send_impl(exo_cap dest, const void *buf, uint64_t len){
-    if(!cap_has_rights(dest.rights, EXO_RIGHT_W)) return -1;
+static enum exo_ipc_status send_impl(exo_cap dest, const void *buf, uint64_t len){
+    if(!cap_has_rights(dest.rights, EXO_RIGHT_W)) return IPC_STATUS_BADDEST;
     struct mailbox *m = &mb[dest.id];
     m->len = len < sizeof(m->buf) ? len : sizeof(m->buf);
     memcpy(m->buf, buf, m->len);
     m->has = 1;
-    return (int)m->len;
+    return IPC_STATUS_SUCCESS;
 }
-static int recv_impl(exo_cap src, void *buf, uint64_t len){
-    if(!cap_has_rights(src.rights, EXO_RIGHT_R)) return -1;
+static enum exo_ipc_status recv_impl(exo_cap src, void *buf, uint64_t len){
+    if(!cap_has_rights(src.rights, EXO_RIGHT_R)) return IPC_STATUS_BADDEST;
     struct mailbox *m = &mb[src.id];
-    if(!m->has) return 0;
+    if(!m->has) return IPC_STATUS_AGAIN;
     size_t n = m->len < len ? m->len : len;
     memcpy(buf, m->buf, n);
     m->has = 0;
-    return (int)n;
+    return IPC_STATUS_SUCCESS;
 }
 static struct exo_ipc_ops ops = { send_impl, recv_impl };
 
@@ -40,12 +40,12 @@ int main(void){
     exo_ipc_register(&ops);
     exo_cap dst0 = { .id=0, .rights=EXO_RIGHT_W };
     char msg[3] = "hi";
-    assert(exo_send(dst0, msg, 2)==2);
+    assert(exo_send(dst0, msg, 2)==IPC_STATUS_SUCCESS);
     exo_cap r1 = { .id=1, .rights=EXO_RIGHT_R };
     char buf[8];
-    assert(exo_recv(r1, buf, 8)==0);
+    assert(exo_recv(r1, buf, 8)==IPC_STATUS_AGAIN);
     exo_cap r0 = { .id=0, .rights=EXO_RIGHT_R };
-    assert(exo_recv(r0, buf, 8)==2);
+    assert(exo_recv(r0, buf, 8)==IPC_STATUS_SUCCESS);
     assert(buf[0]=='h' && buf[1]=='i');
     return 0;
 }


### PR DESCRIPTION
## Summary
- define `exo_ipc_status` in exo_ipc.h and convert IPC helpers
- return `exo_ipc_status` from exo_send/exo_recv and queue helpers
- adjust typed channel API, driver and door wrappers for new status codes
- update documentation for the new enum
- update unit tests for the `exo_ipc_status` return values

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*