### PR TITLE
Implement socket option helpers

### DIFF
--- a/libos/inet.c
+++ b/libos/inet.c
@@ -1,0 +1,10 @@
+#include "libos/posix.h"
+#include <arpa/inet.h>
+
+int libos_inet_aton(const char *cp, struct in_addr *addr){
+    return inet_aton(cp, addr);
+}
+
+const char *libos_inet_ntoa(struct in_addr addr){
+    return inet_ntoa(addr);
+}

--- a/libos/posix.c
+++ b/libos/posix.c
@@ -262,3 +262,11 @@ long libos_send(int fd,const void *buf,size_t len,int flags){
 long libos_recv(int fd,void *buf,size_t len,int flags){
     return recv(fd, buf, len, flags);
 }
+
+int libos_getsockopt(int fd,int level,int optname,void *optval,socklen_t *optlen){
+    return getsockopt(fd, level, optname, optval, optlen);
+}
+
+int libos_setsockopt(int fd,int level,int optname,const void *optval,socklen_t optlen){
+    return setsockopt(fd, level, optname, optval, optlen);
+}

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -45,6 +45,12 @@ int libos_accept(int fd, struct sockaddr *addr, socklen_t *len);
 int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
+int libos_getsockopt(int fd, int level, int optname, void *optval, socklen_t *optlen);
+int libos_setsockopt(int fd, int level, int optname, const void *optval, socklen_t optlen);
+
+struct in_addr;
+int libos_inet_aton(const char *cp, struct in_addr *addr);
+const char *libos_inet_ntoa(struct in_addr addr);
 
 int libos_setenv(const char *name, const char *value);
 const char *libos_getenv(const char *name);

--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -7,7 +7,7 @@
 #include <string.h>
 #include "libos/posix.h"
 
-int libos_open(const char *path, int flags){ return open(path, flags | O_CREAT, 0600); }
+int libos_open(const char *path, int flags, int mode){ (void)mode; return open(path, flags | O_CREAT, 0600); }
 int libos_close(int fd){ return close(fd); }
 int libos_ftruncate(int fd,long length){ return ftruncate(fd, length); }
 void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){ return mmap(addr,len,prot,flags,fd,off); }
@@ -19,7 +19,7 @@ int libos_sigaddset(libos_sigset_t *set,int sig){ *set |= 1UL<<sig; return 0; }
 int libos_sigismember(const libos_sigset_t *set,int sig){ return (*set & (1UL<<sig)) != 0; }
 
 int main(void){
-    int fd = libos_open("misc.tmp", O_RDWR);
+int fd = libos_open("misc.tmp", O_RDWR, 0600);
     assert(fd >= 0);
     assert(libos_ftruncate(fd, 1024) == 0);
     assert(libos_ftruncate(-1, 1) == -1);

--- a/src-uland/user/posix_sockopt_test.c
+++ b/src-uland/user/posix_sockopt_test.c
@@ -1,0 +1,38 @@
+#define _DEFAULT_SOURCE
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "libos/posix.h"
+
+int libos_setsockopt(int fd,int level,int optname,const void *val,socklen_t len){
+    return setsockopt(fd, level, optname, val, len);
+}
+int libos_getsockopt(int fd,int level,int optname,void *val,socklen_t *len){
+    return getsockopt(fd, level, optname, val, len);
+}
+int libos_inet_aton(const char *cp, struct in_addr *addr){ return inet_aton(cp, addr); }
+const char *libos_inet_ntoa(struct in_addr a){ return inet_ntoa(a); }
+int libos_socket(int d,int t,int p){ return socket(d,t,p); }
+int libos_close(int fd){ return close(fd); }
+
+int main(void){
+    int s = libos_socket(AF_INET, SOCK_STREAM, 0);
+    assert(s >= 0);
+
+    int opt = 1;
+    assert(libos_setsockopt(s, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt)) == 0);
+    int got = 0; socklen_t len = sizeof(got);
+    assert(libos_getsockopt(s, SOL_SOCKET, SO_REUSEADDR, &got, &len) == 0);
+    assert(got == 1);
+
+    struct in_addr a;
+    assert(libos_inet_aton("127.0.0.1", &a) == 1);
+    const char *str = libos_inet_ntoa(a);
+    assert(strcmp(str, "127.0.0.1") == 0);
+
+    libos_close(s);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -2,7 +2,8 @@ posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
                     '../../src-uland/posix_pipe_test.c',
                     '../../src-uland/user/posix_misc_test.c',
-                    '../../src-uland/user/posix_socket_test.c')
+                    '../../src-uland/user/posix_socket_test.c',
+                    '../../src-uland/user/posix_sockopt_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -10,6 +10,7 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_pipe_test.c',
     ROOT / 'src-uland/user/posix_misc_test.c',
     ROOT / 'src-uland/user/posix_socket_test.c',
+    ROOT / 'src-uland/user/posix_sockopt_test.c',
 ]
 
 
@@ -43,3 +44,7 @@ def test_posix_misc_ops():
 
 def test_posix_socket_ops():
     compile_and_run(SRC_FILES[4])
+
+
+def test_posix_sockopt_ops():
+    compile_and_run(SRC_FILES[5])


### PR DESCRIPTION
## Summary
- add libos_getsockopt and libos_setsockopt implementations
- add IPv4 helpers in new inet.c
- expose new routines in the POSIX header
- extend POSIX tests with socket option and inet helpers
- fix misc POSIX test open prototype

## Testing
- `pytest -q tests/test_posix_apis.py tests/test_posix_compat.py tests/test_libos_env.py -q`
