### PR TITLE
Switch to standard string.h functions

### DIFF
--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -184,13 +184,7 @@ void initsleeplock(struct sleeplock *, char *);
 
 // string.c
 
-int memcmp(const void *, const void *, size_t);
-void *memmove(void *, const void *, size_t);
-void *memset(void *, int, size_t);
 char *safestrcpy(char *, const char *, size_t);
-size_t strlen(const char *);
-int strncmp(const char *, const char *, size_t);
-char *strncpy(char *, const char *, size_t);
 
 // syscall.c
 int argint(int, int *);

--- a/src-kernel/console.c
+++ b/src-kernel/console.c
@@ -13,6 +13,7 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "proc.h"
+#include <string.h>
 #include "x86.h"
 #include "fastipc.h"
 #include "tty.h"

--- a/src-kernel/dag_sched.c
+++ b/src-kernel/dag_sched.c
@@ -4,6 +4,7 @@
 #include "dag.h"
 #include "exo_stream.h"
 #include "exo_cpu.h"
+#include <string.h>
 
 
 static struct spinlock dag_lock;

--- a/src-kernel/exec.c
+++ b/src-kernel/exec.c
@@ -6,6 +6,7 @@
 #include "defs.h"
 #include "x86.h"
 #include "elf.h"
+#include <string.h>
 
 int
 exec(char *path, char **argv)

--- a/src-kernel/fs.c
+++ b/src-kernel/fs.c
@@ -18,6 +18,7 @@
 #include "spinlock.h"
 #include "sleeplock.h"
 #include "fs.h"
+#include <string.h>
 #include <errno.h>
 #define EXO_KERNEL
 #include "include/exokernel.h"

--- a/src-kernel/kalloc.c
+++ b/src-kernel/kalloc.c
@@ -9,6 +9,7 @@
 #include "mmu.h"
 #include "spinlock.h"
 #include "proc.h"
+#include <string.h>
 
 void freerange(void *vstart, void *vend);
 extern char end[]; // first address after kernel loaded from ELF file

--- a/src-kernel/lapic.c
+++ b/src-kernel/lapic.c
@@ -9,6 +9,7 @@
 #include "traps.h"
 #include "mmu.h"
 #include "x86.h"
+#include <string.h>
 
 // Local APIC registers, divided by 4 for use as uint32_t[] indices.
 #define ID      (0x0020/4)   // ID

--- a/src-kernel/log.c
+++ b/src-kernel/log.c
@@ -5,6 +5,7 @@
 #include "sleeplock.h"
 #include "fs.h"
 #include "buf.h"
+#include <string.h>
 
 // Simple logging that allows concurrent FS system calls.
 //

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -10,6 +10,7 @@
 #include "spinlock.h"
 #include "exo_stream.h"
 #include "exo_ipc.h"
+#include <string.h>
 
 static void startothers(void);
 static void mpmain(void) __attribute__((noreturn));

--- a/src-kernel/memide.c
+++ b/src-kernel/memide.c
@@ -10,6 +10,7 @@
 #include "traps.h"
 #include "spinlock.h"
 #include "sleeplock.h"
+#include <string.h>
 #include "fs.h"
 #include "buf.h"
 

--- a/src-kernel/mmu64.c
+++ b/src-kernel/mmu64.c
@@ -5,6 +5,7 @@
 #include "memlayout.h"
 #include "mmu.h"
 #include "proc.h"
+#include <string.h>
 
 extern char data[];
 

--- a/src-kernel/mp.c
+++ b/src-kernel/mp.c
@@ -10,6 +10,7 @@
 #include "x86.h"
 #include "mmu.h"
 #include "proc.h"
+#include <string.h>
 
 struct cpu cpus[NCPU];
 int ncpu;

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -6,6 +6,7 @@
 #include "x86.h"
 #include "proc.h"
 #include "spinlock.h"
+#include <string.h>
 
 struct ptable ptable;
 struct spinlock sched_lock;

--- a/src-kernel/string.c
+++ b/src-kernel/string.c
@@ -1,104 +1,15 @@
 #include "types.h"
-#include "x86.h"
-
-void*
-memset(void *dst, int c, size_t n)
-{
-  if ((uintptr_t)dst%4 == 0 && n%4 == 0){
-    c &= 0xFF;
-    stosl(dst, (c<<24)|(c<<16)|(c<<8)|c, n/4);
-  } else
-    stosb(dst, c, n);
-  return dst;
-}
-
-int
-memcmp(const void *v1, const void *v2, size_t n)
-{
-  const uint8_t *s1, *s2;
-
-  s1 = v1;
-  s2 = v2;
-  while(n-- > 0){
-    if(*s1 != *s2)
-      return *s1 - *s2;
-    s1++, s2++;
-  }
-
-  return 0;
-}
-
-void*
-memmove(void *dst, const void *src, size_t n)
-{
-  const char *s;
-  char *d;
-
-  s = src;
-  d = dst;
-  if(s < d && s + n > d){
-    s += n;
-    d += n;
-    while(n-- > 0)
-      *--d = *--s;
-  } else
-    while(n-- > 0)
-      *d++ = *s++;
-
-  return dst;
-}
-
-// memcpy exists to placate GCC.  Use memmove.
-void*
-memcpy(void *dst, const void *src, size_t n)
-{
-  return memmove(dst, src, n);
-}
-
-int
-strncmp(const char *p, const char *q, size_t n)
-{
-  while(n > 0 && *p && *p == *q)
-    n--, p++, q++;
-  if(n == 0)
-    return 0;
-  return (uint8_t)*p - (uint8_t)*q;
-}
-
-char*
-strncpy(char *s, const char *t, size_t n)
-{
-  char *os;
-
-  os = s;
-  while(n-- > 0 && (*s++ = *t++) != 0)
-    ;
-  while(n-- > 0)
-    *s++ = 0;
-  return os;
-}
+#include <string.h>
 
 // Like strncpy but guaranteed to NUL-terminate.
-char*
+char *
 safestrcpy(char *s, const char *t, size_t n)
 {
-  char *os;
-
-  os = s;
-  if(n <= 0)
+  char *os = s;
+  if (n <= 0)
     return os;
-  while(--n > 0 && (*s++ = *t++) != 0)
+  while (--n > 0 && (*s++ = *t++) != 0)
     ;
   *s = 0;
   return os;
-}
-
-size_t
-strlen(const char *s)
-{
-  size_t n;
-
-  for(n = 0; s[n]; n++)
-    ;
-  return n;
 }

--- a/src-kernel/sysfile.c
+++ b/src-kernel/sysfile.c
@@ -10,6 +10,7 @@
 #include "stat.h"
 #include "mmu.h"
 #include "proc.h"
+#include <string.h>
 #include "fs.h"
 #include "spinlock.h"
 #include "sleeplock.h"


### PR DESCRIPTION
## Summary
- replace custom kernel memset/memmove/… implementations with the
  standard `<string.h>` versions
- keep only `safestrcpy` in `string.c`
- remove obsolete prototypes from `defs.h`
- include `<string.h>` in kernel modules that use string routines

## Testing
- `pytest -q` *(fails: CalledProcessError from gcc)*