### PR TITLE
Document env inheritance and locale stubs

### DIFF
--- a/doc/posix_progress.md
+++ b/doc/posix_progress.md
@@ -43,3 +43,12 @@ This log tracks implementation status of the POSIX wrappers provided by the Phoe
 | `libos_chdir` | Missing | N/A | N/A |
 | `libos_getcwd` | Missing | N/A | N/A |
 
+## Notes
+
+- Environment variables set with `libos_setenv()` are local to the process.
+  Child processes launched via `libos_spawn()` start with an empty table and do
+  not inherit the parent's values.
+- Locale support is only stubbed.  Functions such as `setlocale()` and
+  `localeconv()` accept arguments but always behave as if the default "C" locale
+  is active.
+


### PR DESCRIPTION
## Summary
- clarify that environment variables aren't inherited across `libos_spawn`
- document stubbed locale functions in the POSIX progress matrix

## Testing
- `pytest -q`