### PR TITLE
Implement basic timer support

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -1,4 +1,4 @@
-# POSIX Compatibility Layer
+#POSIX Compatibility Layer
 
 Phoenix exposes capabilities for blocks, pages and IPC endpoints.
 The libOS translates these primitives into familiar POSIX file and
@@ -18,6 +18,8 @@ the host socket APIs.
 | Signal set operations | `libos_sig*set()` manipulate a bitmask type. |
 | Process groups | Forward to the host's `getpgrp()` and `setpgid()` calls. |
 | Socket APIs | Thin wrappers around standard Berkeley sockets. |
+| `libos_nanosleep` | Uses the kernel tick counter for delays. |
+| `libos_timer_create`/`libos_timer_delete` | Manage a small list of timers. |
 
 
 These wrappers mirror the POSIX names where possible but are not fully

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -5,6 +5,7 @@
 #include "user.h"
 #include "signal.h"
 #include <stdlib.h>
+#include <time.h>
 #include "stat.h"
 #include <unistd.h>
 #include <sys/socket.h>
@@ -14,203 +15,279 @@
 static struct file *fd_table[LIBOS_MAXFD];
 static void (*sig_handlers[32])(int);
 
+struct timer {
+  int id;
+  struct timer *next;
+};
+
+static struct timer timer_nodes[16];
+static struct timer *timer_free;
+static struct timer *timer_active;
+
+static void init_timers(void) {
+  for (int i = 0; i < 16; i++) {
+    timer_nodes[i].id = i;
+    timer_nodes[i].next = timer_free;
+    timer_free = &timer_nodes[i];
+  }
+}
+
+__attribute__((constructor)) static void posix_init(void) { init_timers(); }
+
 int libos_open(const char *path, int flags) {
-    struct file *f = libfs_open(path, flags);
-    if(!f)
-        return -1;
-    for(int i = 0; i < LIBOS_MAXFD; i++) {
-        if(!fd_table[i]) {
-            fd_table[i] = f;
-            return i;
-        }
-    }
-    fileclose(f);
+  struct file *f = libfs_open(path, flags);
+  if (!f)
     return -1;
+  for (int i = 0; i < LIBOS_MAXFD; i++) {
+    if (!fd_table[i]) {
+      fd_table[i] = f;
+      return i;
+    }
+  }
+  fileclose(f);
+  return -1;
 }
 
 int libos_read(int fd, void *buf, size_t n) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    return libfs_read(fd_table[fd], buf, n);
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+    return -1;
+  return libfs_read(fd_table[fd], buf, n);
 }
 
 int libos_write(int fd, const void *buf, size_t n) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    return libfs_write(fd_table[fd], buf, n);
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+    return -1;
+  return libfs_write(fd_table[fd], buf, n);
 }
 
 int libos_close(int fd) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    libfs_close(fd_table[fd]);
-    fd_table[fd] = 0;
-    return 0;
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+    return -1;
+  libfs_close(fd_table[fd]);
+  fd_table[fd] = 0;
+  return 0;
 }
 
 int libos_spawn(const char *path, char *const argv[]) {
-    int pid = fork();
-    if(pid == 0) {
-        exec((char *)path, (char **)argv);
-        exit();
-    }
-    return pid;
+  int pid = fork();
+  if (pid == 0) {
+    exec((char *)path, (char **)argv);
+    exit();
+  }
+  return pid;
 }
 
 int libos_execve(const char *path, char *const argv[]) {
-    return exec((char *)path, (char **)argv);
+  return exec((char *)path, (char **)argv);
 }
 
-int libos_mkdir(const char *path) {
-    return mkdir((char *)path);
-}
+int libos_mkdir(const char *path) { return mkdir((char *)path); }
 
-int libos_rmdir(const char *path) {
-    return unlink((char *)path);
-}
+int libos_rmdir(const char *path) { return unlink((char *)path); }
 
 int libos_dup(int fd) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    struct file *f = filedup(fd_table[fd]);
