### PR TITLE
Ensure Meson available in Codex setup

### DIFF
--- a/.codex/setup
+++ b/.codex/setup
@@ -7,3 +7,14 @@ mkdir -p "$LOG_DIR"
 exec > >(tee -a "$LOG_FILE") 2>&1
 
 "$(dirname "$0")/../setup.sh"
+
+# Ensure meson and its related build tools are available
+if ! command -v meson >/dev/null 2>&1; then
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update -y || true
+    sudo apt-get install -y meson ninja-build || true
+  fi
+  if ! command -v meson >/dev/null 2>&1; then
+    pip3 install --no-cache-dir meson || true
+  fi
+fi


### PR DESCRIPTION
## Summary
- extend `.codex/setup` to install `meson` and `ninja-build` if missing

## Testing
- `pytest -q` *(fails: CalledProcessError)*