### PR TITLE
Document exo_ipc_status codes

### DIFF
--- a/doc/IPC.md
+++ b/doc/IPC.md
@@ -12,13 +12,14 @@ Timeouts are encoded as a `timeout_t` value passed to `sys_ipc`. When the wait p
 
 ## Status Codes
 
-`IPC_STATUS_SUCCESS`  – operation completed normally.
+All IPC helpers return an `exo_ipc_status` value defined in
+`src-headers/exo_ipc.h`.  The enumeration documents the possible
+outcomes:
 
-`IPC_STATUS_TIMEOUT`  – receiver waited past the specified timeout.
-
-`IPC_STATUS_AGAIN`    – destination mailbox was full.
-
-`IPC_STATUS_BADDEST`  – the destination thread or process id was invalid.
+- `IPC_STATUS_SUCCESS` – operation completed normally.
+- `IPC_STATUS_TIMEOUT` – receiver waited past the specified timeout.
+- `IPC_STATUS_AGAIN`   – destination mailbox was full.
+- `IPC_STATUS_BADDEST` – the destination thread or process id was invalid.
 
 ## Typed Channels and Capabilities
 

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -144,6 +144,15 @@ queuing is handled in user
                        using the `zipc_msg_t` structure defined in `ipc.h`.
 
                        IPC messages are now queued entirely in user space; the kernel merely forwards each `exo_send` or `exo_recv` request.
+
+The helpers return an `exo_ipc_status` value defined in
+`src-headers/exo_ipc.h`:
+
+- `IPC_STATUS_SUCCESS` – operation completed normally.
+- `IPC_STATUS_TIMEOUT` – wait timed out.
+- `IPC_STATUS_AGAIN`   – destination mailbox was full.
+- `IPC_STATUS_BADDEST` – invalid endpoint capability.
+
 Typed channels built with the `CHAN_DECLARE` macro wrap these primitives
 and automatically serialize Cap'n Proto messages.  Each channel is
 backed by a `msg_type_desc` describing the size of the Cap'n Proto

--- a/doc/track_technical.md
+++ b/doc/track_technical.md
@@ -37,6 +37,14 @@ The charter outlines the full scope and goals of the project.
 - `exo_yield_to()` – switch to a user controlled context.
 - `exo_send()` / `exo_recv()` – fast message passing between endpoints.
 
+The IPC helpers return an `exo_ipc_status` value declared in
+`src-headers/exo_ipc.h`:
+
+- `IPC_STATUS_SUCCESS` – message delivered or received.
+- `IPC_STATUS_TIMEOUT` – wait timed out.
+- `IPC_STATUS_AGAIN`   – destination mailbox was full.
+- `IPC_STATUS_BADDEST` – invalid endpoint capability.
+
 These calls are thin wrappers around the kernel interface.  Higher layers
 are implemented in the libOS.
 


### PR DESCRIPTION
## Summary
- explain exo_ipc_status enum in IPC.md
- mention IPC return codes in track_technical.md and phoenixkernel.md

## Testing
- `pre-commit run --files doc/IPC.md doc/track_technical.md doc/phoenixkernel.md` *(fails: command not found)*
- `pytest -q` *(fails: gcc/clang missing for build)*