### PR TITLE
Implement exo_recv_timed syscall and tests

### DIFF
--- a/src-headers/caplib.h
+++ b/src-headers/caplib.h
@@ -10,6 +10,8 @@ exo_cap cap_alloc_page(void);
 void cap_flush_block(exo_blockcap *cap, void *data);
 [[nodiscard]] int cap_send(exo_cap dest, const void *buf, uint64_t len);
 [[nodiscard]] int cap_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] int cap_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                 unsigned timeout);
 [[nodiscard]] int cap_set_timer(void (*handler)(void));
 [[nodiscard]] int cap_set_gas(uint64_t amount);
 [[nodiscard]] int cap_get_gas(void);

--- a/src-headers/exo_ipc.h
+++ b/src-headers/exo_ipc.h
@@ -11,3 +11,5 @@ struct exo_ipc_ops {
 void exo_ipc_register(struct exo_ipc_ops *ops);
 [[nodiscard]] int exo_send(exo_cap dest, const void *buf, uint64_t len);
 [[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] int exo_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                 unsigned timeout);

--- a/src-headers/exokernel.h
+++ b/src-headers/exokernel.h
@@ -59,6 +59,8 @@ exo_cap exo_alloc_dma(uint32_t chan);
 /* Receive up to 'len' bytes from source capability 'src' into 'buf'.  The call
  * blocks according to policy implemented by the library OS. */
 [[nodiscard]] int exo_recv(exo_cap src, void *buf, uint64_t len);
+[[nodiscard]] int exo_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                 unsigned timeout);
 
 /* Read or write arbitrary byte ranges using a block capability. */
 [[nodiscard]] int exo_read_disk(exo_blockcap cap, void *dst, uint64_t off,
@@ -86,6 +88,7 @@ enum exo_syscall {
   EXO_SYSCALL_YIELD_TO = SYS_exo_yield_to,
   EXO_SYSCALL_SEND = SYS_exo_send,
   EXO_SYSCALL_RECV = SYS_exo_recv,
+  EXO_SYSCALL_RECV_TIMED = SYS_exo_recv_timed,
   EXO_SYSCALL_READ_DISK = SYS_exo_read_disk,
   EXO_SYSCALL_WRITE_DISK = SYS_exo_write_disk,
   EXO_SYSCALL_ALLOC_IOPORT = SYS_exo_alloc_ioport,

--- a/src-headers/string.h
+++ b/src-headers/string.h
@@ -2,3 +2,5 @@
 #include <stddef.h>
 void *memmove(void *dst, const void *src, size_t n);
 int memcmp(const void *s1, const void *s2, size_t n);
+void *memcpy(void *dst, const void *src, size_t n);
+void *memset(void *dst, int c, size_t n);

--- a/src-headers/syscall.h
+++ b/src-headers/syscall.h
@@ -23,6 +23,7 @@ enum {
   SYS_exo_write_disk,
   SYS_exo_send,
   SYS_exo_recv,
+  SYS_exo_recv_timed,
   SYS_endpoint_send,
   SYS_endpoint_recv,
   SYS_proc_alloc,

--- a/src-kernel/exo_ipc.c
+++ b/src-kernel/exo_ipc.c
@@ -17,3 +17,13 @@ void exo_ipc_register(struct exo_ipc_ops *ops) { ipc_ops = *ops; }
     return ipc_ops.recv(src, buf, len);
   return -1;
 }
+
+[[nodiscard]] int exo_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                 unsigned timeout) {
+  for (unsigned i = 0; i < timeout; i++) {
+    int r = exo_recv(src, buf, len);
+    if (r != 0)
+      return r;
+  }
+  return -1;
+}

--- a/src-kernel/syscall.c
+++ b/src-kernel/syscall.c
@@ -147,6 +147,7 @@ extern int sys_exo_read_disk(void);
 extern int sys_exo_write_disk(void);
 extern int sys_exo_send(void);
 extern int sys_exo_recv(void);
+extern int sys_exo_recv_timed(void);
 extern int sys_exo_alloc_ioport(void);
 extern int sys_exo_bind_irq(void);
 extern int sys_exo_alloc_dma(void);
@@ -195,6 +196,7 @@ static int (*syscalls[])(void) = {
     [SYS_exo_alloc_dma] sys_exo_alloc_dma,
     [SYS_exo_send] sys_exo_send,
     [SYS_exo_recv] sys_exo_recv,
+    [SYS_exo_recv_timed] sys_exo_recv_timed,
     [SYS_endpoint_send] sys_endpoint_send,
     [SYS_endpoint_recv] sys_endpoint_recv,
     [SYS_proc_alloc] sys_proc_alloc,

--- a/src-kernel/sysproc.c
+++ b/src-kernel/sysproc.c
@@ -16,6 +16,9 @@
 #include "x86.h"
 // clang-format on
 
+extern int exo_ipc_queue_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                    unsigned timeout);
+
 int sys_fork(void) { return fork(); }
 
 int sys_exit(void) {
@@ -286,6 +289,20 @@ int sys_exo_recv(void) {
   if (!cap_verify(cap))
     return -1;
   return exo_recv(cap, dst, n);
+}
+
+int sys_exo_recv_timed(void) {
+  exo_cap *ucap, cap;
+  char *dst;
+  uint32_t n, to;
+  if (argptr(0, (void *)&ucap, sizeof(cap)) < 0 ||
+      argint(2, (int *)&n) < 0 || argptr(1, &dst, n) < 0 ||
+      argint(3, (int *)&to) < 0)
+    return -1;
+  memcpy(&cap, ucap, sizeof(cap));
+  if (!cap_verify(cap))
+    return -1;
+  return exo_ipc_queue_recv_timed(cap, dst, n, to);
 }
 
 int sys_proc_alloc(void) {

--- a/src-uland/caplib.c
+++ b/src-uland/caplib.c
@@ -54,6 +54,11 @@ int cap_revoke(void) { return cap_revoke_syscall(); }
   return exo_recv(src, buf, len);
 }
 
+[[nodiscard]] int cap_recv_timed(exo_cap src, void *buf, uint64_t len,
+                                 unsigned timeout) {
+  return exo_recv_timed(src, buf, len, timeout);
+}
+
 [[nodiscard]] int cap_ipc_echo_demo(void) {
   const char *msg = "ping";
   char buf[5];

--- a/tests/test_exo_recv_timed.py
+++ b/tests/test_exo_recv_timed.py
@@ -27,13 +27,6 @@ static int recv_impl(exo_cap src, void *buf, uint64_t len){
 }
 static struct exo_ipc_ops ops = { send_impl, recv_impl };
 
-static int exo_recv_timed(exo_cap src, void *buf, uint64_t len, unsigned to){
-    for(unsigned i=0;i<to;i++){
-        int r = exo_recv(src, buf, len);
-        if(r!=0) return r;
-    }
-    return -1;
-}
 
 int main(void){
     mb = mmap(NULL, sizeof(struct mailbox)*2, PROT_READ|PROT_WRITE,


### PR DESCRIPTION
## Summary
- add `exo_recv_timed` prototypes
- implement `exo_recv_timed` and kernel helper
- wire new syscall number and dispatch
- expose wrapper through caplib
- update stub `string.h` for memcpy/memset
- update test to use real API

## Testing
- `pytest -q tests/test_exo_recv_timed.py`