-    for(int i = 0; i < LIBOS_MAXFD; i++) {
-        if(!fd_table[i]) {
-            fd_table[i] = f;
-            return i;
-        }
-    }
-    fileclose(f);
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
     return -1;
+  struct file *f = filedup(fd_table[fd]);
+  for (int i = 0; i < LIBOS_MAXFD; i++) {
+    if (!fd_table[i]) {
+      fd_table[i] = f;
+      return i;
+    }
+  }
+  fileclose(f);
+  return -1;
 }
 
-int libos_pipe(int fd[2]) {
-    return pipe(fd);
-}
+int libos_pipe(int fd[2]) { return pipe(fd); }
 
-int libos_fork(void) {
-    return fork();
-}
+int libos_fork(void) { return fork(); }
 
 int libos_waitpid(int pid) {
-    int w;
-    while((w = wait()) >= 0) {
-        if(w == pid)
-            return w;
-    }
-    return -1;
+  int w;
+  while ((w = wait()) >= 0) {
+    if (w == pid)
+      return w;
+  }
+  return -1;
 }
 
-int libos_sigsend(int pid, int sig) {
-    return sigsend(pid, sig);
-}
+int libos_sigsend(int pid, int sig) { return sigsend(pid, sig); }
 
 int libos_sigcheck(void) {
-    int pending = sigcheck();
-    for(int s = 0; s < 32; s++) {
-        if((pending & (1<<s)) && sig_handlers[s])
-            sig_handlers[s](s);
-    }
-    return pending;
+  int pending = sigcheck();
+  for (int s = 0; s < 32; s++) {
+    if ((pending & (1 << s)) && sig_handlers[s])
+      sig_handlers[s](s);
+  }
+  return pending;
 }
 
 int libos_signal(int sig, void (*handler)(int)) {
-    if(sig < 0 || sig >= 32)
-        return -1;
-    sig_handlers[sig] = handler;
-    return 0;
+  if (sig < 0 || sig >= 32)
+    return -1;
+  sig_handlers[sig] = handler;
+  return 0;
 }
 
 int libos_stat(const char *path, struct stat *st) {
-    struct file *f = libfs_open(path, 0);
-    if(!f)
-        return -1;
-    int r = filestat(f, st);
-    libfs_close(f);
-    return r;
+  struct file *f = libfs_open(path, 0);
+  if (!f)
+    return -1;
+  int r = filestat(f, st);
+  libfs_close(f);
+  return r;
 }
 
 long libos_lseek(int fd, long off, int whence) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    struct file *f = fd_table[fd];
-    switch(whence){
-    case 0: /* SEEK_SET */
-        f->off = off;
-        break;
-    case 1: /* SEEK_CUR */
-        f->off += off;
-        break;
-    case 2: {
-        struct stat st;
-        if(filestat(f, &st) < 0)
-            return -1;
-        f->off = st.size + off;
-        break;
-    }
-    default:
-        return -1;
-    }
-    return f->off;
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+    return -1;
+  struct file *f = fd_table[fd];
+  switch (whence) {
+  case 0: /* SEEK_SET */
+    f->off = off;
+    break;
+  case 1: /* SEEK_CUR */
+    f->off += off;
+    break;
+  case 2: {
+    struct stat st;
+    if (filestat(f, &st) < 0)
+      return -1;
+    f->off = st.size + off;
+    break;
+  }
+  default:
+    return -1;
+  }
+  return f->off;
 }
 
 int libos_ftruncate(int fd, long length) {
-    if(fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
-        return -1;
-    (void)length;
-    /* The simple in-memory filesystem ignores size changes. */
-    return 0;
+  if (fd < 0 || fd >= LIBOS_MAXFD || !fd_table[fd])
+    return -1;
+  (void)length;
+  /* The simple in-memory filesystem ignores size changes. */
+  return 0;
 }
 
-void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off) {
-    (void)addr; (void)prot; (void)flags; (void)fd; (void)off;
-    void *p = malloc(len);
-    return p ? p : (void*)-1;
+void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                 long off) {
+  (void)addr;
+  (void)prot;
+  (void)flags;
+  (void)fd;
+  (void)off;
+  void *p = malloc(len);
+  return p ? p : (void *)-1;
 }
 
 int libos_munmap(void *addr, size_t len) {
-    (void)len;
-    free(addr);
+  (void)len;
+  free(addr);
+  return 0;
+}
+
+int libos_sigemptyset(libos_sigset_t *set) {
+  *set = 0;
+  return 0;
+}
+int libos_sigfillset(libos_sigset_t *set) {
+  *set = ~0UL;
+  return 0;
+}
+int libos_sigaddset(libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
+    return -1;
+  *set |= (1UL << sig);
+  return 0;
+}
+int libos_sigdelset(libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
+    return -1;
+  *set &= ~(1UL << sig);
+  return 0;
+}
+int libos_sigismember(const libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
     return 0;
+  return (*set & (1UL << sig)) != 0;
 }
 
