### PR TITLE
Add ipcs mailbox for timed IPC queue

### DIFF
--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -9,7 +9,7 @@
 #define EXO_KERNEL
 #include "include/exokernel.h"
 
-
+static struct mailbox ipcs;
 
 static void ipc_init(struct mailbox *mb) {
   if (!mb->inited) {
@@ -98,7 +98,7 @@ int exo_ipc_queue_recv_timed(exo_cap src, void *buf, uint64_t len,
                              unsigned timeout) {
   if (!cap_has_rights(src.rights, EXO_RIGHT_R))
     return -EPERM;
-  ipc_init();
+  ipc_init(&ipcs);
   acquire(&ipcs.lock);
   while (ipcs.r == ipcs.w && timeout > 0) {
     wakeup(&ipcs.w);


### PR DESCRIPTION
## Summary
- add global `ipcs` mailbox in `exo_ipc_queue.c`
- initialize `ipcs` inside `exo_ipc_queue_recv_timed`

## Testing
- `pytest -q` *(fails: CalledProcessError during C compilation)*