### PR TITLE
Add POSIX API tests

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -139,3 +139,4 @@ fsimg = custom_target('fs.img',
   build_by_default: true)
 
 subdir('tests/microbench')
+subdir('tests/posix')

--- a/src-uland/posix_file_test.c
+++ b/src-uland/posix_file_test.c
@@ -1,0 +1,32 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include "libos/posix.h"
+
+int libos_open(const char *path, int flags) { return open(path, flags | O_CREAT, 0600); }
+int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
+int libos_write(int fd, const void *buf, size_t n) { return (int)write(fd, buf, n); }
+int libos_close(int fd) { return close(fd); }
+int libos_dup(int fd) { return dup(fd); }
+
+int main(void) {
+    const char *msg = "hello";
+    int fd = libos_open("tmpfile.txt", O_RDWR);
+    assert(fd >= 0);
+    assert(libos_write(fd, msg, strlen(msg)) == (int)strlen(msg));
+    assert(libos_close(fd) == 0);
+
+    fd = libos_open("tmpfile.txt", O_RDONLY);
+    char buf[16];
+    int n = libos_read(fd, buf, sizeof(buf) - 1);
+    assert(n >= 0);
+    buf[n] = '\0';
+    assert(strcmp(buf, msg) == 0);
+
+    int dupfd = libos_dup(fd);
+    assert(dupfd >= 0);
+    assert(libos_close(fd) == 0);
+    assert(libos_close(dupfd) == 0);
+    return 0;
+}

--- a/src-uland/posix_pipe_test.c
+++ b/src-uland/posix_pipe_test.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/wait.h>
+#include "libos/posix.h"
+
+int libos_pipe(int fd[2]) { return pipe(fd); }
+int libos_fork(void) { return fork(); }
+int libos_waitpid(int pid) { int st; return waitpid(pid, &st, 0); }
+int libos_close(int fd) { return close(fd); }
+int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
+int libos_write(int fd, const void *buf, size_t n) { return (int)write(fd, buf, n); }
+
+int main(void) {
+    int p[2];
+    assert(libos_pipe(p) == 0);
+    int pid = libos_fork();
+    if (pid == 0) {
+        libos_close(p[1]);
+        char buf[6];
+        int n = libos_read(p[0], buf, sizeof(buf) - 1);
+        buf[n] = '\0';
+        assert(strcmp(buf, "hello") == 0);
+        _exit(0);
+    }
+    libos_close(p[0]);
+    assert(libos_write(p[1], "hello", 5) == 5);
+    libos_close(p[1]);
+    libos_waitpid(pid);
+    return 0;
+}

--- a/src-uland/posix_signal_test.c
+++ b/src-uland/posix_signal_test.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <signal.h>
+#include <unistd.h>
+#include <string.h>
+#include "libos/posix.h"
+
+static volatile sig_atomic_t got;
+
+int libos_signal(int sig, void (*handler)(int)) { return signal(sig, handler) == SIG_ERR ? -1 : 0; }
+int libos_sigsend(int pid, int sig) { (void)pid; return raise(sig); }
+int libos_sigcheck(void) { return got; }
+
+static void handler(int s) { got = s; }
+
+int main(void) {
+    got = 0;
+    assert(libos_signal(SIGUSR1, handler) == 0);
+    assert(libos_sigsend(getpid(), SIGUSR1) == 0);
+    sleep(1);
+    assert(libos_sigcheck() == SIGUSR1);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,0 +1,9 @@
+posix_tests = files('../../src-uland/posix_file_test.c',
+                    '../../src-uland/posix_signal_test.c',
+                    '../../src-uland/posix_pipe_test.c')
+foreach src : posix_tests
+  exe_name = src.stem()
+  executable(exe_name, src,
+             include_directories: include_directories('../../src-headers'),
+             install: false)
+endforeach

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -1,0 +1,35 @@
+import subprocess
+import tempfile
+import pathlib
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+SRC_FILES = [
+    ROOT / 'src-uland/posix_file_test.c',
+    ROOT / 'src-uland/posix_signal_test.c',
+    ROOT / 'src-uland/posix_pipe_test.c',
+]
+
+
+def compile_and_run(source: pathlib.Path) -> None:
+    with tempfile.TemporaryDirectory() as td:
+        exe = pathlib.Path(td) / 'test'
+        subprocess.check_call([
+            'gcc', '-std=c2x', '-Wall', '-Werror',
+            '-idirafter', str(ROOT / 'src-headers'),
+            str(source),
+            '-o', str(exe),
+        ])
+        subprocess.check_call([str(exe)])
+
+
+def test_posix_file_ops():
+    compile_and_run(SRC_FILES[0])
+
+
+def test_posix_signal_ops():
+    compile_and_run(SRC_FILES[1])
+
+
+def test_posix_pipe_ops():
+    compile_and_run(SRC_FILES[2])


### PR DESCRIPTION
## Summary
- add simple POSIX API test programs in `src-uland`
- compile them through a new `tests/posix` Meson subdir
- run them from a new `test_posix_apis.py`

## Testing
- `pytest -q tests/test_posix_apis.py`
- `pytest -q` *(fails: 19 failed, 19 passed)*