-int libos_sigemptyset(libos_sigset_t *set){ *set = 0; return 0; }
-int libos_sigfillset(libos_sigset_t *set){ *set = ~0UL; return 0; }
-int libos_sigaddset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; *set |= (1UL<<sig); return 0; }
-int libos_sigdelset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; *set &= ~(1UL<<sig); return 0; }
-int libos_sigismember(const libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return 0; return (*set & (1UL<<sig))!=0; }
+int libos_getpgrp(void) { return (int)getpgrp(); }
 
-int libos_getpgrp(void){
-    return (int)getpgrp();
+int libos_setpgid(int pid, int pgid) { return setpgid(pid, pgid); }
+
+int libos_socket(int domain, int type, int protocol) {
+  return socket(domain, type, protocol);
 }
 
-int libos_setpgid(int pid, int pgid){
-    return setpgid(pid, pgid);
+int libos_bind(int fd, const struct sockaddr *addr, socklen_t len) {
+  return bind(fd, addr, len);
 }
 
-int libos_socket(int domain, int type, int protocol){
-    return socket(domain, type, protocol);
+int libos_listen(int fd, int backlog) { return listen(fd, backlog); }
+
+int libos_accept(int fd, struct sockaddr *addr, socklen_t *len) {
+  return accept(fd, addr, len);
 }
 
-int libos_bind(int fd,const struct sockaddr *addr,socklen_t len){
-    return bind(fd, addr, len);
+int libos_connect(int fd, const struct sockaddr *addr, socklen_t len) {
+  return connect(fd, addr, len);
 }
 
-int libos_listen(int fd,int backlog){
-    return listen(fd, backlog);
+long libos_send(int fd, const void *buf, size_t len, int flags) {
+  return send(fd, buf, len, flags);
 }
 
-int libos_accept(int fd,struct sockaddr *addr,socklen_t *len){
-    return accept(fd, addr, len);
+long libos_recv(int fd, void *buf, size_t len, int flags) {
+  return recv(fd, buf, len, flags);
 }
 
-int libos_connect(int fd,const struct sockaddr *addr,socklen_t len){
-    return connect(fd, addr, len);
+int libos_nanosleep(const struct timespec *req, struct timespec *rem) {
+  const long TICK_NS = 10000000L; /* 10ms */
+  long remain = req->tv_sec * 1000000000L + req->tv_nsec;
+  uint32_t start = uptime();
+  while (1) {
+    uint32_t now = uptime();
+    long elapsed = (long)(now - start) * TICK_NS;
+    if (elapsed >= remain)
+      break;
+    sleep(1);
+  }
+  if (rem) {
+    rem->tv_sec = 0;
+    rem->tv_nsec = 0;
+  }
+  return 0;
 }
 
-long libos_send(int fd,const void *buf,size_t len,int flags){
-    return send(fd, buf, len, flags);
+int libos_timer_create(clockid_t clockid, struct sigevent *sevp,
+                       timer_t *timerid) {
+  (void)clockid;
+  (void)sevp;
+  if (!timer_free)
+    return -1;
+  struct timer *t = timer_free;
+  timer_free = t->next;
+  t->next = timer_active;
+  timer_active = t;
+  if (timerid)
+    *timerid = t->id;
+  return 0;
 }
 
-long libos_recv(int fd,void *buf,size_t len,int flags){
-    return recv(fd, buf, len, flags);
+int libos_timer_delete(timer_t timerid) {
+  struct timer **pp = &timer_active;
+  while (*pp) {
+    if ((*pp)->id == timerid) {
+      struct timer *t = *pp;
+      *pp = t->next;
+      t->next = timer_free;
+      timer_free = t;
+      return 0;
+    }
+    pp = &(*pp)->next;
+  }
+  return -1;
 }

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -45,3 +45,12 @@ int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
 int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
+
+struct timespec;
+struct sigevent;
+typedef int timer_t;
+typedef int clockid_t;
+int libos_nanosleep(const struct timespec *req, struct timespec *rem);
+int libos_timer_create(clockid_t clockid, struct sigevent *sevp,
+                       timer_t *timerid);
+int libos_timer_delete(timer_t timerid);

--- a/src-uland/timer_test.c
+++ b/src-uland/timer_test.c
@@ -1,0 +1,22 @@
+#include <assert.h>
+#include <time.h>
+#include "libos/posix.h"
+
+int libos_nanosleep(const struct timespec *req, struct timespec *rem) {
+  return nanosleep(req, rem);
+}
+
+int libos_timer_create(clockid_t clockid, struct sigevent *sevp, timer_t *tid) {
+  return timer_create(clockid, sevp, tid);
+}
+
+int libos_timer_delete(timer_t tid) { return timer_delete(tid); }
+
+int main(void) {
+  struct timespec ts = {0, 1000000};
+  assert(libos_nanosleep(&ts, 0) == 0);
+  timer_t t;
+  assert(libos_timer_create(CLOCK_REALTIME, NULL, &t) == 0);
+  assert(libos_timer_delete(t) == 0);
+  return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,7 @@
 posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
-                    '../../src-uland/posix_pipe_test.c')
+                    '../../src-uland/posix_pipe_test.c',
+                    '../../src-uland/timer_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -5,21 +5,29 @@ import pathlib
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 
 SRC_FILES = [
-    ROOT / 'src-uland/posix_file_test.c',
-    ROOT / 'src-uland/posix_signal_test.c',
-    ROOT / 'src-uland/posix_pipe_test.c',
+    ROOT / "src-uland/posix_file_test.c",
+    ROOT / "src-uland/posix_signal_test.c",
+    ROOT / "src-uland/posix_pipe_test.c",
+    ROOT / "src-uland/timer_test.c",
 ]
 
 
 def compile_and_run(source: pathlib.Path) -> None:
     with tempfile.TemporaryDirectory() as td:
-        exe = pathlib.Path(td) / 'test'
-        subprocess.check_call([
-            'gcc', '-std=c2x', '-Wall', '-Werror',
-            '-idirafter', str(ROOT / 'src-headers'),
-            str(source),
-            '-o', str(exe),
-        ])
+        exe = pathlib.Path(td) / "test"
+        subprocess.check_call(
+            [
+                "gcc",
+                "-std=c2x",
+                "-Wall",
+                "-Werror",
+                "-idirafter",
+                str(ROOT / "src-headers"),
+                str(source),
+                "-o",
+                str(exe),
+            ]
+        )
         subprocess.check_call([str(exe)])
 
 


### PR DESCRIPTION
## Summary
- implement nanosleep and per-process timer tracking in libos
- declare timer helpers in headers
- document new functionality
- add timer test program and include it in build/test scripts

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*
- `pytest -q` *(fails: gcc compile errors)*