### PR TITLE
Enable warnings globally

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_STANDARD 23)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+add_compile_options(-Wall -Werror)
 
 if(NOT CMAKE_C_COMPILER_ID MATCHES "Clang")
   message(WARNING "Clang is recommended for building this project")
@@ -44,7 +45,6 @@ file(GLOB_RECURSE KERNEL_SOURCES
 )
 
 add_executable(kernel ${KERNEL_SOURCES})
-target_compile_options(kernel PRIVATE -Wall -Werror)
 
 if(USE_TICKET_LOCK)
   target_compile_definitions(kernel PRIVATE USE_TICKET_LOCK)


### PR DESCRIPTION
## Summary
- add `-Wall -Werror` as project-wide compile options
- remove the per-kernel warning flags

## Testing
- `pytest -q` *(fails: CalledProcessError during compilation)*