### PR TITLE
Add nanosleep wrapper and kernel timer support

### DIFF
--- a/libos/posix.c
+++ b/libos/posix.c
@@ -6,6 +6,8 @@
 #include "user.h"
 #include "signal.h"
 #include <stdlib.h>
+#include <time.h>
+#include "libos/timer.h"
 #include <fcntl.h>
 #include "stat.h"
 #include <unistd.h>
@@ -261,4 +263,19 @@ long libos_send(int fd,const void *buf,size_t len,int flags){
 
 long libos_recv(int fd,void *buf,size_t len,int flags){
     return recv(fd, buf, len, flags);
+}
+
+uint64_t libos_timer_now(void){
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    return (uint64_t)ts.tv_sec * 1000000000ULL + ts.tv_nsec;
+}
+
+int libos_nanosleep(const struct timespec *req){
+    uint64_t start = libos_timer_now();
+    uint64_t dur = (uint64_t)req->tv_sec * 1000000000ULL + req->tv_nsec;
+    struct timespec sl = {0, 1000000};
+    while(libos_timer_now() - start < dur)
+        nanosleep(&sl, NULL);
+    return 0;
 }

--- a/src-headers/defs.h
+++ b/src-headers/defs.h
@@ -160,6 +160,8 @@ void wakeup(void *);
 void yield(void);
 struct proc *pctr_lookup(uint32_t);
 struct proc *allocproc(void);
+void proc_timer_tick(struct proc *);
+uint64_t proc_timer_now(struct proc *);
 
 // swtch.S
 void swtch(context_t **, context_t *);

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -48,3 +48,6 @@ long libos_recv(int fd, void *buf, size_t len, int flags);
 
 int libos_setenv(const char *name, const char *value);
 const char *libos_getenv(const char *name);
+
+struct timespec;
+int libos_nanosleep(const struct timespec *req);

--- a/src-headers/libos/timer.h
+++ b/src-headers/libos/timer.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <stdint.h>
+
+struct libos_timer {
+    uint64_t ticks;
+};
+
+uint64_t libos_timer_now(void);

--- a/src-headers/proc.h
+++ b/src-headers/proc.h
@@ -6,6 +6,7 @@
 #include "spinlock.h"
 #include "ipc.h"
 #include "../exo.h"
+#include "libos/timer.h"
 
 // Context used for kernel context switches.
 #if defined(__x86_64__) || defined(__aarch64__)
@@ -123,13 +124,14 @@ struct proc {
   int preferred_node;            // NUMA allocation preference
   int out_of_gas;                // Flag set when gas runs out
   struct mailbox *mailbox;       // Per-process IPC mailbox
+  struct libos_timer timer;      // Per-process timer
 };
 
 // Ensure scheduler relies on fixed struct proc size
 #if defined(__x86_64__) || defined(__aarch64__)
-_Static_assert(sizeof(struct proc) == 264, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 272, "struct proc size incorrect");
 #else
-_Static_assert(sizeof(struct proc) == 160, "struct proc size incorrect");
+_Static_assert(sizeof(struct proc) == 168, "struct proc size incorrect");
 #endif
 
 

--- a/src-kernel/proc.c
+++ b/src-kernel/proc.c
@@ -149,6 +149,7 @@ found:
   p->preferred_node = 0;
   p->out_of_gas = 0;
   p->pending_signal = 0;
+  p->timer.ticks = 0;
 
   pctr_insert(p);
 
@@ -668,4 +669,13 @@ procdump(void)
     }
     cprintf("\n");
   }
+}
+
+void proc_timer_tick(struct proc *p) {
+  if (p)
+    p->timer.ticks++;
+}
+
+uint64_t proc_timer_now(struct proc *p) {
+  return p ? p->timer.ticks : 0;
 }

--- a/src-kernel/trap.c
+++ b/src-kernel/trap.c
@@ -52,6 +52,7 @@ void trap(struct trapframe *tf) {
       release(&tickslock);
     }
     if (myproc()) {
+      proc_timer_tick(myproc());
       if (myproc()->gas_remaining > 0)
         myproc()->gas_remaining--;
       if (myproc()->gas_remaining == 0) {

--- a/src-uland/user/posix_nanosleep_test.c
+++ b/src-uland/user/posix_nanosleep_test.c
@@ -1,0 +1,14 @@
+#include <assert.h>
+#include <time.h>
+#include "libos/posix.h"
+
+int main(void){
+    struct timespec req = {0, 1000000};
+    struct timespec before, after;
+    clock_gettime(CLOCK_MONOTONIC, &before);
+    assert(libos_nanosleep(&req) == 0);
+    clock_gettime(CLOCK_MONOTONIC, &after);
+    long diff = (after.tv_sec - before.tv_sec)*1000000000L + (after.tv_nsec - before.tv_nsec);
+    assert(diff >= 1000000L);
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -2,7 +2,8 @@ posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_signal_test.c',
                     '../../src-uland/posix_pipe_test.c',
                     '../../src-uland/user/posix_misc_test.c',
-                    '../../src-uland/user/posix_socket_test.c')
+                    '../../src-uland/user/posix_socket_test.c',
+                    '../../src-uland/user/posix_nanosleep_test.c')
 foreach src : posix_tests
   exe_name = src.stem()
   executable(exe_name, src,


### PR DESCRIPTION
## Summary
- track per-process timers in the kernel
- expose timer data structures via a new header
- implement `libos_nanosleep` using timer helpers
- test nanosleep through a new user program

## Testing
- `pytest -q` *(fails: CalledProcessError for many tests)*