### PR TITLE
Add socket option wrappers and inet helpers

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -18,6 +18,8 @@ the host socket APIs.
 | Signal set operations | `libos_sig*set()` manipulate a bitmask type. |
 | Process groups | Forward to the host's `getpgrp()` and `setpgid()` calls. |
 | Socket APIs | Thin wrappers around standard Berkeley sockets. |
+| `libos_setsockopt`/`libos_getsockopt` | Forward to `setsockopt()` and `getsockopt()`. |
+| `libos_inet_pton`/`libos_inet_ntop` | Wrap the host helpers for IP string conversion. |
 
 
 These wrappers mirror the POSIX names where possible but are not fully

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -8,6 +8,7 @@
 #include "stat.h"
 #include <unistd.h>
 #include <sys/socket.h>
+#include <arpa/inet.h>
 
 #define LIBOS_MAXFD 16
 
@@ -213,4 +214,22 @@ long libos_send(int fd,const void *buf,size_t len,int flags){
 
 long libos_recv(int fd,void *buf,size_t len,int flags){
     return recv(fd, buf, len, flags);
+}
+
+int libos_setsockopt(int fd,int level,int optname,
+                     const void *optval,socklen_t optlen){
+    return setsockopt(fd, level, optname, optval, optlen);
+}
+
+int libos_getsockopt(int fd,int level,int optname,
+                     void *optval,socklen_t *optlen){
+    return getsockopt(fd, level, optname, optval, optlen);
+}
+
+int libos_inet_pton(int af,const char *src,void *dst){
+    return inet_pton(af, src, dst);
+}
+
+const char *libos_inet_ntop(int af,const void *src,char *dst,socklen_t size){
+    return inet_ntop(af, src, dst, size);
 }

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -45,3 +45,12 @@ int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
 int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
+
+int libos_setsockopt(int fd, int level, int optname,
+                     const void *optval, socklen_t optlen);
+int libos_getsockopt(int fd, int level, int optname,
+                     void *optval, socklen_t *optlen);
+
+int libos_inet_pton(int af, const char *src, void *dst);
+const char *libos_inet_ntop(int af, const void *src,
+                            char *dst, socklen_t size);

--- a/src-uland/posix_net_test.c
+++ b/src-uland/posix_net_test.c
@@ -1,0 +1,31 @@
+#include <assert.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <unistd.h>
+#include "libos/posix.h"
+
+int libos_socket(int d,int t,int p){ return socket(d,t,p); }
+int libos_setsockopt(int fd,int level,int optname,const void *ov,socklen_t ol){ return setsockopt(fd,level,optname,ov,ol); }
+int libos_getsockopt(int fd,int level,int optname,void *ov,socklen_t *ol){ return getsockopt(fd,level,optname,ov,ol); }
+int libos_close(int fd){ return close(fd); }
+int libos_inet_pton(int af,const char *src,void *dst){ return inet_pton(af,src,dst); }
+const char *libos_inet_ntop(int af,const void *src,char *dst,socklen_t sz){ return inet_ntop(af,src,dst,sz); }
+
+int main(void){
+    int s = libos_socket(AF_INET, SOCK_STREAM, 0);
+    assert(s >= 0);
+    int v = 1; socklen_t l = sizeof(v);
+    assert(libos_setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &v, l) == 0);
+    v = 0;
+    assert(libos_getsockopt(s, SOL_SOCKET, SO_REUSEADDR, &v, &l) == 0);
+    assert(v == 1);
+    struct in_addr ia;
+    char buf[INET_ADDRSTRLEN];
+    assert(libos_inet_pton(AF_INET, "127.0.0.1", &ia) == 1);
+    assert(libos_inet_ntop(AF_INET, &ia, buf, sizeof(buf)) != NULL);
+    assert(strcmp(buf, "127.0.0.1") == 0);
+    libos_close(s);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,7 @@
 posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
-                    '../../src-uland/posix_pipe_test.c')
+                    '../../src-uland/posix_pipe_test.c',
+                    '../../src-uland/posix_net_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -8,6 +8,7 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_file_test.c',
     ROOT / 'src-uland/posix_signal_test.c',
     ROOT / 'src-uland/posix_pipe_test.c',
+    ROOT / 'src-uland/posix_net_test.c',
 ]
 
 
@@ -33,3 +34,7 @@ def test_posix_signal_ops():
 
 def test_posix_pipe_ops():
     compile_and_run(SRC_FILES[2])
+
+
+def test_posix_net_ops():
+    compile_and_run(SRC_FILES[3])


### PR DESCRIPTION
## Summary
- implement `libos_getsockopt` and `libos_setsockopt`
- add inet address helpers
- document new functions
- extend POSIX test suite with networking checks

## Testing
- `pytest tests/test_posix_apis.py::test_posix_net_ops -q`
- `pytest -q` *(fails: subprocess.CalledProcessError)*