### PR TITLE
Add additional POSIX wrappers

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -1,4 +1,4 @@
-# POSIX Compatibility Layer
+#POSIX Compatibility Layer
 
 Phoenix exposes capabilities for blocks, pages and IPC endpoints.
 The libOS translates these primitives into familiar POSIX file and
@@ -19,22 +19,38 @@ the host socket APIs.
 | Signal set operations | `libos_sig*set()` manipulate a bitmask type. |
 | Process groups | Forward to the host's `getpgrp()` and `setpgid()` calls. |
 | Socket APIs | Thin wrappers around standard Berkeley sockets. |
+| `libos_sigaction` | Stores handlers in a table;
+mask and flags are ignored.| | `libos_sigprocmask` |
+    Maintains a simple process - local mask.| | `libos_killpg` |
+    Forwards the signal to `sigsend` using the group as a PID.|
+    | `libos_execve` | Accepts an `envp` array but ignores it.|
+    | `libos_waitpid` | Provides the standard signature;
+only the PID is returned.|
 
+        These wrappers mirror the POSIX names where possible but
+                are not fully featured
+                    .They exist so portability layers can build against Phoenix
+                        without pulling in a real C library.
 
-These wrappers mirror the POSIX names where possible but are not fully
-featured.  They exist so portability layers can build against Phoenix
-without pulling in a real C library.
+            ##Environment Variables
 
-## Environment Variables
+`libos_setenv()` stores a key /
+            value pair in a small internal table.
+`libos_getenv()` retrieves the value or
+    returns `NULL` if the variable is unknown
+            .Variables are not inherited across spawned processes
+            .
 
-`libos_setenv()` stores a key/value pair in a small internal table.
-`libos_getenv()` retrieves the value or returns `NULL` if the variable is
-unknown.  Variables are not inherited across spawned processes.
+        ##Locale Stubs
 
-## Locale Stubs
-
-Only stub implementations of the standard locale interfaces are
-available.  Functions like `setlocale()` and `localeconv()` accept any
-input but always behave as if the `"C"` locale is active.  The stubs
-exist so that third-party code expecting these calls can link against the
-libOS without pulling in a full C library.
+            Only stub implementations of the standard locale interfaces are
+                available
+            .Functions
+                like `setlocale()` and `localeconv()` accept any input but
+                                               always behave
+                                                   as if the `"C"` locale is
+                                                       active.The stubs exist so
+                                                           that third -
+                                           party code expecting these calls can
+                                               link against the libOS without
+                                                   pulling in a full C library.

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -17,248 +17,307 @@ static struct file **fd_table;
 static int fd_table_cap = 0;
 
 static void ensure_fd_table(void) {
-    if(!fd_table) {
-        fd_table_cap = LIBOS_INITFD;
-        fd_table = calloc(fd_table_cap, sizeof(struct file *));
-    }
+  if (!fd_table) {
+    fd_table_cap = LIBOS_INITFD;
+    fd_table = calloc(fd_table_cap, sizeof(struct file *));
+  }
 }
 static void (*sig_handlers[32])(int);
 
 int libos_open(const char *path, int flags, int mode) {
-    (void)mode; /* mode ignored by simple filesystem */
-    ensure_fd_table();
-    struct file *f = libfs_open(path, flags);
-    if(!f)
-        return -1;
-    if(flags & O_TRUNC){
-        char zero[BSIZE] = {0};
-        fs_write_block(f->cap, zero);
-        f->off = 0;
+  (void)mode; /* mode ignored by simple filesystem */
+  ensure_fd_table();
+  struct file *f = libfs_open(path, flags);
+  if (!f)
+    return -1;
+  if (flags & O_TRUNC) {
+    char zero[BSIZE] = {0};
+    fs_write_block(f->cap, zero);
+    f->off = 0;
+  }
+  if (flags & O_APPEND) {
+    struct stat st;
+    if (filestat(f, &st) == 0)
+      f->off = st.size;
+  }
+  for (int i = 0; i < fd_table_cap; i++) {
+    if (!fd_table[i]) {
+      fd_table[i] = f;
+      return i;
     }
-    if(flags & O_APPEND){
-        struct stat st;
-        if(filestat(f, &st) == 0)
-            f->off = st.size;
-    }
-    for(int i = 0; i < fd_table_cap; i++) {
-        if(!fd_table[i]) {
-            fd_table[i] = f;
-            return i;
-        }
-    }
-    int new_cap = fd_table_cap * 2;
-    struct file **nt = realloc(fd_table, new_cap * sizeof(struct file*));
-    if(!nt){
-        fileclose(f);
-        return -1;
-    }
-    memset(nt + fd_table_cap, 0, (new_cap - fd_table_cap) * sizeof(struct file*));
-    fd_table = nt;
-    int idx = fd_table_cap;
-    fd_table_cap = new_cap;
-    fd_table[idx] = f;
-    return idx;
+  }
+  int new_cap = fd_table_cap * 2;
+  struct file **nt = realloc(fd_table, new_cap * sizeof(struct file *));
+  if (!nt) {
+    fileclose(f);
+    return -1;
+  }
+  memset(nt + fd_table_cap, 0,
+         (new_cap - fd_table_cap) * sizeof(struct file *));
+  fd_table = nt;
+  int idx = fd_table_cap;
+  fd_table_cap = new_cap;
+  fd_table[idx] = f;
+  return idx;
 }
 
 int libos_read(int fd, void *buf, size_t n) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    return libfs_read(fd_table[fd], buf, n);
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
+    return -1;
+  return libfs_read(fd_table[fd], buf, n);
 }
 
 int libos_write(int fd, const void *buf, size_t n) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    return libfs_write(fd_table[fd], buf, n);
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
+    return -1;
+  return libfs_write(fd_table[fd], buf, n);
 }
 
 int libos_close(int fd) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    libfs_close(fd_table[fd]);
