### PR TITLE
Implement posix capability checks

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -8,6 +8,15 @@ Process creation uses capability protected channels to the scheduler but
 returns a traditional PID.  Networking calls are thin wrappers around
 the host socket APIs.
 
+### Virtual filesystem permissions
+
+The toy filesystem keeps a single read/write permission mask for each
+entry.  `libos_open` verifies these bits along with the capability
+rights before returning a descriptor.  Subsequent calls such as
+`libos_read`, `libos_write` and `libos_ftruncate` fail when the backing
+capability lacks the required access.  No ownership or group metadata is
+tracked and permissions do not persist beyond the in-memory table.
+
 ## Implemented Interfaces
 | Interface | Notes |
 |-----------|----------------------------------------------|

--- a/libos/fs_ufs.c
+++ b/libos/fs_ufs.c
@@ -1,12 +1,17 @@
 #include "libfs.h"
 #include "string.h"
 #include "stdlib.h"
+#include "fcntl.h"
+#include "include/exokernel.h"
 
 #define MAX_VFILES 16
+#define VF_READ  0x1
+#define VF_WRITE 0x2
 
 struct vfile {
     char path[32];
     int used;
+    unsigned perm; /* simple read/write permission bits */
     struct exo_blockcap cap;
 };
 
@@ -27,6 +32,7 @@ static struct vfile *create_vfile(const char *path) {
             strncpy(vfiles[i].path, path, sizeof(vfiles[i].path)-1);
             vfiles[i].path[sizeof(vfiles[i].path)-1] = '\0';
             vfiles[i].used = 1;
+            vfiles[i].perm = VF_READ|VF_WRITE;
             return &vfiles[i];
         }
     }
@@ -38,27 +44,40 @@ void libfs_init(void) {
 }
 
 struct file *libfs_open(const char *path, int flags) {
-    (void)flags;
     struct vfile *vf = lookup_vfile(path);
-    if(!vf)
+    if(!vf) {
+        if(!(flags & O_CREATE))
+            return 0;
         vf = create_vfile(path);
+    }
     if(!vf)
         return 0;
+    int want_r = (flags & O_WRONLY) ? 0 : 1;
+    if(flags & O_RDWR)
+        want_r = 1;
+    int want_w = (flags & O_WRONLY) || (flags & O_RDWR);
+    if((want_r && !(vf->perm & VF_READ)) || (want_w && !(vf->perm & VF_WRITE)))
+        return 0;
+
     struct file *f = filealloc();
     if(!f)
         return 0;
     f->cap = vf->cap;
-    f->readable = 1;
-    f->writable = 1;
+    f->readable = want_r;
+    f->writable = want_w;
     f->off = 0;
     return f;
 }
 
 int libfs_read(struct file *f, void *buf, size_t n) {
+    if(!cap_has_rights(f->cap.rights, EXO_RIGHT_R))
+        return -1;
     return fileread(f, buf, n);
 }
 
 int libfs_write(struct file *f, const void *buf, size_t n) {
+    if(!cap_has_rights(f->cap.rights, EXO_RIGHT_W))
+        return -1;
     return filewrite(f, (char*)buf, n);
 }
 

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,7 @@
 posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
-                    '../../src-uland/posix_pipe_test.c')
+                    '../../src-uland/posix_pipe_test.c',
+                    '../../src-uland/user/libos_posix_extra_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,


### PR DESCRIPTION
## Summary
- enforce capability rights in `libos/posix.c`
- track per-file permissions in the tiny VFS
- document new behaviour
- build extra POSIX regression test

## Testing
- `pytest tests/test_posix_apis.py::test_posix_file_ops -q`