### PR TITLE
Add capability-backed IPC stubs

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -1,4 +1,4 @@
-# POSIX Compatibility Layer
+#POSIX Compatibility Layer
 
 Phoenix exposes capabilities for blocks, pages and IPC endpoints.
 The libOS translates these primitives into familiar POSIX file and
@@ -18,6 +18,9 @@ the host socket APIs.
 | Signal set operations | `libos_sig*set()` manipulate a bitmask type. |
 | Process groups | Forward to the host's `getpgrp()` and `setpgid()` calls. |
 | Socket APIs | Thin wrappers around standard Berkeley sockets. |
+| Message queues | `mq_*()` allocate endpoints and exchange data with `cap_send` and `cap_recv`. |
+| Semaphores | `sem_*()` store a counter in a capability-backed page. |
+| Shared memory | `shm_*()` return page capabilities that map to process memory. |
 
 
 These wrappers mirror the POSIX names where possible but are not fully

--- a/libos/ipc.c
+++ b/libos/ipc.c
@@ -1,0 +1,119 @@
+#include "libos/posix.h"
+#include "caplib.h"
+#include <stdlib.h>
+#include <string.h>
+
+struct libos_mq {
+  exo_cap cap;
+};
+
+libos_mqd_t mq_open(const char *name, int flags) {
+  (void)name;
+  (void)flags;
+  struct libos_mq *q = malloc(sizeof(*q));
+  if (!q)
+    return NULL;
+  q->cap = cap_alloc_page();
+  return q;
+}
+
+int mq_send(libos_mqd_t q, const char *buf, size_t len, unsigned prio) {
+  (void)prio;
+  if (!q)
+    return -1;
+  return cap_send(q->cap, buf, len);
+}
+
+int mq_receive(libos_mqd_t q, char *buf, size_t len, unsigned *prio) {
+  (void)prio;
+  if (!q)
+    return -1;
+  return cap_recv(q->cap, buf, len);
+}
+
+int mq_close(libos_mqd_t q) {
+  if (!q)
+    return -1;
+  cap_unbind_page(q->cap);
+  free(q);
+  return 0;
+}
+
+struct libos_sem {
+  exo_cap cap;
+  unsigned value;
+};
+
+libos_sem_t sem_open(const char *name, int flags, unsigned value) {
+  (void)name;
+  (void)flags;
+  struct libos_sem *s = malloc(sizeof(*s));
+  if (!s)
+    return NULL;
+  s->cap = cap_alloc_page();
+  s->value = value;
+  return s;
+}
+
+int sem_wait(libos_sem_t s) {
+  if (!s)
+    return -1;
+  if (s->value == 0)
+    return -1;
+  s->value--;
+  return 0;
+}
+
+int sem_post(libos_sem_t s) {
+  if (!s)
+    return -1;
+  s->value++;
+  return 0;
+}
+
+int sem_close(libos_sem_t s) {
+  if (!s)
+    return -1;
+  cap_unbind_page(s->cap);
+  free(s);
+  return 0;
+}
+
+struct libos_shm {
+  exo_cap cap;
+  void *addr;
+  size_t size;
+};
+
+libos_shm_t shm_open(const char *name, int flags, size_t size) {
+  (void)name;
+  (void)flags;
+  struct libos_shm *s = malloc(sizeof(*s));
+  if (!s)
+    return NULL;
+  s->cap = cap_alloc_page();
+  s->addr = malloc(size);
+  s->size = size;
+  return s;
+}
+
+void *shm_map(libos_shm_t s) {
+  if (!s)
+    return NULL;
+  return s->addr;
+}
+
+int shm_unmap(libos_shm_t s) {
+  if (!s)
+    return -1;
+  return 0;
+}
+
+int shm_close(libos_shm_t s) {
+  if (!s)
+    return -1;
+  free(s->addr);
+  cap_unbind_page(s->cap);
+  free(s);
+  return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -1,168 +1,155 @@
-project('xv6', 'c', default_options: ['c_std=c23'])
-add_project_arguments('-Wall', '-Werror', language: ['c', 'cpp'])
+project('xv6', 'c', default_options : ['c_std=c23'])
+    add_project_arguments('-Wall', '-Werror', language : [ 'c', 'cpp' ])
 
-use_ticket_lock = get_option('use_ticket_lock')
-ipc_debug = get_option('ipc_debug')
-use_capnp = get_option('use_capnp')
-common_cargs = []
-if use_ticket_lock
-  common_cargs += ['-DUSE_TICKET_LOCK']
-endif
-if ipc_debug
-  common_cargs += ['-DIPC_DEBUG']
-endif
+        use_ticket_lock = get_option('use_ticket_lock') ipc_debug =
+            get_option('ipc_debug') use_capnp = get_option('use_capnp')
+                common_cargs = [] if use_ticket_lock common_cargs
+    += ['-DUSE_TICKET_LOCK'] endif if ipc_debug common_cargs
+    += ['-DIPC_DEBUG'] endif
 
-clang_tidy = find_program('clang-tidy', required: false)
-bison = find_program('bison', required: false)
-if bison.found()
-  example_parser = custom_target('example_parser',
-    input: 'proto/example.y',
-    output: ['example_parser.c', 'example_parser.h'],
-    command: [bison, '--defines=@OUTPUT1@', '-o', '@OUTPUT0@', '@INPUT@'])
-endif
+    clang_tidy = find_program('clang-tidy', required : false) bison =
+        find_program('bison', required : false) if bison.found()
+            example_parser = custom_target(
+            'example_parser', input : 'proto/example.y',
+            output : [ 'example_parser.c', 'example_parser.h' ],
+            command :
+            [ bison, '--defines=@OUTPUT1@', '-o', '@OUTPUT0@',
+              '@INPUT@' ]) endif
 
-# User-space runtime library
-mock_capnpc = find_program('scripts/mock_capnpc.sh')
-capnp_targets = []
-if use_capnp
-  driver_capnp = custom_target('driver_capnp',
-      input: 'proto/driver.capnp',
-      output: ['driver.capnp.c', 'driver.capnp.h'],
-      command: [mock_capnpc, '@INPUT@'])
-  hello_capnp = custom_target('hello_capnp',
-      input: 'proto/hello.capnp',
-      output: ['hello.capnp.c', 'hello.capnp.h'],
-      command: [mock_capnpc, '@INPUT@'])
-  capnp_targets += [driver_capnp, hello_capnp]
-  libcapnp = static_library('libcapnp',
-      ['libos/capnp/capnp_helpers.c'] + capnp_targets,
-      include_directories: include_directories('.', 'src-headers', 'proto', 'libos/capnp'),
-      c_args: common_cargs)
-endif
+#User - space runtime library
+    mock_capnpc = find_program('scripts/mock_capnpc.sh')
+        capnp_targets = [] if use_capnp driver_capnp = custom_target(
+            'driver_capnp', input : 'proto/driver.capnp',
+            output : [ 'driver.capnp.c', 'driver.capnp.h' ],
+            command : [ mock_capnpc, '@INPUT@' ]) hello_capnp =
+            custom_target('hello_capnp', input : 'proto/hello.capnp',
+                          output : [ 'hello.capnp.c', 'hello.capnp.h' ],
+                          command : [ mock_capnpc, '@INPUT@' ]) capnp_targets
+    += [ driver_capnp, hello_capnp ] libcapnp = static_library(
+        'libcapnp', ['libos/capnp/capnp_helpers.c'] + capnp_targets,
+        include_directories : include_directories('.', 'src-headers', 'proto',
+                                                  'libos/capnp'),
+        c_args : common_cargs) endif
 
-libos_sources = [
-  'src-uland/ulib.c',
-  'src-uland/printf.c',
-  'src-uland/umalloc.c',
-  'src-uland/caplib.c',
-  'src-uland/chan.c',
-  'src-uland/door.c',
-  'src-uland/math_core.c',
-  'src-uland/libos/sched.c',
-  'libos/fs.c',
-  'libos/file.c',
-  'libos/driver.c',
-  'libos/affine_runtime.c',
-  'libos/posix.c',
-  'libos/microkernel/cap.c',
-  'libos/microkernel/msg_router.c',
-  'libos/microkernel/resource_account.c',
-  'libos/microkernel/registration.c',
-]
+    libos_sources =
+        [
+          'src-uland/ulib.c',
+          'src-uland/printf.c',
+          'src-uland/umalloc.c',
+          'src-uland/caplib.c',
+          'src-uland/chan.c',
+          'src-uland/door.c',
+          'src-uland/math_core.c',
+          'src-uland/libos/sched.c',
+          'libos/fs.c',
+          'libos/file.c',
+          'libos/driver.c',
+          'libos/affine_runtime.c',
+          'libos/posix.c',
+          'libos/microkernel/cap.c',
+          'libos/microkernel/msg_router.c',
+          'libos/microkernel/resource_account.c',
+          'libos/microkernel/registration.c',
+        ]
 
-libos = static_library('libos', libos_sources,
-    include_directories: include_directories('.', 'src-headers', 'proto', 'libos/include', 'libos/capnp'),
-    c_args: common_cargs)
+    libos = static_library('libos', libos_sources,
+                           include_directories : include_directories(
+                               '.', 'src-headers', 'proto', 'libos/include',
+                               'libos/capnp'),
+                           c_args : common_cargs)
 
-src_dirs = ['src-kernel', 'src-uland', 'src-uland/user', 'libos']
+        src_dirs = [ 'src-kernel', 'src-uland', 'src-uland/user', 'libos' ]
 
-sources = []
-foreach d : src_dirs
-  sources += files(d + '/*.c')
-endforeach
+    sources = [] foreach d
+    : src_dirs sources
+      += files(d + '/*.c') endforeach
 
-kernel = executable('kernel', sources,
-           include_directories: include_directories('.',
-                                            'src-headers',
-                                            'src-kernel/include',
-                                            'proto',
-                                            'libos/include',
-                                            'libos/capnp'),
-           install: false,
-           c_args: common_cargs)
+      kernel = executable('kernel', sources,
+                          include_directories : include_directories(
+                              '.', 'src-headers', 'src-kernel/include', 'proto',
+                              'libos/include', 'libos/capnp'),
+                          install : false, c_args : common_cargs)
 
-if clang_tidy.found()
-  run_target('clang-tidy', command: [clang_tidy, sources],
-             depends: sources)
-endif
+                   if clang_tidy.found()
+                       run_target('clang-tidy',
+                                  command : [ clang_tidy, sources ],
+                                  depends : sources) endif
 
-qemu = find_program('qemu-system-x86_64', 'qemu-system-i386', 'qemu', required: false)
-if qemu.found()
-  run_target('qemu-nox',
-             command: [qemu, '-nographic', '-serial', 'stdio',
-                       '-kernel', kernel.full_path()],
-             depends: kernel,
-             console: true)
-endif
+               qemu = find_program('qemu-system-x86_64', 'qemu-system-i386',
+                                   'qemu', required : false) if qemu.found()
+                          run_target('qemu-nox',
+                                     command :
+                                     [
+                                       qemu, '-nographic', '-serial', 'stdio',
+                                       '-kernel', kernel.full_path()
+                                     ],
+                                     depends : kernel, console : true) endif
 
-subdir('libnstr_graph')
+                      subdir('libnstr_graph')
 
-# User-space programs
-uprogs = {
-  'cat': 'src-uland/cat.c',
-  'echo': 'src-uland/echo.c',
-  'forktest': 'src-uland/forktest.c',
-  'grep': 'src-uland/grep.c',
-  'init': 'src-uland/init.c',
-  'kill': 'src-uland/kill.c',
-  'ln': 'src-uland/ln.c',
-  'ls': 'src-uland/ls.c',
-  'mkdir': 'src-uland/mkdir.c',
-  'rm': 'src-uland/rm.c',
-  'sh': 'src-uland/sh.c',
-  'stressfs': 'src-uland/stressfs.c',
-  'usertests': 'src-uland/usertests.c',
-  'wc': 'src-uland/wc.c',
-  'zombie': 'src-uland/zombie.c',
-  'phi': 'src-uland/phi.c',
-  'exo_stream_demo': 'src-uland/user/exo_stream_demo.c',
-  'dag_demo': 'src-uland/user/dag_demo.c',
-  'beatty_demo': 'src-uland/user/beatty_demo.c',
-  'beatty_dag_demo': 'src-uland/user/beatty_dag_demo.c',
-  'ipc_test': 'src-uland/ipc_test.c',
-  'nbtest': 'src-uland/nbtest.c',
-  'rcrs': 'src-uland/rcrs.c',
-  'libos_posix_test': 'src-uland/libos_posix_test.c',
-  'libos_posix_extra_test': 'src-uland/user/libos_posix_extra_test.c',
-  'qspin_demo': 'src-uland/user/qspin_demo.c',
-  'tty_demo': 'src-uland/tty_demo.c',
-}
+#User - space programs
+                          uprogs = {
+        'cat' : 'src-uland/cat.c',
+        'echo' : 'src-uland/echo.c',
+        'forktest' : 'src-uland/forktest.c',
+        'grep' : 'src-uland/grep.c',
+        'init' : 'src-uland/init.c',
+        'kill' : 'src-uland/kill.c',
+        'ln' : 'src-uland/ln.c',
+        'ls' : 'src-uland/ls.c',
+        'mkdir' : 'src-uland/mkdir.c',
+        'rm' : 'src-uland/rm.c',
+        'sh' : 'src-uland/sh.c',
+        'stressfs' : 'src-uland/stressfs.c',
+        'usertests' : 'src-uland/usertests.c',
+        'wc' : 'src-uland/wc.c',
+        'zombie' : 'src-uland/zombie.c',
+        'phi' : 'src-uland/phi.c',
+        'exo_stream_demo' : 'src-uland/user/exo_stream_demo.c',
+        'dag_demo' : 'src-uland/user/dag_demo.c',
+        'beatty_demo' : 'src-uland/user/beatty_demo.c',
+        'beatty_dag_demo' : 'src-uland/user/beatty_dag_demo.c',
+        'ipc_test' : 'src-uland/ipc_test.c',
+        'nbtest' : 'src-uland/nbtest.c',
+        'rcrs' : 'src-uland/rcrs.c',
+        'libos_posix_test' : 'src-uland/libos_posix_test.c',
+        'libos_posix_extra_test' : 'src-uland/user/libos_posix_extra_test.c',
+        'qspin_demo' : 'src-uland/user/qspin_demo.c',
+        'tty_demo' : 'src-uland/tty_demo.c',
+        'mq_example' : 'src-uland/mq_example.c',
+        'sem_example' : 'src-uland/sem_example.c',
+        'shm_example' : 'src-uland/shm_example.c',
+      }
 
-if use_capnp
-  uprogs += {
-    'pingdriver': 'src-uland/pingdriver.c',
-    'typed_chan_demo': 'src-uland/user/typed_chan_demo.c',
-    'typed_chan_send': 'src-uland/user/typed_chan_send.c',
-    'typed_chan_recv': 'src-uland/user/typed_chan_recv.c',
-    'affine_channel_demo': 'src-uland/user/affine_channel_demo.c',
-    'chan_dag_supervisor_demo': 'src-uland/user/chan_dag_supervisor_demo.c',
-    'chan_beatty_rcrs_demo': 'src-uland/user/chan_beatty_rcrs_demo.c',
-  }
-endif
+      if use_capnp uprogs
+      += {
+           'pingdriver' : 'src-uland/pingdriver.c',
+           'typed_chan_demo' : 'src-uland/user/typed_chan_demo.c',
+           'typed_chan_send' : 'src-uland/user/typed_chan_send.c',
+           'typed_chan_recv' : 'src-uland/user/typed_chan_recv.c',
+           'affine_channel_demo' : 'src-uland/user/affine_channel_demo.c',
+           'chan_dag_supervisor_demo' :
+               'src-uland/user/chan_dag_supervisor_demo.c',
+           'chan_beatty_rcrs_demo' : 'src-uland/user/chan_beatty_rcrs_demo.c',
+         } endif
 
-uprogs_targets = []
-foreach name, path : uprogs
-  incs = [include_directories('.', 'src-headers', 'proto', 'libos/include')]
-  deps = [libos]
-  if use_capnp
-    incs += include_directories('libos/capnp')
-    deps += libcapnp
-  endif
-  exe = executable('_' + name, path,
-                   include_directories: incs,
-                   link_with: deps,
-                   install: false,
-                   c_args: common_cargs)
-  uprogs_targets += exe
-endforeach
+      uprogs_targets = [] foreach name,
+        path
+    : uprogs incs = [include_directories(
+          '.', 'src-headers', 'proto',
+          'libos/include')] deps = [libos] if use_capnp incs
+      += include_directories('libos/capnp') deps
+      += libcapnp endif exe = executable('_' + name, path,
+                                         include_directories : incs,
+                                         link_with : deps, install : false,
+                                         c_args : common_cargs) uprogs_targets
+      += exe endforeach
 
-# mkfs and filesystem image
-mkfs = executable('mkfs', 'mkfs.c', install: false)
-fsimg = custom_target('fs.img',
-  output: 'fs.img',
-  command: [mkfs, '@OUTPUT@', 'README'] + uprogs_targets,
-  depends: uprogs_targets,
-  build_by_default: true)
+#mkfs and filesystem image
+      mkfs = executable('mkfs', 'mkfs.c', install : false) fsimg =
+          custom_target('fs.img', output : 'fs.img',
+                        command :
+                            [ mkfs, '@OUTPUT@', 'README' ] + uprogs_targets,
+                        depends : uprogs_targets, build_by_default : true)
 
-subdir('tests/microbench')
-subdir('tests/posix')
+              subdir('tests/microbench') subdir('tests/posix')

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -45,3 +45,22 @@ int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
 int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
+
+/* Basic IPC wrappers backed by Phoenix capabilities */
+typedef struct libos_mq *libos_mqd_t;
+libos_mqd_t mq_open(const char *name, int flags);
+int mq_send(libos_mqd_t q, const char *buf, size_t len, unsigned prio);
+int mq_receive(libos_mqd_t q, char *buf, size_t len, unsigned *prio);
+int mq_close(libos_mqd_t q);
+
+typedef struct libos_sem *libos_sem_t;
+libos_sem_t sem_open(const char *name, int flags, unsigned value);
+int sem_wait(libos_sem_t sem);
+int sem_post(libos_sem_t sem);
+int sem_close(libos_sem_t sem);
+
+typedef struct libos_shm *libos_shm_t;
+libos_shm_t shm_open(const char *name, int flags, size_t size);
+void *shm_map(libos_shm_t shm);
+int shm_unmap(libos_shm_t shm);
+int shm_close(libos_shm_t shm);

--- a/src-uland/mq_example.c
+++ b/src-uland/mq_example.c
@@ -1,0 +1,18 @@
+#include "libos/posix.h"
+#include "user.h"
+
+int main(void) {
+  libos_mqd_t q = mq_open("demo", 0);
+  if (!q) {
+    printf(1, "mq_open failed\n");
+    exit();
+  }
+  const char *msg = "ping";
+  mq_send(q, msg, 4, 0);
+  char buf[8];
+  mq_receive(q, buf, sizeof(buf), 0);
+  buf[4] = '\0';
+  printf(1, "mq_demo: %s\n", buf);
+  mq_close(q);
+  exit();
+}

--- a/src-uland/sem_example.c
+++ b/src-uland/sem_example.c
@@ -1,0 +1,15 @@
+#include "libos/posix.h"
+#include "user.h"
+
+int main(void) {
+  libos_sem_t s = sem_open("demo", 0, 1);
+  if (!s) {
+    printf(1, "sem_open failed\n");
+    exit();
+  }
+  sem_wait(s);
+  printf(1, "sem acquired\n");
+  sem_post(s);
+  sem_close(s);
+  exit();
+}

--- a/src-uland/shm_example.c
+++ b/src-uland/shm_example.c
@@ -1,0 +1,17 @@
+#include "libos/posix.h"
+#include "user.h"
+#include <string.h>
+
+int main(void) {
+  libos_shm_t s = shm_open("demo", 0, 128);
+  if (!s) {
+    printf(1, "shm_open failed\n");
+    exit();
+  }
+  char *p = (char *)shm_map(s);
+  strcpy(p, "hello");
+  printf(1, "shm says %s\n", p);
+  shm_unmap(s);
+  shm_close(s);
+  exit();
+}


### PR DESCRIPTION
## Summary
- document additional IPC wrappers
- expose capability-based mq/sem/shm prototypes in the POSIX header
- implement ipc wrappers in a new libos/ipc.c
- add minimal demo programs
- build new demos via meson

## Testing
- `clang-format -i libos/ipc.c src-uland/mq_example.c src-uland/sem_example.c src-uland/shm_example.c src-headers/libos/posix.h doc/posix_compat.md meson.build`
- `scripts/run-clang-tidy.sh --config-file=.clang-tidy libos/ipc.c src-uland/mq_example.c src-uland/sem_example.c src-uland/shm_example.c` *(fails: too many errors)*