### PR TITLE
Replace pointer casts with uintptr_t

### DIFF
--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -105,7 +105,7 @@ static void startothers(void) {
     if (stack == 0)
       panic("startothers: out of memory");
 #ifdef __x86_64__
-    *(uint64_t *)(code - 8) = (uint64_t)stack + KSTACKSIZE;
+    *(uintptr_t *)(code - 8) = (uintptr_t)stack + KSTACKSIZE;
     *(void (**)(void))(code - 16) = mpenter;
 #else
     *(void **)(code - 4) = stack + KSTACKSIZE;

--- a/src-kernel/mmu64.c
+++ b/src-kernel/mmu64.c
@@ -56,8 +56,8 @@ mappages64(pml4e_t *pml4, void *va, uint32_t size, uint64_t pa, int perm)
   char *a, *last;
   pte_t *pte;
 
-  a = (char*)PGROUNDDOWN((uint64_t)va);
-  last = (char*)PGROUNDDOWN(((uint64_t)va) + size - 1);
+  a = (char*)PGROUNDDOWN((uintptr_t)va);
+  last = (char*)PGROUNDDOWN(((uintptr_t)va) + size - 1);
   for(;;){
     if((pte = walkpml4(pml4, a, 1)) == 0)
       return -1;

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -174,7 +174,7 @@ found:
   *(uintptr_t*)sp = (uintptr_t)trapret;
 #else
   sp -= 4;
-  *(uint32_t*)sp = (uint32_t)trapret;
+  *(uintptr_t*)sp = (uintptr_t)trapret;
 #endif
 
   sp -= sizeof *p->context;
@@ -185,7 +185,7 @@ found:
 #elif defined(__aarch64__)
   p->context->lr = (uintptr_t)forkret;
 #else
-  p->context->eip = (uint32_t)forkret;
+  p->context->eip = (uintptr_t)forkret;
 #endif
 
   p->mailbox = (struct mailbox *)kalloc();

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -67,11 +67,11 @@ void trap(struct trapframe *tf) {
 #ifndef __x86_64__
       tf->esp -= 4;
       *(uint32_t *)tf->esp = tf->eip;
-      tf->eip = (uint32_t)myproc()->timer_upcall;
+      tf->eip = (uintptr_t)myproc()->timer_upcall;
 #else
       tf->rsp -= 8;
       *(uint64_t *)tf->rsp = tf->rip;
-      tf->rip = (uint64_t)myproc()->timer_upcall;
+      tf->rip = (uintptr_t)myproc()->timer_upcall;
 #endif
     }
     break;

--- a/src-kernel/vm.c
+++ b/src-kernel/vm.c
@@ -385,9 +385,9 @@ copyout(pde_t *pgdir, uint32_t va, void *p, size_t len)
   buf = (char *)p;
   while (len > 0) {
 #ifdef __x86_64__
-    va0 = (uint64_t)PGROUNDDOWN(va);
+    va0 = (uintptr_t)PGROUNDDOWN(va);
 #else
-    va0 = (uint32_t)PGROUNDDOWN(va);
+    va0 = (uintptr_t)PGROUNDDOWN(va);
 #endif
     pa0 = uva2ka(pgdir, (char *)va0);
     if (pa0 == 0)


### PR DESCRIPTION
## Summary
- use `uintptr_t` for pointer-to-integer casts across the kernel

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*