### PR TITLE
Add tests for extra POSIX wrappers

### DIFF
--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -1,0 +1,42 @@
+#define _XOPEN_SOURCE 700
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/mman.h>
+#include <signal.h>
+#include <string.h>
+#include "libos/posix.h"
+
+int libos_open(const char *path, int flags){ return open(path, flags | O_CREAT, 0600); }
+int libos_close(int fd){ return close(fd); }
+int libos_ftruncate(int fd,long length){ return ftruncate(fd, length); }
+void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){ return mmap(addr,len,prot,flags,fd,off); }
+int libos_munmap(void *addr,size_t len){ return munmap(addr,len); }
+int libos_getpgrp(void){ return (int)getpgrp(); }
+int libos_setpgid(int pid,int pgid){ return setpgid(pid, pgid); }
+int libos_sigemptyset(libos_sigset_t *set){ *set=0; return 0; }
+int libos_sigaddset(libos_sigset_t *set,int sig){ *set |= 1UL<<sig; return 0; }
+int libos_sigismember(const libos_sigset_t *set,int sig){ return (*set & (1UL<<sig)) != 0; }
+
+int main(void){
+    int fd = libos_open("misc.tmp", O_RDWR);
+    assert(fd >= 0);
+    assert(libos_ftruncate(fd, 1024) == 0);
+    assert(libos_ftruncate(-1, 1) == -1);
+    assert(libos_close(fd) == 0);
+    unlink("misc.tmp");
+
+    void *p = libos_mmap(0, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
+    assert(p != MAP_FAILED);
+    strcpy(p, "ok");
+    assert(libos_munmap(p, 4096) == 0);
+
+    int pg = libos_getpgrp();
+    assert(libos_setpgid(0, pg) == 0);
+
+    libos_sigset_t ss;
+    libos_sigemptyset(&ss);
+    libos_sigaddset(&ss, SIGUSR1);
+    assert(libos_sigismember(&ss, SIGUSR1));
+    return 0;
+}

--- a/src-uland/user/posix_socket_test.c
+++ b/src-uland/user/posix_socket_test.c
@@ -1,0 +1,54 @@
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/wait.h>
+#include "libos/posix.h"
+
+int libos_socket(int d,int t,int p){ return socket(d,t,p); }
+int libos_bind(int fd,const struct sockaddr *a,socklen_t l){ return bind(fd,a,l); }
+int libos_listen(int fd,int b){ return listen(fd,b); }
+int libos_accept(int fd,struct sockaddr *a,socklen_t *l){ return accept(fd,a,l); }
+int libos_connect(int fd,const struct sockaddr *a,socklen_t l){ return connect(fd,a,l); }
+long libos_send(int fd,const void *b,size_t l,int f){ return send(fd,b,l,f); }
+long libos_recv(int fd,void *b,size_t l,int f){ return recv(fd,b,l,f); }
+int libos_close(int fd){ return close(fd); }
+
+int main(void){
+    int srv = libos_socket(AF_INET, SOCK_STREAM, 0);
+    assert(srv >= 0);
+    struct sockaddr_in addr = {0};
+    addr.sin_family = AF_INET;
+    addr.sin_port = 0;
+    addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    assert(libos_bind(srv, (struct sockaddr*)&addr, sizeof(addr)) == 0);
+    socklen_t alen = sizeof(addr);
+    assert(getsockname(srv, (struct sockaddr*)&addr, &alen) == 0);
+    assert(libos_listen(srv, 1) == 0);
+
+    int pid = fork();
+    if(pid == 0){
+        int cli = libos_socket(AF_INET, SOCK_STREAM, 0);
+        assert(cli >= 0);
+        assert(libos_connect(cli, (struct sockaddr*)&addr, alen) == 0);
+        assert(libos_send(cli, "hi", 2, 0) == 2);
+        libos_close(cli);
+        _exit(0);
+    }
+
+    int acc = libos_accept(srv, NULL, NULL);
+    assert(acc >= 0);
+    char buf[4] = {0};
+    assert(libos_recv(acc, buf, sizeof(buf), 0) == 2);
+    assert(memcmp(buf, "hi", 2) == 0);
+    libos_close(acc);
+    libos_close(srv);
+    waitpid(pid, NULL, 0);
+
+    int bad = libos_socket(AF_INET, SOCK_STREAM, 0);
+    libos_close(bad);
+    assert(libos_connect(bad, (struct sockaddr*)&addr, alen) == -1);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,8 @@
 posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
-                    '../../src-uland/posix_pipe_test.c')
+                    '../../src-uland/posix_pipe_test.c',
+                    '../../src-uland/user/posix_misc_test.c',
+                    '../../src-uland/user/posix_socket_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -8,6 +8,8 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_file_test.c',
     ROOT / 'src-uland/posix_signal_test.c',
     ROOT / 'src-uland/posix_pipe_test.c',
+    ROOT / 'src-uland/user/posix_misc_test.c',
+    ROOT / 'src-uland/user/posix_socket_test.c',
 ]
 
 
@@ -33,3 +35,11 @@ def test_posix_signal_ops():
 
 def test_posix_pipe_ops():
     compile_and_run(SRC_FILES[2])
+
+
+def test_posix_misc_ops():
+    compile_and_run(SRC_FILES[3])
+
+
+def test_posix_socket_ops():
+    compile_and_run(SRC_FILES[4])


### PR DESCRIPTION
## Summary
- extend C test suite with programs exercising recently added POSIX helpers
- compile new programs via Meson and Python harness

## Testing
- `pytest -q tests/test_posix_apis.py::test_posix_misc_ops -vv`
- `pytest -q tests/test_posix_apis.py::test_posix_socket_ops -vv`
- `pytest -q` *(fails: gcc build errors in other tests)*