### PR TITLE
Add FIFO support with mkfifo and tests

### DIFF
--- a/libos/fs_ufs.c
+++ b/libos/fs_ufs.c
@@ -1,13 +1,16 @@
 #include "libfs.h"
 #include "string.h"
 #include "stdlib.h"
+#include "file.h"
 
 #define MAX_VFILES 16
 
 struct vfile {
     char path[32];
     int used;
+    int type; /* 0=file, 1=fifo */
     struct exo_blockcap cap;
+    struct fifo *fifo;
 };
 
 static struct vfile vfiles[MAX_VFILES];
@@ -27,6 +30,30 @@ static struct vfile *create_vfile(const char *path) {
             strncpy(vfiles[i].path, path, sizeof(vfiles[i].path)-1);
             vfiles[i].path[sizeof(vfiles[i].path)-1] = '\0';
             vfiles[i].used = 1;
+            vfiles[i].type = 0;
+            vfiles[i].fifo = 0;
+            return &vfiles[i];
+        }
+    }
+    return 0;
+}
+
+static struct vfile *create_fifo(const char *path) {
+    for(int i=0;i<MAX_VFILES;i++) {
+        if(!vfiles[i].used) {
+            struct fifo *q = malloc(sizeof(struct fifo));
+            if(!q)
+                return 0;
+            if(fs_alloc_block(1, EXO_RIGHT_R|EXO_RIGHT_W, &q->cap) < 0){
+                free(q);
+                return 0;
+            }
+            q->rpos = q->wpos = 0;
+            strncpy(vfiles[i].path, path, sizeof(vfiles[i].path)-1);
+            vfiles[i].path[sizeof(vfiles[i].path)-1] = '\0';
+            vfiles[i].used = 1;
+            vfiles[i].type = 1;
+            vfiles[i].fifo = q;
             return &vfiles[i];
         }
     }
@@ -35,6 +62,13 @@ static struct vfile *create_vfile(const char *path) {
 
 void libfs_init(void) {
     memset(vfiles, 0, sizeof(vfiles));
+}
+
+int libfs_mkfifo(const char *path, int mode){
+    (void)mode;
+    if(lookup_vfile(path))
+        return -1;
+    return create_fifo(path) ? 0 : -1;
 }
 
 struct file *libfs_open(const char *path, int flags) {
@@ -47,10 +81,16 @@ struct file *libfs_open(const char *path, int flags) {
     struct file *f = filealloc();
     if(!f)
         return 0;
-    f->cap = vf->cap;
     f->readable = 1;
     f->writable = 1;
-    f->off = 0;
+    if(vf->type == 1){
+        f->type = FD_FIFO;
+        f->fifo = vf->fifo;
+    } else {
+        f->type = FD_CAP;
+        f->cap = vf->cap;
+        f->off = 0;
+    }
     return f;
 }
 

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -100,6 +100,11 @@ int libos_mkdir(const char *path) {
     return mkdir((char *)path);
 }
 
+int libos_mkfifo(const char *path, int mode){
+    (void)mode;
+    return libfs_mkfifo(path, mode);
+}
+
 int libos_rmdir(const char *path) {
     return unlink((char *)path);
 }

--- a/src-headers/libos/file.h
+++ b/src-headers/libos/file.h
@@ -2,12 +2,20 @@
 
 #include "include/exokernel.h"
 
+struct fifo {
+  char data[512];
+  size_t rpos;
+  size_t wpos;
+  struct exo_blockcap cap;
+};
+
 struct file {
-  enum { FD_NONE, FD_CAP } type;
+  enum { FD_NONE, FD_CAP, FD_FIFO } type;
   size_t ref; // reference count
   char readable;
   char writable;
-  struct exo_blockcap cap; // backing storage capability
+  struct exo_blockcap cap; // backing storage capability for regular files
+  struct fifo *fifo;        // for FIFO files
   size_t off;
 };
 

--- a/src-headers/libos/libfs.h
+++ b/src-headers/libos/libfs.h
@@ -8,6 +8,7 @@ int fs_write_block(struct exo_blockcap cap, const void *src);
 int fs_alloc_block(uint32_t dev, uint32_t rights, struct exo_blockcap *cap);
 int fs_bind_block(struct exo_blockcap *cap, void *data, int write);
 void libfs_init(void);
+int libfs_mkfifo(const char *path, int mode);
 struct file *libfs_open(const char *path, int flags);
 int libfs_read(struct file *f, void *buf, size_t n);
 int libfs_write(struct file *f, const void *buf, size_t n);

--- a/src-uland/user/fifo_test.c
+++ b/src-uland/user/fifo_test.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include "libos/posix.h"
+
+int libos_mkfifo(const char *path, int mode){ return mkfifo(path, mode); }
+int libos_open(const char *p, int f, int m){ return open(p,f,m); }
+int libos_read(int fd, void *b, size_t n){ return (int)read(fd,b,n); }
+int libos_write(int fd, const void *b, size_t n){ return (int)write(fd,b,n); }
+int libos_close(int fd){ return close(fd); }
+int libos_fork(void){ return fork(); }
+int libos_waitpid(int pid){ int st; return waitpid(pid,&st,0); }
+
+int main(void){
+    const char *path = "testfifo";
+    unlink(path);
+    assert(libos_mkfifo(path, 0600) == 0);
+    int pid = libos_fork();
+    if(pid==0){
+        int fd = libos_open(path, O_RDONLY, 0);
+        char buf[6];
+        int n = libos_read(fd, buf, sizeof(buf)-1);
+        buf[n] = '\0';
+        assert(strcmp(buf,"hello") == 0);
+        _exit(0);
+    }
+    int fd = libos_open(path, O_WRONLY, 0);
+    assert(libos_write(fd, "hello", 5) == 5);
+    libos_close(fd);
+    libos_waitpid(pid);
+    return 0;
+}
+

--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include "libos/posix.h"
 
-int libos_open(const char *path, int flags){ return open(path, flags | O_CREAT, 0600); }
+int libos_open(const char *path, int flags, int mode){ (void)mode; return open(path, flags | O_CREAT, 0600); }
 int libos_close(int fd){ return close(fd); }
 int libos_ftruncate(int fd,long length){ return ftruncate(fd, length); }
 void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){ return mmap(addr,len,prot,flags,fd,off); }
@@ -19,7 +19,7 @@ int libos_sigaddset(libos_sigset_t *set,int sig){ *set |= 1UL<<sig; return 0; }
 int libos_sigismember(const libos_sigset_t *set,int sig){ return (*set & (1UL<<sig)) != 0; }
 
 int main(void){
-    int fd = libos_open("misc.tmp", O_RDWR);
+    int fd = libos_open("misc.tmp", O_RDWR, 0600);
     assert(fd >= 0);
     assert(libos_ftruncate(fd, 1024) == 0);
     assert(libos_ftruncate(-1, 1) == -1);

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -2,7 +2,8 @@ posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
                     '../../src-uland/posix_pipe_test.c',
                     '../../src-uland/user/posix_misc_test.c',
-                    '../../src-uland/user/posix_socket_test.c')
+                    '../../src-uland/user/posix_socket_test.c',
+                    '../../src-uland/user/fifo_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -10,6 +10,7 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_pipe_test.c',
     ROOT / 'src-uland/user/posix_misc_test.c',
     ROOT / 'src-uland/user/posix_socket_test.c',
+    ROOT / 'src-uland/user/fifo_test.c',
 ]
 
 
@@ -43,3 +44,7 @@ def test_posix_misc_ops():
 
 def test_posix_socket_ops():
     compile_and_run(SRC_FILES[4])
+
+
+def test_fifo_ops():
+    compile_and_run(SRC_FILES[5])


### PR DESCRIPTION
## Summary
- extend user-space filesystem with FIFO nodes
- support FIFO descriptors in libos
- add libos_mkfifo interface
- add fifo_test user program and integrate with posix tests
- fix posix_misc_test prototype

## Testing
- `pytest -k posix_apis -q`