-    fd_table[fd] = 0;
-    return 0;
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
+    return -1;
+  libfs_close(fd_table[fd]);
+  fd_table[fd] = 0;
+  return 0;
 }
 
 int libos_spawn(const char *path, char *const argv[]) {
-    int pid = fork();
-    if(pid == 0) {
-        exec((char *)path, (char **)argv);
-        exit();
-    }
-    return pid;
+  int pid = fork();
+  if (pid == 0) {
+    exec((char *)path, (char **)argv);
+    exit();
+  }
+  return pid;
 }
 
-int libos_execve(const char *path, char *const argv[]) {
-    return exec((char *)path, (char **)argv);
+int libos_execve(const char *path, char *const argv[], char *const envp[]) {
+  (void)envp;
+  return exec((char *)path, (char **)argv);
 }
 
-int libos_mkdir(const char *path) {
-    return mkdir((char *)path);
-}
+int libos_mkdir(const char *path) { return mkdir((char *)path); }
 
-int libos_rmdir(const char *path) {
-    return unlink((char *)path);
-}
+int libos_rmdir(const char *path) { return unlink((char *)path); }
 
 int libos_dup(int fd) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    struct file *f = filedup(fd_table[fd]);
-    for(int i = 0; i < fd_table_cap; i++) {
-        if(!fd_table[i]) {
-            fd_table[i] = f;
-            return i;
-        }
-    }
-    int new_cap = fd_table_cap * 2;
-    struct file **nt = realloc(fd_table, new_cap * sizeof(struct file*));
-    if(!nt){
-        fileclose(f);
-        return -1;
-    }
-    memset(nt + fd_table_cap, 0, (new_cap - fd_table_cap) * sizeof(struct file*));
-    fd_table = nt;
-    int idx = fd_table_cap;
-    fd_table_cap = new_cap;
-    fd_table[idx] = f;
-    return idx;
-}
-
-int libos_pipe(int fd[2]) {
-    return pipe(fd);
-}
-
-int libos_fork(void) {
-    return fork();
-}
-
-int libos_waitpid(int pid) {
-    int w;
-    while((w = wait()) >= 0) {
-        if(w == pid)
-            return w;
-    }
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
     return -1;
+  struct file *f = filedup(fd_table[fd]);
+  for (int i = 0; i < fd_table_cap; i++) {
+    if (!fd_table[i]) {
+      fd_table[i] = f;
+      return i;
+    }
+  }
+  int new_cap = fd_table_cap * 2;
+  struct file **nt = realloc(fd_table, new_cap * sizeof(struct file *));
+  if (!nt) {
+    fileclose(f);
+    return -1;
+  }
+  memset(nt + fd_table_cap, 0,
+         (new_cap - fd_table_cap) * sizeof(struct file *));
+  fd_table = nt;
+  int idx = fd_table_cap;
+  fd_table_cap = new_cap;
+  fd_table[idx] = f;
+  return idx;
 }
 
