### PR TITLE
Add waitpid options and spawn/wait tests

### DIFF
--- a/libos/posix.c
+++ b/libos/posix.c
@@ -57,7 +57,8 @@ int libos_spawn(const char *path, char *const argv[]) {
     return pid;
 }
 
-int libos_execve(const char *path, char *const argv[]) {
+int libos_execve(const char *path, char *const argv[], char *const envp[]) {
+    (void)envp;
     return exec((char *)path, (char **)argv);
 }
 
@@ -91,7 +92,8 @@ int libos_fork(void) {
     return fork();
 }
 
-int libos_waitpid(int pid) {
+int libos_waitpid(int pid, int options) {
+    (void)options;
     int w;
     while((w = wait()) >= 0) {
         if(w == pid)

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -6,14 +6,14 @@ int libos_read(int fd, void *buf, size_t n);
 int libos_write(int fd, const void *buf, size_t n);
 int libos_close(int fd);
 int libos_spawn(const char *path, char *const argv[]);
-int libos_execve(const char *path, char *const argv[]);
+int libos_execve(const char *path, char *const argv[], char *const envp[]);
 int libos_mkdir(const char *path);
 int libos_rmdir(const char *path);
 int libos_signal(int sig, void (*handler)(int));
 int libos_dup(int fd);
 int libos_pipe(int fd[2]);
 int libos_fork(void);
-int libos_waitpid(int pid);
+int libos_waitpid(int pid, int options);
 int libos_sigsend(int pid, int sig);
 int libos_sigcheck(void);
 

--- a/src-uland/posix_pipe_test.c
+++ b/src-uland/posix_pipe_test.c
@@ -6,7 +6,7 @@
 
 int libos_pipe(int fd[2]) { return pipe(fd); }
 int libos_fork(void) { return fork(); }
-int libos_waitpid(int pid) { int st; return waitpid(pid, &st, 0); }
+int libos_waitpid(int pid, int options) { int st; return waitpid(pid, &st, options); }
 int libos_close(int fd) { return close(fd); }
 int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
 int libos_write(int fd, const void *buf, size_t n) { return (int)write(fd, buf, n); }
@@ -26,6 +26,6 @@ int main(void) {
     libos_close(p[0]);
     assert(libos_write(p[1], "hello", 5) == 5);
     libos_close(p[1]);
-    libos_waitpid(pid);
+    libos_waitpid(pid, 0);
     return 0;
 }

--- a/src-uland/posix_spawn_wait_test.c
+++ b/src-uland/posix_spawn_wait_test.c
@@ -1,0 +1,33 @@
+#include <assert.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/wait.h>
+#include "libos/posix.h"
+
+int libos_spawn(const char *path, char *const argv[]) {
+    pid_t pid = fork();
+    if (pid == 0) {
+        execv(path, argv);
+        _exit(1);
+    }
+    return pid;
+}
+
+int libos_waitpid(int pid, int options) {
+    int st;
+    return (int)waitpid(pid, &st, options);
+}
+
+int main(void) {
+    char *argv1[] = {"echo", "child", NULL};
+    int pid = libos_spawn("/bin/echo", argv1);
+    assert(pid > 0);
+    assert(libos_waitpid(pid, 0) == pid);
+
+    char *argv2[] = {"sleep", "1", NULL};
+    pid = libos_spawn("/bin/sleep", argv2);
+    assert(pid > 0);
+    assert(libos_waitpid(pid, WNOHANG) == 0);
+    assert(libos_waitpid(pid, 0) == pid);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,7 @@
 posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
-                    '../../src-uland/posix_pipe_test.c')
+                    '../../src-uland/posix_pipe_test.c',
+                    '../../src-uland/posix_spawn_wait_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -8,6 +8,7 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_file_test.c',
     ROOT / 'src-uland/posix_signal_test.c',
     ROOT / 'src-uland/posix_pipe_test.c',
+    ROOT / 'src-uland/posix_spawn_wait_test.c',
 ]
 
 
@@ -33,3 +34,7 @@ def test_posix_signal_ops():
 
 def test_posix_pipe_ops():
     compile_and_run(SRC_FILES[2])
+
+
+def test_posix_spawn_wait_ops():
+    compile_and_run(SRC_FILES[3])


### PR DESCRIPTION
## Summary
- extend libos POSIX interface for `execve` and `waitpid`
- adjust libos implementation of new prototypes
- update existing POSIX pipe test to use new waitpid interface
- add a spawn/wait test and hook it up with the build system

## Testing
- `pytest tests/test_posix_apis.py::test_posix_spawn_wait_ops -q`