### PR TITLE
Implement mprotect/msync tracking

### DIFF
--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -26,6 +26,8 @@ long libos_lseek(int fd, long off, int whence);
 int libos_ftruncate(int fd, long length);
 void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd, long off);
 int libos_munmap(void *addr, size_t len);
+int libos_mprotect(void *addr, size_t len, int prot);
+int libos_msync(void *addr, size_t len, int flags);
 
 int libos_sigemptyset(libos_sigset_t *set);
 int libos_sigfillset(libos_sigset_t *set);

--- a/src-uland/posix_prot_test.c
+++ b/src-uland/posix_prot_test.c
@@ -1,0 +1,20 @@
+#include <assert.h>
+#include <sys/mman.h>
+#include "libos/posix.h"
+
+void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){
+    return mmap(addr,len,prot,flags,fd,off);
+}
+int libos_munmap(void *addr,size_t len){ return munmap(addr,len); }
+int libos_mprotect(void *addr,size_t len,int prot){ return mprotect(addr,len,prot); }
+int libos_msync(void *addr,size_t len,int flags){ return msync(addr,len,flags); }
+
+int main(void){
+    void *p = libos_mmap(0,4096,PROT_READ|PROT_WRITE,MAP_PRIVATE|MAP_ANON,-1,0);
+    assert(p != MAP_FAILED);
+    assert(libos_mprotect(p,4096,PROT_READ)==0);
+    assert(libos_msync(p,4096,MS_SYNC)==0);
+    assert(libos_mprotect(p,4096,PROT_READ|PROT_WRITE)==0);
+    assert(libos_munmap(p,4096)==0);
+    return 0;
+}

--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -12,6 +12,8 @@ int libos_close(int fd){ return close(fd); }
 int libos_ftruncate(int fd,long length){ return ftruncate(fd, length); }
 void *libos_mmap(void *addr,size_t len,int prot,int flags,int fd,long off){ return mmap(addr,len,prot,flags,fd,off); }
 int libos_munmap(void *addr,size_t len){ return munmap(addr,len); }
+int libos_mprotect(void *addr,size_t len,int prot){ return mprotect(addr,len,prot); }
+int libos_msync(void *addr,size_t len,int flags){ return msync(addr,len,flags); }
 int libos_getpgrp(void){ return (int)getpgrp(); }
 int libos_setpgid(int pid,int pgid){ return setpgid(pid, pgid); }
 int libos_sigemptyset(libos_sigset_t *set){ *set=0; return 0; }
@@ -28,6 +30,8 @@ int main(void){
 
     void *p = libos_mmap(0, 4096, PROT_READ|PROT_WRITE, MAP_PRIVATE|MAP_ANONYMOUS, -1, 0);
     assert(p != MAP_FAILED);
+    assert(libos_mprotect(p, 4096, PROT_READ) == 0);
+    assert(libos_msync(p, 4096, MS_SYNC) == 0);
     strcpy(p, "ok");
     assert(libos_munmap(p, 4096) == 0);
 

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -2,7 +2,8 @@ posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
                     '../../src-uland/posix_pipe_test.c',
                     '../../src-uland/user/posix_misc_test.c',
-                    '../../src-uland/user/posix_socket_test.c')
+                    '../../src-uland/user/posix_socket_test.c',
+                    '../../src-uland/posix_prot_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -10,6 +10,7 @@ SRC_FILES = [
     ROOT / 'src-uland/posix_pipe_test.c',
     ROOT / 'src-uland/user/posix_misc_test.c',
     ROOT / 'src-uland/user/posix_socket_test.c',
+    ROOT / 'src-uland/posix_prot_test.c',
 ]
 
 
@@ -43,3 +44,7 @@ def test_posix_misc_ops():
 
 def test_posix_socket_ops():
     compile_and_run(SRC_FILES[4])
+
+
+def test_posix_prot_ops():
+    compile_and_run(SRC_FILES[5])

--- a/tests/test_posix_compat.py
+++ b/tests/test_posix_compat.py
@@ -14,6 +14,8 @@ long libos_lseek(int fd,long off,int whence){ (void)fd;(void)off;(void)whence; r
 int libos_ftruncate(int fd,long l){ (void)fd;(void)l; return 0; }
 void *libos_mmap(void *a,size_t l,int p,int f,int fd,long o){ (void)a;(void)l;(void)p;(void)f;(void)fd;(void)o; return (void*)1; }
 int libos_munmap(void *a,size_t l){ (void)a;(void)l; return 0; }
+int libos_mprotect(void *a,size_t l,int p){ (void)a;(void)l;(void)p; return 0; }
+int libos_msync(void *a,size_t l,int f){ (void)a;(void)l;(void)f; return 0; }
 int libos_sigemptyset(libos_sigset_t *s){ *s=0; return 0; }
 int libos_sigfillset(libos_sigset_t *s){ *s=~0UL; return 0; }
 int libos_sigaddset(libos_sigset_t *s,int sig){ *s|=1UL<<sig; return 0; }


### PR DESCRIPTION
## Summary
- track mmap protections internally
- expose `libos_mprotect` and `libos_msync`
- add prototypes for new calls
- exercise new calls in misc test
- add new protection test

## Testing
- `pytest tests/test_posix_apis.py::test_posix_prot_ops -q`