-int libos_sigsend(int pid, int sig) {
-    return sigsend(pid, sig);
+int libos_pipe(int fd[2]) { return pipe(fd); }
+
+int libos_fork(void) { return fork(); }
+
+int libos_waitpid(int pid, int *status, int flags) {
+  (void)flags;
+  int w;
+  if (pid == -1) {
+    w = wait();
+    if (w >= 0 && status)
+      *status = 0;
+    return w;
+  }
+  while ((w = wait()) >= 0) {
+    if (w == pid) {
+      if (status)
+        *status = 0;
+      return w;
+    }
+  }
+  return -1;
 }
+
+int libos_sigsend(int pid, int sig) { return sigsend(pid, sig); }
 
 int libos_sigcheck(void) {
-    int pending = sigcheck();
-    for(int s = 0; s < 32; s++) {
-        if((pending & (1<<s)) && sig_handlers[s])
-            sig_handlers[s](s);
-    }
-    return pending;
+  int pending = sigcheck();
+  for (int s = 0; s < 32; s++) {
+    if ((pending & (1 << s)) && sig_handlers[s])
+      sig_handlers[s](s);
+  }
+  return pending;
 }
 
 int libos_signal(int sig, void (*handler)(int)) {
-    if(sig < 0 || sig >= 32)
-        return -1;
-    sig_handlers[sig] = handler;
-    return 0;
+  if (sig < 0 || sig >= 32)
+    return -1;
+  sig_handlers[sig] = handler;
+  return 0;
 }
 
+int libos_sigaction(int sig, const struct sigaction *act,
+                    struct sigaction *oact) {
+  if (sig < 0 || sig >= 32)
+    return -1;
+  if (oact) {
+    memset(oact, 0, sizeof(*oact));
+    oact->sa_handler = sig_handlers[sig];
+  }
+  if (act)
+    sig_handlers[sig] = act->sa_handler;
+  return 0;
+}
+
+int libos_sigprocmask(int how, const libos_sigset_t *set, libos_sigset_t *old) {
+  static libos_sigset_t cur;
+  if (old)
+    *old = cur;
+  if (!set)
+    return 0;
+  switch (how) {
+  case 0: /* SIG_BLOCK */
+    cur |= *set;
+    break;
+  case 1: /* SIG_UNBLOCK */
+    cur &= ~(*set);
+    break;
+  case 2: /* SIG_SETMASK */
+    cur = *set;
+    break;
+  default:
+    return -1;
+  }
+  return 0;
+}
+
+int libos_killpg(int pgrp, int sig) { return sigsend(pgrp, sig); }
+
 int libos_stat(const char *path, struct stat *st) {
-    struct file *f = libfs_open(path, 0);
-    if(!f)
-        return -1;
-    int r = filestat(f, st);
-    libfs_close(f);
-    return r;
+  struct file *f = libfs_open(path, 0);
+  if (!f)
+    return -1;
+  int r = filestat(f, st);
+  libfs_close(f);
+  return r;
 }
 
 long libos_lseek(int fd, long off, int whence) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    struct file *f = fd_table[fd];
-    switch(whence){
-    case 0: /* SEEK_SET */
-        f->off = off;
-        break;
-    case 1: /* SEEK_CUR */
-        f->off += off;
-        break;
-    case 2: {
-        struct stat st;
-        if(filestat(f, &st) < 0)
-            return -1;
-        f->off = st.size + off;
-        break;
-    }
-    default:
-        return -1;
-    }
-    return f->off;
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
+    return -1;
+  struct file *f = fd_table[fd];
+  switch (whence) {
+  case 0: /* SEEK_SET */
+    f->off = off;
+    break;
+  case 1: /* SEEK_CUR */
+    f->off += off;
+    break;
+  case 2: {
+    struct stat st;
+    if (filestat(f, &st) < 0)
+      return -1;
+    f->off = st.size + off;
+    break;
+  }
+  default:
+    return -1;
+  }
+  return f->off;
 }
 
 int libos_ftruncate(int fd, long length) {
-    ensure_fd_table();
-    if(fd < 0 || fd >= fd_table_cap || !fd_table[fd])
-        return -1;
-    (void)length;
-    /* The simple in-memory filesystem ignores size changes. */
-    return 0;
+  ensure_fd_table();
+  if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])
+    return -1;
+  (void)length;
+  /* The simple in-memory filesystem ignores size changes. */
+  return 0;
 }
 
