### PR TITLE
Add environment table to libOS

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -23,3 +23,17 @@ the host socket APIs.
 These wrappers mirror the POSIX names where possible but are not fully
 featured.  They exist so portability layers can build against Phoenix
 without pulling in a real C library.
+
+## Environment Variables
+
+`libos_setenv()` stores a key/value pair in a small internal table.
+`libos_getenv()` retrieves the value or returns `NULL` if the variable is
+unknown.  Variables are not inherited across spawned processes.
+
+## Locale Stubs
+
+Only stub implementations of the standard locale interfaces are
+available.  Functions like `setlocale()` and `localeconv()` accept any
+input but always behave as if the `"C"` locale is active.  The stubs
+exist so that third-party code expecting these calls can link against the
+libOS without pulling in a full C library.

--- a/libos/env.c
+++ b/libos/env.c
@@ -1,0 +1,53 @@
+#include <string.h>
+#include <stdlib.h>
+#include "libos/posix.h"
+
+#ifndef LIBOS_MAXENV
+#define LIBOS_MAXENV 32
+#endif
+
+struct env_entry {
+    char *name;
+    char *value;
+};
+
+static struct env_entry env_table[LIBOS_MAXENV];
+
+int libos_setenv(const char *name, const char *value) {
+    if(!name || !value)
+        return -1;
+    for(int i = 0; i < LIBOS_MAXENV; i++) {
+        if(env_table[i].name && strcmp(env_table[i].name, name) == 0) {
+            char *v = strdup(value);
+            if(!v)
+                return -1;
+            free(env_table[i].value);
+            env_table[i].value = v;
+            return 0;
+        }
+    }
+    for(int i = 0; i < LIBOS_MAXENV; i++) {
+        if(!env_table[i].name) {
+            env_table[i].name = strdup(name);
+            env_table[i].value = strdup(value);
+            if(!env_table[i].name || !env_table[i].value) {
+                free(env_table[i].name);
+                free(env_table[i].value);
+                env_table[i].name = env_table[i].value = NULL;
+                return -1;
+            }
+            return 0;
+        }
+    }
+    return -1;
+}
+
+const char *libos_getenv(const char *name) {
+    if(!name)
+        return NULL;
+    for(int i = 0; i < LIBOS_MAXENV; i++) {
+        if(env_table[i].name && strcmp(env_table[i].name, name) == 0)
+            return env_table[i].value;
+    }
+    return NULL;
+}

--- a/meson.build
+++ b/meson.build
@@ -53,6 +53,7 @@ libos_sources = [
   'libos/file.c',
   'libos/driver.c',
   'libos/affine_runtime.c',
+  'libos/env.c',
   'libos/posix.c',
   'libos/microkernel/cap.c',
   'libos/microkernel/msg_router.c',

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -45,3 +45,6 @@ int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
 int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
+
+int libos_setenv(const char *name, const char *value);
+const char *libos_getenv(const char *name);

--- a/tests/test_libos_env.py
+++ b/tests/test_libos_env.py
@@ -1,0 +1,34 @@
+import subprocess, tempfile, pathlib, textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+C_CODE = textwrap.dedent("""
+#include <assert.h>
+#include <string.h>
+#include "libos/posix.h"
+
+int main(void) {
+    assert(libos_setenv("FOO", "BAR") == 0);
+    assert(strcmp(libos_getenv("FOO"), "BAR") == 0);
+    assert(libos_getenv("MISSING") == NULL);
+    return 0;
+}
+""")
+
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td)/"test.c"
+        exe = pathlib.Path(td)/"test"
+        src.write_text(C_CODE)
+        subprocess.check_call([
+            "gcc","-std=c2x","-Wall","-Werror",
+            "-idirafter", str(ROOT/"src-headers"),
+            str(src), str(ROOT/"libos/env.c"),
+            "-o", str(exe)
+        ])
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_libos_env_basic():
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- maintain key/value environment variables in libOS
- expose `libos_setenv` and `libos_getenv`
- document environment and locale support
- unit test the new helpers
- build system: compile new `libos/env.c`

## Testing
- `pytest -q` *(fails: CalledProcessError)*
- `pytest tests/test_libos_env.py::test_libos_env_basic -q`