### PR TITLE
Add minimal pthread wrappers

### DIFF
--- a/doc/posix_compat.md
+++ b/doc/posix_compat.md
@@ -38,3 +38,11 @@ available.  Functions like `setlocale()` and `localeconv()` accept any
 input but always behave as if the `"C"` locale is active.  The stubs
 exist so that third-party code expecting these calls can link against the
 libOS without pulling in a full C library.
+
+## Thread Stubs
+
+A basic pthread API is provided for portability. `pthread_create()`
+spawns a new process executing the requested function and
+`pthread_join()` waits on that process. Mutexes spin on an integer and
+only coordinate with other Phoenix pthread calls. Condition variables,
+thread-local storage and other features are not implemented.

--- a/libos/pthread.c
+++ b/libos/pthread.c
@@ -1,0 +1,45 @@
+#include "pthread.h"
+#include <unistd.h>
+#include <sys/wait.h>
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg) {
+  (void)attr;
+  pid_t pid = fork();
+  if (pid < 0)
+    return -1;
+  if (pid == 0) {
+    start_routine(arg);
+    _exit(0);
+  }
+  if (thread)
+    *thread = pid;
+  return 0;
+}
+
+int pthread_join(pthread_t thread, void **retval) {
+  (void)retval;
+  return waitpid(thread, NULL, 0) < 0 ? -1 : 0;
+}
+
+int pthread_mutex_init(pthread_mutex_t *m, const pthread_mutexattr_t *a) {
+  (void)a;
+  m->locked = 0;
+  return 0;
+}
+
+int pthread_mutex_lock(pthread_mutex_t *m) {
+  while (__sync_lock_test_and_set(&m->locked, 1))
+    sleep(0);
+  return 0;
+}
+
+int pthread_mutex_unlock(pthread_mutex_t *m) {
+  __sync_lock_release(&m->locked);
+  return 0;
+}
+
+int pthread_mutex_destroy(pthread_mutex_t *m) {
+  (void)m;
+  return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -55,6 +55,7 @@ libos_sources = [
   'libos/affine_runtime.c',
   'libos/env.c',
   'libos/posix.c',
+  'libos/pthread.c',
   'libos/termios.c',
   'libos/microkernel/cap.c',
   'libos/microkernel/msg_router.c',

--- a/src-headers/libos/pthread.h
+++ b/src-headers/libos/pthread.h
@@ -1,0 +1,25 @@
+#pragma once
+#include <stddef.h>
+
+typedef int pthread_t;
+
+typedef struct {
+  int dummy;
+} pthread_attr_t;
+
+int pthread_create(pthread_t *thread, const pthread_attr_t *attr,
+                   void *(*start_routine)(void *), void *arg);
+int pthread_join(pthread_t thread, void **retval);
+
+typedef struct {
+  volatile int locked;
+} pthread_mutex_t;
+
+typedef int pthread_mutexattr_t;
+
+#define PTHREAD_MUTEX_INITIALIZER {0}
+
+int pthread_mutex_init(pthread_mutex_t *m, const pthread_mutexattr_t *a);
+int pthread_mutex_lock(pthread_mutex_t *m);
+int pthread_mutex_unlock(pthread_mutex_t *m);
+int pthread_mutex_destroy(pthread_mutex_t *m);


### PR DESCRIPTION
## Summary
- define small pthread interface in src headers
- implement pthread calls over processes
- hook pthread source into build
- note pthread limitations

## Testing
- `pytest -k lockstress -vv` *(fails: Command '/tmp/tmpggt72iel/test' died with SIGSEGV)*