-void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off) {
-    (void)addr; (void)prot; (void)flags; (void)fd; (void)off;
-    void *p = malloc(len);
-    return p ? p : (void*)-1;
+void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                 long off) {
+  (void)addr;
+  (void)prot;
+  (void)flags;
+  (void)fd;
+  (void)off;
+  void *p = malloc(len);
+  return p ? p : (void *)-1;
 }
 
 int libos_munmap(void *addr, size_t len) {
-    (void)len;
-    free(addr);
+  (void)len;
+  free(addr);
+  return 0;
+}
+
+int libos_sigemptyset(libos_sigset_t *set) {
+  *set = 0;
+  return 0;
+}
+int libos_sigfillset(libos_sigset_t *set) {
+  *set = ~0UL;
+  return 0;
+}
+int libos_sigaddset(libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
+    return -1;
+  *set |= (1UL << sig);
+  return 0;
+}
+int libos_sigdelset(libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
+    return -1;
+  *set &= ~(1UL << sig);
+  return 0;
+}
+int libos_sigismember(const libos_sigset_t *set, int sig) {
+  if (sig < 0 || sig >= 32)
     return 0;
+  return (*set & (1UL << sig)) != 0;
 }
 
-int libos_sigemptyset(libos_sigset_t *set){ *set = 0; return 0; }
-int libos_sigfillset(libos_sigset_t *set){ *set = ~0UL; return 0; }
-int libos_sigaddset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; *set |= (1UL<<sig); return 0; }
-int libos_sigdelset(libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return -1; *set &= ~(1UL<<sig); return 0; }
-int libos_sigismember(const libos_sigset_t *set,int sig){ if(sig<0||sig>=32) return 0; return (*set & (1UL<<sig))!=0; }
+int libos_getpgrp(void) { return (int)getpgrp(); }
 
