### PR TITLE
Implement per-process IPC mailboxes

### DIFF
--- a/libos/ipc_queue.c
+++ b/libos/ipc_queue.c
@@ -1,34 +1,23 @@
 #include "include/exokernel.h"
 #include "exo_ipc.h"
 #include "ipc.h"
-#include "uv_spinlock.h"
+#include "proc.h"
 #include <string.h>
 #include <errno.h>
 
-#define IPC_BUFSZ 64
-
-struct ipc_entry {
-    zipc_msg_t msg;
-    exo_cap frame;
-};
-
-static struct {
-    uv_spinlock_t lock;
-    struct ipc_entry buf[IPC_BUFSZ];
-    unsigned r, w;
-    int inited;
-} ipcs;
-
-static void ipc_init(void) {
-    if (!ipcs.inited) {
-        uv_spinlock_init(&ipcs.lock);
-        ipcs.r = ipcs.w = 0;
-        ipcs.inited = 1;
+static void ipc_init(struct mailbox *mb) {
+    if(!mb->inited){
+        initlock(&mb->lock, "ipcq");
+        mb->r = mb->w = 0;
+        mb->inited = 1;
     }
 }
 
+
+
 int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
-    ipc_init();
+    struct mailbox *mb = myproc()->mailbox;
+    ipc_init(mb);
     if(!cap_has_rights(dest.rights, EXO_RIGHT_W))
         return -EPERM;
     if(len > sizeof(zipc_msg_t) + sizeof(exo_cap))
@@ -47,15 +36,15 @@ int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
             fr.owner = dest.owner;
     }
 
-    uv_spinlock_lock(&ipcs.lock);
-    while(ipcs.w - ipcs.r == IPC_BUFSZ) {
-        uv_spinlock_unlock(&ipcs.lock);
-        uv_spinlock_lock(&ipcs.lock);
+    acquire(&mb->lock);
+    while(mb->w - mb->r == MAILBOX_BUFSZ) {
+        release(&mb->lock);
+        acquire(&mb->lock);
     }
-    ipcs.buf[ipcs.w % IPC_BUFSZ].msg = m;
-    ipcs.buf[ipcs.w % IPC_BUFSZ].frame = fr;
-    ipcs.w++;
-    uv_spinlock_unlock(&ipcs.lock);
+    mb->buf[mb->w % MAILBOX_BUFSZ].msg = m;
+    mb->buf[mb->w % MAILBOX_BUFSZ].frame = fr;
+    mb->w++;
+    release(&mb->lock);
 
     return exo_send(dest, buf, len);
 }
@@ -63,28 +52,29 @@ int ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
 int ipc_queue_recv(exo_cap src, void *buf, uint64_t len) {
     if(!cap_has_rights(src.rights, EXO_RIGHT_R))
         return -EPERM;
-    ipc_init();
-    uv_spinlock_lock(&ipcs.lock);
-    while(ipcs.r == ipcs.w) {
-        uv_spinlock_unlock(&ipcs.lock);
+    struct mailbox *mb = myproc()->mailbox;
+    ipc_init(mb);
+    acquire(&mb->lock);
+    while(mb->r == mb->w) {
+        release(&mb->lock);
         char tmp[sizeof(zipc_msg_t) + sizeof(exo_cap)];
         int r = exo_recv(src, tmp, sizeof(tmp));
         if(r > 0) {
-            uv_spinlock_lock(&ipcs.lock);
-            struct ipc_entry *e = &ipcs.buf[ipcs.w % IPC_BUFSZ];
+            acquire(&mb->lock);
+            struct ipc_entry *e = &mb->buf[mb->w % MAILBOX_BUFSZ];
             memset(e, 0, sizeof(*e));
             size_t cplen = r < sizeof(zipc_msg_t) ? r : sizeof(zipc_msg_t);
             memmove(&e->msg, tmp, cplen);
             if(r > sizeof(zipc_msg_t))
                 memmove(&e->frame, tmp + sizeof(zipc_msg_t), r - sizeof(zipc_msg_t));
-            ipcs.w++;
+            mb->w++;
         } else {
-            uv_spinlock_lock(&ipcs.lock);
+            acquire(&mb->lock);
         }
     }
-    struct ipc_entry e = ipcs.buf[ipcs.r % IPC_BUFSZ];
-    ipcs.r++;
-    uv_spinlock_unlock(&ipcs.lock);
+    struct ipc_entry e = mb->buf[mb->r % MAILBOX_BUFSZ];
+    mb->r++;
+    release(&mb->lock);
 
     size_t total = sizeof(zipc_msg_t);
     if(e.frame.id)

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -188,6 +188,10 @@ found:
   p->context->eip = (uint32_t)forkret;
 #endif
 
+  p->mailbox = (struct mailbox *)kalloc();
+  if(p->mailbox)
+    memset(p->mailbox, 0, sizeof(struct mailbox));
+
   return p;
 }
 
@@ -370,6 +374,10 @@ wait(void)
         pid = p->pid;
         kfree(p->kstack);
         p->kstack = 0;
+        if(p->mailbox){
+          kfree((char*)p->mailbox);
+          p->mailbox = 0;
+        }
         freevm(p->pgdir);
         p->pid = 0;
         p->parent = 0;

--- a/tests/test_mailbox_isolation.py
+++ b/tests/test_mailbox_isolation.py
@@ -6,44 +6,45 @@ C_CODE = textwrap.dedent("""
 #include <assert.h>
 #include <stdint.h>
 #include <string.h>
-#include <sys/mman.h>
 #include "src-headers/exo_ipc.h"
 #include "src-headers/exokernel.h"
 
-struct mailbox { int has; char buf[8]; size_t len; };
-static struct mailbox *mb;
+struct spinlock { int locked; struct cpu *cpu; };
+struct mailbox;
+struct proc { struct mailbox *mailbox; };
+static struct proc *cur;
+static struct proc* myproc(void){ return cur; }
+static void initlock(struct spinlock*l,const char*n){(void)l;(void)n;}
+static void acquire(struct spinlock*l){(void)l;}
+static void release(struct spinlock*l){(void)l;}
+static void wakeup(void*c){(void)c;}
+static void sleep(void*c, struct spinlock*l){(void)c;(void)l;}
+static int cap_verify(exo_cap c){(void)c; return 1;}
 
-static int send_impl(exo_cap dest, const void *buf, uint64_t len){
-    if(!cap_has_rights(dest.rights, EXO_RIGHT_W)) return -1;
-    struct mailbox *m = &mb[dest.id];
-    m->len = len < sizeof(m->buf) ? len : sizeof(m->buf);
-    memcpy(m->buf, buf, m->len);
-    m->has = 1;
-    return (int)m->len;
-}
-static int recv_impl(exo_cap src, void *buf, uint64_t len){
-    if(!cap_has_rights(src.rights, EXO_RIGHT_R)) return -1;
-    struct mailbox *m = &mb[src.id];
-    if(!m->has) return 0;
-    size_t n = m->len < len ? m->len : len;
-    memcpy(buf, m->buf, n);
-    m->has = 0;
-    return (int)n;
-}
-static struct exo_ipc_ops ops = { send_impl, recv_impl };
+#define MAILBOX_BUFSZ 4
+struct ipc_entry { zipc_msg_t msg; exo_cap frame; };
+struct mailbox { struct spinlock lock; struct ipc_entry buf[MAILBOX_BUFSZ];
+                  uint32_t r; uint32_t w; int inited; };
+static struct mailbox mbs[2];
+static struct proc ps[2];
+
+#include "src-kernel/exo_ipc_queue.c"
+#include "src-kernel/exo_ipc.c"
 
 int main(void){
-    mb = mmap(NULL, sizeof(struct mailbox)*2, PROT_READ|PROT_WRITE,
-              MAP_ANON|MAP_SHARED, -1, 0);
-    assert(mb != MAP_FAILED);
-    memset(mb,0,sizeof(struct mailbox)*2);
-    exo_ipc_register(&ops);
-    exo_cap dst0 = { .id=0, .rights=EXO_RIGHT_W };
+    ps[0].mailbox = &mbs[0];
+    ps[1].mailbox = &mbs[1];
+    memset(mbs,0,sizeof(mbs));
+    cur = &ps[0];
+    exo_ipc_register(&exo_ipc_queue_ops);
+    exo_cap dst = { .id=0, .rights=EXO_RIGHT_W };
     char msg[3] = "hi";
-    assert(exo_send(dst0, msg, 2)==2);
-    exo_cap r1 = { .id=1, .rights=EXO_RIGHT_R };
+    assert(exo_send(dst, msg, 2)==2);
     char buf[8];
+    cur = &ps[1];
+    exo_cap r1 = { .id=0, .rights=EXO_RIGHT_R };
     assert(exo_recv(r1, buf, 8)==0);
+    cur = &ps[0];
     exo_cap r0 = { .id=0, .rights=EXO_RIGHT_R };
     assert(exo_recv(r0, buf, 8)==2);
     assert(buf[0]=='h' && buf[1]=='i');
@@ -63,17 +64,20 @@ def compile_and_run():
             "typedef unsigned long uint64;\n"
             "typedef unsigned long uintptr;\n"
         )
-        (pathlib.Path(td)/"defs.h").write_text("")
-        (pathlib.Path(td)/"stdint.h").write_text(
-            "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
-        )
+        (pathlib.Path(td)/"proc.h").write_text("#include <stdint.h>\n" +
+            "struct spinlock{int locked; struct cpu *cpu;};\n" +
+            "struct ipc_entry{ zipc_msg_t msg; exo_cap frame; };\n" +
+            "#define MAILBOX_BUFSZ 4\n" +
+            "struct mailbox{ struct spinlock lock; struct ipc_entry buf[MAILBOX_BUFSZ];" +
+            " uint32_t r; uint32_t w; int inited; };\n" +
+            "struct proc{ struct mailbox *mailbox; };\n")
+        (pathlib.Path(td)/"defs.h").write_text("void wakeup(void*); void sleep(void*, struct spinlock*); void panic(char*);\n")
         subprocess.check_call([
             "gcc","-std=c2x","-Wall","-Werror",
             "-I", str(td),
             "-I", str(ROOT),
             "-I", str(ROOT/"src-headers"),
             str(src),
-            str(ROOT/"src-kernel/exo_ipc.c"),
             "-o", str(exe)
         ])
         return subprocess.run([str(exe)]).returncode


### PR DESCRIPTION
## Summary
- extend `struct proc` with per-process mailbox support
- queue operations now use `myproc()->mailbox`
- allocate/free mailboxes with process lifecycle
- mirror mailbox queue handling in libos
- add an isolation test using per-process queues

## Testing
- `pytest -q` *(fails: CalledProcessError)*