### PR TITLE
Add more POSIX wrappers

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -1,20 +1,24 @@
 # POSIX Compatibility Layer
 
-This repository contains a small POSIX wrapper used by the user level
-programs.  The implementation is intentionally tiny and only supports a
-subset of the standard.  The new helpers added by this change provide
-basic stubs so code depending on common interfaces can compile.
+Phoenix exposes capabilities for blocks, pages and IPC endpoints.
+The libOS translates these primitives into familiar POSIX file and
+process abstractions.  Each open file stores the underlying block
+capability and read/write requests issue disk operations on that block.
+Process creation uses capability protected channels to the scheduler but
+returns a traditional PID.  Networking calls are thin wrappers around
+the host socket APIs.
 
 ## Implemented Interfaces
+| Interface | Notes |
+|-----------|----------------------------------------------|
+| `libos_stat` | Returns dummy metadata from the virtual FS. |
+| `libos_lseek` | Adjusts the in-memory file offset. |
+| `libos_ftruncate` | Ignored by the demo filesystem but provided for compatibility. |
+| `libos_mmap` / `libos_munmap` | Allocate and free memory using `malloc`. |
+| Signal set operations | `libos_sig*set()` manipulate a bitmask type. |
+| Process groups | Forward to the host's `getpgrp()` and `setpgid()` calls. |
+| Socket APIs | Thin wrappers around standard Berkeley sockets. |
 
-| Interface                | Notes                                              |
-|--------------------------|----------------------------------------------------|
-| `libos_stat`             | Returns dummy metadata from the virtual FS.        |
-| `libos_lseek`            | Adjusts the in-memory file offset.                 |
-| `libos_mmap` / `libos_munmap` | Allocate and free memory using `malloc`.       |
-| Signal set operations    | `libos_sig*set()` manipulate a bitmask type.       |
-| Process groups           | `libos_getpgrp` and `libos_setpgid` are stubs.     |
-| Socket APIs              | `libos_socket` and friends currently return `-1`.  |
 
 These wrappers mirror the POSIX names where possible but are not fully
 featured.  They exist so portability layers can build against Phoenix

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -6,6 +6,8 @@
 #include "signal.h"
 #include <stdlib.h>
 #include "stat.h"
+#include <unistd.h>
+#include <sys/socket.h>
 
 #define LIBOS_MAXFD 16
 
@@ -151,6 +153,14 @@ long libos_lseek(int fd, long off, int whence) {
     return f->off;
 }
 
+int libos_ftruncate(int fd, long length) {
+    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+        return -1;
+    (void)length;
+    /* The simple in-memory filesystem ignores size changes. */
+    return 0;
+}
+
 void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off) {
     (void)addr; (void)prot; (void)flags; (void)fd; (void)off;
     void *p = malloc(len);
@@ -169,13 +179,38 @@ int libos_sigaddset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; 
 int libos_sigdelset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; *set &= ~(1UL<<sig); return 0; }
 int libos_sigismember(const libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return 0; return (*set & (1UL<<sig))!=0; }
 
-int libos_getpgrp(void){ return getpid(); }
-int libos_setpgid(int pid, int pgid){ (void)pid; (void)pgid; return 0; }
+int libos_getpgrp(void){
+    return (int)getpgrp();
+}
 
