### PR TITLE
Add microkernel helper modules and docs

### DIFF
--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -246,6 +246,8 @@ User space may host several small microkernels built on top of the Phoenix capab
 
 Registered microkernels share capabilities through the libOS helpers in `libos/microkernel/`.  The capability manager hands out pages and revokes them when a runtime exits.  Messages are routed by the `msg_router` library which simply forwards buffers to the destination capability.  Resource usage may be metered with the lightweight accounting functions in `resource_account.c` so cooperating kernels can enforce quotas on one another.  Because all communication relies on explicit capabilities the kernels remain isolated yet can still collaborate within the same address space.
 
+The microkernel helpers include modules for runtime registration, message routing and lambda capabilities. `cap.c` now exposes `mk_obtain_cap()` and `mk_revoke_cap()` so runtimes can duplicate or revoke tokens securely. `lambda_cap.c` wraps the affine runtime to create capabilities that execute small policies when consumed. See `examples/microkernel_rcrs_demo.c` for a minimal runtime that registers with `rcrs`, allocates a page and sends a message through the router.
+
 ## Cap'n Proto IPC
 
 Phoenix uses [Cap'n Proto](https://capnproto.org/) schemas to describe the

--- a/examples/microkernel_rcrs_demo.c
+++ b/examples/microkernel_rcrs_demo.c
@@ -1,0 +1,24 @@
+#include "microkernel/microkernel.h"
+#include "user.h"
+
+static int print_step(void *env) {
+    (void)env;
+    printf(1, "demo lambda executed\n");
+    return 1;
+}
+
+int main(void) {
+    microkernel_register();
+
+    exo_cap page = mk_cap_alloc_page();
+    mk_cap_free_page(page);
+
+    lambda_cap_t *lc = mk_lambda_cap_create(print_step, 0, (exo_cap){0});
+    mk_lambda_cap_use(lc, 1);
+    mk_lambda_cap_destroy(lc);
+
+    const char msg[] = "hello";
+    mk_route_message((exo_cap){0}, msg, sizeof(msg));
+
+    return 0;
+}

--- a/libos/microkernel/cap.c
+++ b/libos/microkernel/cap.c
@@ -7,3 +7,16 @@ exo_cap mk_cap_alloc_page(void) {
 int mk_cap_free_page(exo_cap cap) {
     return cap_unbind_page(cap);
 }
+
+int mk_obtain_cap(exo_cap cap, exo_cap *out) {
+    if (!out)
+        return -1;
+    if (cap_inc(cap.id) < 0)
+        return -1;
+    *out = cap;
+    return 0;
+}
+
+int mk_revoke_cap(exo_cap cap) {
+    return cap_revoke(cap.id);
+}

--- a/libos/microkernel/lambda_cap.c
+++ b/libos/microkernel/lambda_cap.c
@@ -1,0 +1,18 @@
+#include "microkernel/microkernel.h"
+#include "affine_runtime.h"
+
+lambda_cap_t *mk_lambda_cap_create(lambda_fn fn, void *env, exo_cap cap) {
+    return lambda_cap_create(fn, env, cap);
+}
+
+void mk_lambda_cap_destroy(lambda_cap_t *lc) { lambda_cap_destroy(lc); }
+
+int mk_lambda_cap_use(lambda_cap_t *lc, int fuel) {
+    return lambda_cap_use(lc, fuel);
+}
+
+int mk_lambda_cap_delegate(lambda_cap_t *lc, uint16_t new_owner) {
+    return lambda_cap_delegate(lc, new_owner);
+}
+
+int mk_lambda_cap_revoke(lambda_cap_t *lc) { return lambda_cap_revoke(lc); }

--- a/libos/microkernel/msg_router.c
+++ b/libos/microkernel/msg_router.c
@@ -1,15 +1,30 @@
 #include "microkernel/microkernel.h"
 
+#define MAX_ENDPOINTS 16
+static exo_cap endpoints[MAX_ENDPOINTS];
+static int endpoint_count;
+
 int mk_route_message(exo_cap dest, const void *buf, size_t len) {
-    return cap_send(dest, buf, len);
+    for (int i = 0; i < endpoint_count; i++) {
+        if (endpoints[i].id == dest.id)
+            return cap_send(dest, buf, len);
+    }
+    return -1;
 }
 
 int mk_register_endpoint(exo_cap ep) {
-    (void)ep;
+    if (endpoint_count >= MAX_ENDPOINTS)
+        return -1;
+    endpoints[endpoint_count++] = ep;
     return 0;
 }
 
 int mk_unregister_endpoint(exo_cap ep) {
-    (void)ep;
-    return 0;
+    for (int i = 0; i < endpoint_count; i++) {
+        if (endpoints[i].id == ep.id) {
+            endpoints[i] = endpoints[--endpoint_count];
+            return 0;
+        }
+    }
+    return -1;
 }

--- a/src-headers/libos/microkernel/microkernel.h
+++ b/src-headers/libos/microkernel/microkernel.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "types.h"
 #include "caplib.h"
+#include "affine_runtime.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -12,11 +13,20 @@ int microkernel_register(void);
 // Capability helpers
 exo_cap mk_cap_alloc_page(void);
 int mk_cap_free_page(exo_cap cap);
+int mk_obtain_cap(exo_cap cap, exo_cap *out);
+int mk_revoke_cap(exo_cap cap);
 
 // Message routing helpers
 int mk_route_message(exo_cap dest, const void *buf, size_t len);
 int mk_register_endpoint(exo_cap ep);
 int mk_unregister_endpoint(exo_cap ep);
+
+// Lambda capability helpers
+lambda_cap_t *mk_lambda_cap_create(lambda_fn fn, void *env, exo_cap cap);
+void mk_lambda_cap_destroy(lambda_cap_t *lc);
+int mk_lambda_cap_use(lambda_cap_t *lc, int fuel);
+int mk_lambda_cap_delegate(lambda_cap_t *lc, uint16_t new_owner);
+int mk_lambda_cap_revoke(lambda_cap_t *lc);
 
 // Simple resource accounting structure
 typedef struct {


### PR DESCRIPTION
## Summary
- expand microkernel headers with capability and lambda helpers
- track endpoints in the message router and add lambda capability module
- document the microkernel helpers
- add a simple microkernel demo

## Testing
- `pytest -q tests/test_cap_types.py tests/test_cap_revoke.py` *(fails: `gcc` warnings treated as errors)*