### PR TITLE
Expose IPC timed mailbox

### DIFF
--- a/src-headers/ipc_queue.h
+++ b/src-headers/ipc_queue.h
@@ -1,0 +1,5 @@
+#pragma once
+
+struct mailbox;
+extern struct mailbox ipcs;
+void ipc_timed_init(void);

--- a/src-kernel/exo_ipc_queue.c
+++ b/src-kernel/exo_ipc_queue.c
@@ -9,8 +9,9 @@
 #include "ipc_debug.h"
 #define EXO_KERNEL
 #include "include/exokernel.h"
+#include "ipc_queue.h"
 
-static struct mailbox ipcs;
+struct mailbox ipcs;
 
 static void ipc_init(struct mailbox *mb) {
   if (!mb->inited) {
@@ -19,6 +20,8 @@ static void ipc_init(struct mailbox *mb) {
     mb->inited = 1;
   }
 }
+
+void ipc_timed_init(void) { ipc_init(&ipcs); }
 
 int exo_ipc_queue_send(exo_cap dest, const void *buf, uint64_t len) {
   struct mailbox *mb = myproc()->mailbox;

--- a/src-kernel/main.c
+++ b/src-kernel/main.c
@@ -10,6 +10,7 @@
 #include "spinlock.h"
 #include "exo_stream.h"
 #include "exo_ipc.h"
+#include "ipc_queue.h"
 #include <string.h>
 
 static void startothers(void);
@@ -38,6 +39,7 @@ int main(void) {
   cap_table_init();                           // initialize capability table
   rcuinit();                                  // rcu subsystem
   pinit();                                    // process table
+  ipc_timed_init();                           // initialize timed IPC mailbox
   tvinit();                                   // trap vectors
   binit();                                    // buffer cache
   fileinit();                                 // file table


### PR DESCRIPTION
## Summary
- export the timed IPC mailbox and initialization routine
- initialize the timed mailbox early in boot

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*