-int libos_socket(int domain, int type, int protocol){ (void)domain;(void)type;(void)protocol; return -1; }
-int libos_bind(int fd,const struct sockaddr *addr,socklen_t len){ (void)fd;(void)addr;(void)len; return -1; }
-int libos_listen(int fd,int backlog){ (void)fd;(void)backlog; return -1; }
-int libos_accept(int fd,struct sockaddr *addr,socklen_t *len){ (void)fd;(void)addr;(void)len; return -1; }
-int libos_connect(int fd,const struct sockaddr *addr,socklen_t len){ (void)fd;(void)addr;(void)len; return -1; }
-long libos_send(int fd,const void *buf,size_t len,int flags){ (void)fd;(void)buf;(void)len;(void)flags; return -1; }
-long libos_recv(int fd,void *buf,size_t len,int flags){ (void)fd;(void)buf;(void)len;(void)flags; return -1; }
+int libos_setpgid(int pid, int pgid){
+    return setpgid(pid, pgid);
+}
+
+int libos_socket(int domain, int type, int protocol){
+    return socket(domain, type, protocol);
+}
+
+int libos_bind(int fd,const struct sockaddr *addr,socklen_t len){
+    return bind(fd, addr, len);
+}
+
+int libos_listen(int fd,int backlog){
+    return listen(fd, backlog);
+}
+
+int libos_accept(int fd,struct sockaddr *addr,socklen_t *len){
+    return accept(fd, addr, len);
+}
+
+int libos_connect(int fd,const struct sockaddr *addr,socklen_t len){
+    return connect(fd, addr, len);
+}
+
+long libos_send(int fd,const void *buf,size_t len,int flags){
+    return send(fd, buf, len, flags);
+}
+
+long libos_recv(int fd,void *buf,size_t len,int flags){
+    return recv(fd, buf, len, flags);
+}

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -23,6 +23,7 @@ typedef unsigned long libos_sigset_t;
 
 int libos_stat(const char *path, struct stat *st);
 long libos_lseek(int fd, long off, int whence);
+int libos_ftruncate(int fd, long length);
 void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off);
 int libos_munmap(void *addr, size_t len);
 

--- a/src-uland/user/libos_posix_extra_test.c
+++ b/src-uland/user/libos_posix_extra_test.c
@@ -2,12 +2,15 @@
 #include "user.h"
 #include "stat.h"
 #include "signal.h"
+#include <sys/socket.h>
+#include <netinet/in.h>
 
 int main(void) {
     int fd = libos_open("extra", 0);
     if (fd < 0)
         fd = libos_open("extra", O_CREATE);
     libos_write(fd, "x", 1);
+    libos_ftruncate(fd, 0);
     libos_lseek(fd, 0, 0);
     struct stat st;
     libos_stat("extra", &st);
@@ -15,7 +18,14 @@ int main(void) {
     libos_munmap(p, 128);
     libos_getpgrp();
     libos_setpgid(0, 0);
-    libos_socket(0, 0, 0);
+    int s = libos_socket(AF_INET, SOCK_STREAM, 0);
+    if(s >= 0){
+        struct sockaddr_in a = {0};
+        a.sin_family = AF_INET;
+        libos_bind(s, (struct sockaddr*)&a, sizeof(a));
+        libos_listen(s, 1);
+        libos_close(s);
+    }
     libos_sigset_t ss;
     libos_sigemptyset(&ss);
     libos_sigaddset(&ss, SIGUSR1);

--- a/tests/test_posix_compat.py
+++ b/tests/test_posix_compat.py
@@ -11,6 +11,7 @@ C_CODE = textwrap.dedent("""
 
 int libos_stat(const char *path, struct stat *st){ (void)path; st->size=0; return 0; }
 long libos_lseek(int fd,long off,int whence){ (void)fd;(void)off;(void)whence; return 0; }
+int libos_ftruncate(int fd,long l){ (void)fd;(void)l; return 0; }
 void *libos_mmap(void *a,size_t l,int p,int f,int fd,long o){ (void)a;(void)l;(void)p;(void)f;(void)fd;(void)o; return (void*)1; }
 int libos_munmap(void *a,size_t l){ (void)a;(void)l; return 0; }
 int libos_sigemptyset(libos_sigset_t *s){ *s=0; return 0; }


### PR DESCRIPTION
## Summary
- implement stubs for ftruncate, process groups and socket wrappers
- expose ftruncate prototype
- exercise new calls in libos_posix_extra_test
- document capability mapping in posix_compat

## Testing
- `pytest -q` *(fails: CalledProcessError)*