### PR TITLE
Add missing POSIX stubs

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -1,0 +1,21 @@
+# POSIX Compatibility Layer
+
+This repository contains a small POSIX wrapper used by the user level
+programs.  The implementation is intentionally tiny and only supports a
+subset of the standard.  The new helpers added by this change provide
+basic stubs so code depending on common interfaces can compile.
+
+## Implemented Interfaces
+
+| Interface                | Notes                                              |
+|--------------------------|----------------------------------------------------|
+| `libos_stat`             | Returns dummy metadata from the virtual FS.        |
+| `libos_lseek`            | Adjusts the in-memory file offset.                 |
+| `libos_mmap` / `libos_munmap` | Allocate and free memory using `malloc`.       |
+| Signal set operations    | `libos_sig*set()` manipulate a bitmask type.       |
+| Process groups           | `libos_getpgrp` and `libos_setpgid` are stubs.     |
+| Socket APIs              | `libos_socket` and friends currently return `-1`.  |
+
+These wrappers mirror the POSIX names where possible but are not fully
+featured.  They exist so portability layers can build against Phoenix
+without pulling in a real C library.

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -16,3 +16,31 @@ int libos_fork(void);
 int libos_waitpid(int pid);
 int libos_sigsend(int pid, int sig);
 int libos_sigcheck(void);
+
+/* Additional POSIX helpers */
+struct stat;
+typedef unsigned long libos_sigset_t;
+
+int libos_stat(const char *path, struct stat *st);
+long libos_lseek(int fd, long off, int whence);
+void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off);
+int libos_munmap(void *addr, size_t len);
+
+int libos_sigemptyset(libos_sigset_t *set);
+int libos_sigfillset(libos_sigset_t *set);
+int libos_sigaddset(libos_sigset_t *set, int sig);
+int libos_sigdelset(libos_sigset_t *set, int sig);
+int libos_sigismember(const libos_sigset_t *set, int sig);
+
+int libos_getpgrp(void);
+int libos_setpgid(int pid, int pgid);
+
+struct sockaddr;
+typedef unsigned socklen_t;
+int libos_socket(int domain, int type, int protocol);
+int libos_bind(int fd, const struct sockaddr *addr, socklen_t len);
+int libos_listen(int fd, int backlog);
+int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
+int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
+long libos_send(int fd, const void *buf, size_t len, int flags);
+long libos_recv(int fd, void *buf, size_t len, int flags);

--- a/src-uland/user/libos_posix_extra_test.c
+++ b/src-uland/user/libos_posix_extra_test.c
@@ -1,11 +1,24 @@
 #include "libos/posix.h"
 #include "user.h"
+#include "stat.h"
+#include "signal.h"
 
 int main(void) {
     int fd = libos_open("extra", 0);
     if (fd < 0)
         fd = libos_open("extra", O_CREATE);
     libos_write(fd, "x", 1);
+    libos_lseek(fd, 0, 0);
+    struct stat st;
+    libos_stat("extra", &st);
+    void *p = libos_mmap(0, 128, 0, 0, -1, 0);
+    libos_munmap(p, 128);
+    libos_getpgrp();
+    libos_setpgid(0, 0);
+    libos_socket(0, 0, 0);
+    libos_sigset_t ss;
+    libos_sigemptyset(&ss);
+    libos_sigaddset(&ss, SIGUSR1);
     libos_close(fd);
     char *argv[] = {"echo", "extra", 0};
     libos_spawn("echo", argv);

--- a/tests/test_posix_compat.py
+++ b/tests/test_posix_compat.py
@@ -1,0 +1,56 @@
+import subprocess, tempfile, pathlib, textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent("""
+#include <assert.h>
+#include <sys/socket.h>
+#include "libos/posix.h"
+#include "signal.h"
+#include "stat.h"
+
+int libos_stat(const char *path, struct stat *st){ (void)path; st->size=0; return 0; }
+long libos_lseek(int fd,long off,int whence){ (void)fd;(void)off;(void)whence; return 0; }
+void *libos_mmap(void *a,size_t l,int p,int f,int fd,long o){ (void)a;(void)l;(void)p;(void)f;(void)fd;(void)o; return (void*)1; }
+int libos_munmap(void *a,size_t l){ (void)a;(void)l; return 0; }
+int libos_sigemptyset(libos_sigset_t *s){ *s=0; return 0; }
+int libos_sigfillset(libos_sigset_t *s){ *s=~0UL; return 0; }
+int libos_sigaddset(libos_sigset_t *s,int sig){ *s|=1UL<<sig; return 0; }
+int libos_sigdelset(libos_sigset_t *s,int sig){ *s&=~(1UL<<sig); return 0; }
+int libos_sigismember(const libos_sigset_t *s,int sig){ return (*s&(1UL<<sig))!=0; }
+int libos_getpgrp(void){ return 1; }
+int libos_setpgid(int p,int g){ (void)p;(void)g; return 0; }
+int libos_socket(int d,int t,int p){ (void)d;(void)t;(void)p; return 0; }
+int libos_bind(int s,const struct sockaddr *a,socklen_t l){ (void)s;(void)a;(void)l; return 0; }
+int libos_listen(int s,int b){ (void)s;(void)b; return 0; }
+int libos_accept(int s,struct sockaddr *a,socklen_t *l){ (void)s;(void)a;(void)l; return 0; }
+int libos_connect(int s,const struct sockaddr *a,socklen_t l){ (void)s;(void)a;(void)l; return 0; }
+long libos_send(int s,const void *b,size_t l,int f){ (void)s;(void)b;(void)l;(void)f; return 0; }
+long libos_recv(int s,void *b,size_t l,int f){ (void)s;(void)b;(void)l;(void)f; return 0; }
+
+int main(void){
+    libos_sigset_t ss;
+    libos_sigemptyset(&ss);
+    assert(libos_sigismember(&ss,SIGUSR1)==0);
+    libos_sigaddset(&ss,SIGUSR1);
+    assert(libos_sigismember(&ss,SIGUSR1));
+    return 0;
+}
+""")
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE)
+        subprocess.check_call([
+            "gcc","-std=c2x","-Wall","-Werror",
+            "-I", str(ROOT),
+            "-I", str(ROOT/"src-headers"),
+            str(src),
+            "-o", str(exe)
+        ])
+        subprocess.check_call([str(exe)])
+
+def test_posix_compat():
+    compile_and_run()


### PR DESCRIPTION
## Summary
- expand `libos/posix` with more POSIX wrappers
- exercise the new prototypes from a new python test
- use the new helpers in `libos_posix_extra_test`
- document current compatibility layer

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*