### PR TITLE
Add POSIX progress log

### DIFF
--- a/README
+++ b/README
@@ -461,7 +461,7 @@ See doc/phoenixkernel.md for a design overview of the Phoenix exokernel
 and step-by-step examples of capability allocation, typed channels and
 driver management.  The document also outlines the planned BSD and SVR4
 compatibility layers built on top of the libOS.
-For build instructions and an overview of how capabilities provide POSIX semantics see [doc/posix_user_guide.md](doc/posix_user_guide.md).
+For build instructions and an overview of how capabilities provide POSIX semantics see [doc/posix_user_guide.md](doc/posix_user_guide.md).  The implementation status of individual wrappers is tracked in [doc/posix_progress.md](doc/posix_progress.md).
 Additional notes on the current research direction can be found in
 `doc/track_technical.md`, `doc/track_philosophy.md` and
 `doc/track_hybrid.md`. These summaries reference the project charter

--- a/doc/posix_progress.md
+++ b/doc/posix_progress.md
@@ -1,0 +1,45 @@
+# POSIX Interface Progress
+
+This log tracks implementation status of the POSIX wrappers provided by the Phoenix libOS.  Mark each interface as **Implemented**, **Stubbed**, or **Missing**.  Update the table whenever a new wrapper is merged.
+
+| Interface | Status |
+|-----------|--------|
+| `libos_open` | Implemented |
+| `libos_read` | Implemented |
+| `libos_write` | Implemented |
+| `libos_close` | Implemented |
+| `libos_spawn` | Implemented |
+| `libos_execve` | Implemented |
+| `libos_mkdir` | Implemented |
+| `libos_rmdir` | Implemented |
+| `libos_signal` | Implemented |
+| `libos_dup` | Implemented |
+| `libos_pipe` | Implemented |
+| `libos_fork` | Implemented |
+| `libos_waitpid` | Implemented |
+| `libos_sigsend` | Implemented |
+| `libos_sigcheck` | Implemented |
+| `libos_stat` | Implemented |
+| `libos_lseek` | Implemented |
+| `libos_ftruncate` | Stubbed |
+| `libos_mmap` | Stubbed |
+| `libos_munmap` | Stubbed |
+| `libos_sigemptyset` | Implemented |
+| `libos_sigfillset` | Implemented |
+| `libos_sigaddset` | Implemented |
+| `libos_sigdelset` | Implemented |
+| `libos_sigismember` | Implemented |
+| `libos_getpgrp` | Implemented |
+| `libos_setpgid` | Implemented |
+| `libos_socket` | Implemented |
+| `libos_bind` | Implemented |
+| `libos_listen` | Implemented |
+| `libos_accept` | Implemented |
+| `libos_connect` | Implemented |
+| `libos_send` | Implemented |
+| `libos_recv` | Implemented |
+| `libos_rename` | Missing |
+| `libos_unlink` | Missing |
+| `libos_chdir` | Missing |
+| `libos_getcwd` | Missing |
+


### PR DESCRIPTION
## Summary
- document implementation status of libOS POSIX wrappers
- link the new progress log from the README

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*