-int libos_getpgrp(void){
-    return (int)getpgrp();
+int libos_setpgid(int pid, int pgid) { return setpgid(pid, pgid); }
+
+int libos_socket(int domain, int type, int protocol) {
+  return socket(domain, type, protocol);
 }
 
-int libos_setpgid(int pid, int pgid){
-    return setpgid(pid, pgid);
+int libos_bind(int fd, const struct sockaddr *addr, socklen_t len) {
+  return bind(fd, addr, len);
 }
 
-int libos_socket(int domain, int type, int protocol){
-    return socket(domain, type, protocol);
+int libos_listen(int fd, int backlog) { return listen(fd, backlog); }
+
+int libos_accept(int fd, struct sockaddr *addr, socklen_t *len) {
+  return accept(fd, addr, len);
 }
 
-int libos_bind(int fd,const struct sockaddr *addr,socklen_t len){
-    return bind(fd, addr, len);
+int libos_connect(int fd, const struct sockaddr *addr, socklen_t len) {
+  return connect(fd, addr, len);
 }
 
-int libos_listen(int fd,int backlog){
-    return listen(fd, backlog);
+long libos_send(int fd, const void *buf, size_t len, int flags) {
+  return send(fd, buf, len, flags);
 }
 
-int libos_accept(int fd,struct sockaddr *addr,socklen_t *len){
-    return accept(fd, addr, len);
-}
-
-int libos_connect(int fd,const struct sockaddr *addr,socklen_t len){
-    return connect(fd, addr, len);
-}
-
-long libos_send(int fd,const void *buf,size_t len,int flags){
-    return send(fd, buf, len, flags);
-}
-
-long libos_recv(int fd,void *buf,size_t len,int flags){
-    return recv(fd, buf, len, flags);
+long libos_recv(int fd, void *buf, size_t len, int flags) {
+  return recv(fd, buf, len, flags);
 }

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -6,20 +6,25 @@ int libos_read(int fd, void *buf, size_t n);
 int libos_write(int fd, const void *buf, size_t n);
 int libos_close(int fd);
 int libos_spawn(const char *path, char *const argv[]);
-int libos_execve(const char *path, char *const argv[]);
+int libos_execve(const char *path, char *const argv[], char *const envp[]);
 int libos_mkdir(const char *path);
 int libos_rmdir(const char *path);
 int libos_signal(int sig, void (*handler)(int));
 int libos_dup(int fd);
 int libos_pipe(int fd[2]);
 int libos_fork(void);
-int libos_waitpid(int pid);
+int libos_waitpid(int pid, int *status, int flags);
 int libos_sigsend(int pid, int sig);
 int libos_sigcheck(void);
+struct sigaction;
+int libos_sigaction(int sig, const struct sigaction *act,
+                    struct sigaction *oact);
+typedef unsigned long libos_sigset_t;
+int libos_sigprocmask(int how, const libos_sigset_t *set, libos_sigset_t *old);
+int libos_killpg(int pgrp, int sig);
 
 /* Additional POSIX helpers */
 struct stat;
-typedef unsigned long libos_sigset_t;
 
 int libos_stat(const char *path, struct stat *st);
 long libos_lseek(int fd, long off, int whence);

--- a/src-uland/posix_pipe_test.c
+++ b/src-uland/posix_pipe_test.c
@@ -6,26 +6,43 @@
 
 int libos_pipe(int fd[2]) { return pipe(fd); }
 int libos_fork(void) { return fork(); }
-int libos_waitpid(int pid) { int st; return waitpid(pid, &st, 0); }
+int libos_waitpid(int pid, int *st, int flags) {
+  return waitpid(pid, st, flags);
+}
 int libos_close(int fd) { return close(fd); }
 int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
-int libos_write(int fd, const void *buf, size_t n) { return (int)write(fd, buf, n); }
+int libos_write(int fd, const void *buf, size_t n) {
+  return (int)write(fd, buf, n);
+}
+int libos_spawn(const char *path, char *const argv[]) {
+  int pid = fork();
+  if (pid == 0) {
+    execv(path, argv);
+    _exit(1);
+  }
+  return pid;
+}
 
 int main(void) {
-    int p[2];
-    assert(libos_pipe(p) == 0);
-    int pid = libos_fork();
-    if (pid == 0) {
-        libos_close(p[1]);
-        char buf[6];
-        int n = libos_read(p[0], buf, sizeof(buf) - 1);
-        buf[n] = '\0';
-        assert(strcmp(buf, "hello") == 0);
-        _exit(0);
-    }
-    libos_close(p[0]);
-    assert(libos_write(p[1], "hello", 5) == 5);
+  int p[2];
+  assert(libos_pipe(p) == 0);
+  int pid = libos_fork();
+  if (pid == 0) {
     libos_close(p[1]);
-    libos_waitpid(pid);
-    return 0;
+    char buf[6];
+    int n = libos_read(p[0], buf, sizeof(buf) - 1);
+    buf[n] = '\0';
+    assert(strcmp(buf, "hello") == 0);
+    _exit(0);
+  }
+  libos_close(p[0]);
+  assert(libos_write(p[1], "hello", 5) == 5);
+  libos_close(p[1]);
+  int st;
+  libos_waitpid(pid, &st, 0);
+
+  char *args[] = {"/bin/true", NULL};
+  int sp = libos_spawn("/bin/true", args);
+  libos_waitpid(sp, &st, 0);
+  return 0;
 }

--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -7,36 +7,50 @@
 #include <string.h>
 #include "libos/posix.h"
 
-int libos_open(const char *path, int flags){ return open(path, flags | O_CREAT, 0600); }
-int libos_close(int fd){ return close(fd); }
-int libos_ftruncate(int fd,long length){ return ftruncate(fd, length); }
-void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){ return mmap(addr,len,prot,flags,fd,off); }
-int libos_munmap(void *addr,size_t len){ return munmap(addr,len); }
-int libos_getpgrp(void){ return (int)getpgrp(); }
-int libos_setpgid(int pid,int pgid){ return setpgid(pid, pgid); }
-int libos_sigemptyset(libos_sigset_t *set){ *set=0; return 0; }
-int libos_sigaddset(libos_sigset_t *set,int sig){ *set |= 1UL<<sig; return 0; }
-int libos_sigismember(const libos_sigset_t *set,int sig){ return (*set & (1UL<<sig)) != 0; }
+int libos_open(const char *path, int flags, int mode) {
+  return open(path, flags | O_CREAT, mode);
+}
+int libos_close(int fd) { return close(fd); }
+int libos_ftruncate(int fd, long length) { return ftruncate(fd, length); }
+void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd,
+                 long off) {
+  return mmap(addr, len, prot, flags, fd, off);
+}
+int libos_munmap(void *addr, size_t len) { return munmap(addr, len); }
+int libos_getpgrp(void) { return (int)getpgrp(); }
+int libos_setpgid(int pid, int pgid) { return setpgid(pid, pgid); }
+int libos_sigemptyset(libos_sigset_t *set) {
+  *set = 0;
+  return 0;
+}
+int libos_sigaddset(libos_sigset_t *set, int sig) {
+  *set |= 1UL << sig;
+  return 0;
+}
+int libos_sigismember(const libos_sigset_t *set, int sig) {
+  return (*set & (1UL << sig)) != 0;
+}
 
-int main(void){
-    int fd = libos_open("misc.tmp", O_RDWR);
-    assert(fd >= 0);
-    assert(libos_ftruncate(fd, 1024) == 0);
-    assert(libos_ftruncate(-1, 1) == -1);
-    assert(libos_close(fd) == 0);
-    unlink("misc.tmp");
+int main(void) {
+  int fd = libos_open("misc.tmp", O_RDWR, 0600);
+  assert(fd >= 0);
+  assert(libos_ftruncate(fd, 1024) == 0);
+  assert(libos_ftruncate(-1, 1) == -1);
+  assert(libos_close(fd) == 0);
+  unlink("misc.tmp");
 
-    void *p = libos_mmap(0, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
-    assert(p != MAP_FAILED);
-    strcpy(p, "ok");
-    assert(libos_munmap(p, 4096) == 0);
+  void *p = libos_mmap(0, 4096, PROT_READ | PROT_WRITE,
+                       MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  assert(p != MAP_FAILED);
+  strcpy(p, "ok");
+  assert(libos_munmap(p, 4096) == 0);
 
-    int pg = libos_getpgrp();
-    assert(libos_setpgid(0, pg) == 0);
+  int pg = libos_getpgrp();
+  assert(libos_setpgid(0, pg) == 0);
 
-    libos_sigset_t ss;
-    libos_sigemptyset(&ss);
-    libos_sigaddset(&ss, SIGUSR1);
-    assert(libos_sigismember(&ss, SIGUSR1));
-    return 0;
+  libos_sigset_t ss;
+  libos_sigemptyset(&ss);
+  libos_sigaddset(&ss, SIGUSR1);
+  assert(libos_sigismember(&ss, SIGUSR1));
+  return 0;
 }


### PR DESCRIPTION
## Summary
- expand libOS POSIX wrappers with `sigaction`, `sigprocmask`, `killpg`
- extend `execve` and `waitpid` prototypes
- update pipe test for new signature and demo spawn/wait
- document the new APIs

## Testing
- `pytest -q tests/test_posix_apis.py`