### PR TITLE
Add optional Cap'n Proto library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ endif()
 project(xv6 LANGUAGES C CXX)
 
 option(USE_TICKET_LOCK "Use ticket-based spinlocks" OFF)
+option(USE_CAPNP "Enable Cap'n Proto support" ON)
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -40,7 +41,6 @@ file(GLOB_RECURSE KERNEL_SOURCES
   src-uland/*.c
   src-uland/user/*.c
   libos/*.c
-  libos/capnp/*.c
 )
 
 add_executable(kernel ${KERNEL_SOURCES})
@@ -63,8 +63,12 @@ target_include_directories(kernel PRIVATE
   ${CMAKE_SOURCE_DIR}/src-kernel/include
   ${CMAKE_SOURCE_DIR}/proto
   ${CMAKE_SOURCE_DIR}/libos/include
-  ${CMAKE_SOURCE_DIR}/libos/capnp
 )
+if(USE_CAPNP)
+  target_include_directories(kernel PRIVATE ${CMAKE_SOURCE_DIR}/libos/capnp)
+  target_compile_definitions(kernel PRIVATE USE_CAPNP)
+  add_subdirectory(libos/capnp)
+endif()
 
 if(CPUFLAGS)
   target_compile_options(kernel PRIVATE ${CPUFLAGS})

--- a/libos/capnp/CMakeLists.txt
+++ b/libos/capnp/CMakeLists.txt
@@ -1,0 +1,7 @@
+add_library(capnp STATIC capnp_helpers.c)
+set_target_properties(capnp PROPERTIES POSITION_INDEPENDENT_CODE OFF)
+target_include_directories(capnp PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+
+add_library(capnp_shared SHARED capnp_helpers.c)
+set_target_properties(capnp_shared PROPERTIES OUTPUT_NAME capnp)
+target_include_directories(capnp_shared PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})

--- a/libos/capnp/meson.build
+++ b/libos/capnp/meson.build
@@ -1,0 +1,7 @@
+libcapnp = static_library(
+    'capnp',
+    'capnp_helpers.c',
+    include_directories: include_directories('.'),
+    pic: false,
+)
+install_headers('capnp_helpers.h')

--- a/meson.build
+++ b/meson.build
@@ -2,9 +2,14 @@ project('xv6', 'c', default_options: ['c_std=c23'])
 add_project_arguments('-Wall', '-Werror', language: ['c', 'cpp'])
 
 use_ticket_lock = get_option('use_ticket_lock')
+use_capnp = get_option('use_capnp')
+libcapnp = []
 common_cargs = []
 if use_ticket_lock
   common_cargs += ['-DUSE_TICKET_LOCK']
+endif
+if use_capnp
+  common_cargs += ['-DUSE_CAPNP']
 endif
 
 clang_tidy = find_program('clang-tidy', required: false)
@@ -38,7 +43,6 @@ libos_sources = [
   'libos/driver.c',
   'libos/affine_runtime.c',
   'libos/posix.c',
-  'libos/capnp/capnp_helpers.c',
 ]
 
 libos = static_library('libos', libos_sources,
@@ -76,6 +80,9 @@ if qemu.found()
              console: true)
 endif
 
+if use_capnp
+  subdir('libos/capnp')
+endif
 subdir('libnstr_graph')
 
 # User-space programs
@@ -118,9 +125,13 @@ uprogs = {
 
 uprogs_targets = []
 foreach name, path : uprogs
+  link_libs = [libos]
+  if use_capnp
+    link_libs += libcapnp
+  endif
   exe = executable('_' + name, path,
                    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'),
-                   link_with: libos,
+                   link_with: link_libs,
                    install: false,
                    c_args: common_cargs)
   uprogs_targets += exe

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('use_ticket_lock', type: 'boolean', value : false, description : 'Use ticket-based spinlocks instead of qspinlock')
+option('use_capnp', type: 'boolean', value : true, description : 'Enable Cap\'n Proto support')


### PR DESCRIPTION
## Summary
- create `libcapnp` wrapping existing capnp helpers
- support USE_CAPNP build flag in meson and CMake
- link user programs with libcapnp when enabled

## Testing
- `pytest -q` *(fails: CalledProcessError)*