### PR TITLE
Link POSIX tests with libos

### DIFF
--- a/src-uland/posix_file_test.c
+++ b/src-uland/posix_file_test.c
@@ -4,11 +4,6 @@
 #include <string.h>
 #include "libos/posix.h"
 
-int libos_open(const char *path, int flags, int mode) { return open(path, flags, mode); }
-int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
-int libos_write(int fd, const void *buf, size_t n) { return (int)write(fd, buf, n); }
-int libos_close(int fd) { return close(fd); }
-int libos_dup(int fd) { return dup(fd); }
 
 int main(void) {
     const char *msg = "hello";

--- a/src-uland/posix_pipe_test.c
+++ b/src-uland/posix_pipe_test.c
@@ -4,24 +4,6 @@
 #include <sys/wait.h>
 #include "libos/posix.h"
 
-int libos_pipe(int fd[2]) { return pipe(fd); }
-int libos_fork(void) { return fork(); }
-int libos_waitpid(int pid, int *st, int flags) {
-  return waitpid(pid, st, flags);
-}
-int libos_close(int fd) { return close(fd); }
-int libos_read(int fd, void *buf, size_t n) { return (int)read(fd, buf, n); }
-int libos_write(int fd, const void *buf, size_t n) {
-  return (int)write(fd, buf, n);
-}
-int libos_spawn(const char *path, char *const argv[]) {
-  int pid = fork();
-  if (pid == 0) {
-    execv(path, argv);
-    _exit(1);
-  }
-  return pid;
-}
 
 int main(void) {
   int p[2];

--- a/src-uland/posix_signal_test.c
+++ b/src-uland/posix_signal_test.c
@@ -6,9 +6,6 @@
 
 static volatile sig_atomic_t got;
 
-int libos_signal(int sig, void (*handler)(int)) { return signal(sig, handler) == SIG_ERR ? -1 : 0; }
-int libos_sigsend(int pid, int sig) { (void)pid; return raise(sig); }
-int libos_sigcheck(void) { return got; }
 
 static void handler(int s) { got = s; }
 

--- a/src-uland/user/posix_misc_test.c
+++ b/src-uland/user/posix_misc_test.c
@@ -7,29 +7,6 @@
 #include <string.h>
 #include "libos/posix.h"
 
-int libos_open(const char *path, int flags, int mode) {
-  return open(path, flags | O_CREAT, mode);
-}
-int libos_close(int fd) { return close(fd); }
-int libos_ftruncate(int fd, long length) { return ftruncate(fd, length); }
-void *libos_mmap(void *addr, size_t len, int prot, int flags, int fd,
-                 long off) {
-  return mmap(addr, len, prot, flags, fd, off);
-}
-int libos_munmap(void *addr, size_t len) { return munmap(addr, len); }
-int libos_getpgrp(void) { return (int)getpgrp(); }
-int libos_setpgid(int pid, int pgid) { return setpgid(pid, pgid); }
-int libos_sigemptyset(libos_sigset_t *set) {
-  *set = 0;
-  return 0;
-}
-int libos_sigaddset(libos_sigset_t *set, int sig) {
-  *set |= 1UL << sig;
-  return 0;
-}
-int libos_sigismember(const libos_sigset_t *set, int sig) {
-  return (*set & (1UL << sig)) != 0;
-}
 
 int main(void) {
   int fd = libos_open("misc.tmp", O_RDWR, 0600);

--- a/src-uland/user/posix_socket_test.c
+++ b/src-uland/user/posix_socket_test.c
@@ -7,14 +7,6 @@
 #include <sys/wait.h>
 #include "libos/posix.h"
 
-int libos_socket(int d,int t,int p){ return socket(d,t,p); }
-int libos_bind(int fd,const struct sockaddr *a,socklen_t l){ return bind(fd,a,l); }
-int libos_listen(int fd,int b){ return listen(fd,b); }
-int libos_accept(int fd,struct sockaddr *a,socklen_t *l){ return accept(fd,a,l); }
-int libos_connect(int fd,const struct sockaddr *a,socklen_t l){ return connect(fd,a,l); }
-long libos_send(int fd,const void *b,size_t l,int f){ return send(fd,b,l,f); }
-long libos_recv(int fd,void *b,size_t l,int f){ return recv(fd,b,l,f); }
-int libos_close(int fd){ return close(fd); }
 
 int main(void){
     int srv = libos_socket(AF_INET, SOCK_STREAM, 0);

--- a/tests/include/exokernel.h
+++ b/tests/include/exokernel.h
@@ -1,0 +1,3 @@
+#include <stddef.h>
+#include "../src-headers/exokernel.h"
+

--- a/tests/libos_host_stubs.c
+++ b/tests/libos_host_stubs.c
@@ -1,0 +1,59 @@
+#include <stdint.h>
+#include <string.h>
+#include "exo.h"
+
+#define STUB_BLOCKS 128
+#define BSIZE 512
+
+static unsigned char disk[STUB_BLOCKS * BSIZE];
+static uint32_t next_block;
+
+int exo_alloc_page(exo_cap *cap) {
+    static uint32_t next_page = 1;
+    if (!cap) return -1;
+    cap->pa = next_page * 0x1000;
+    cap->id = next_page++;
+    cap->rights = 0;
+    cap->owner = 1;
+    return 0;
+}
+
+int exo_unbind_page(exo_cap c) {
+    (void)c;
+    return 0;
+}
+
+int exo_alloc_block(uint32_t dev, uint32_t rights, exo_blockcap *cap) {
+    (void)dev;
+    if (!cap) return -1;
+    cap->dev = 1;
+    cap->blockno = next_block++;
+    cap->rights = rights;
+    cap->owner = 1;
+    return 0;
+}
+
+int exo_bind_block(exo_blockcap *cap, void *data, int write) {
+    if (!cap || cap->blockno >= STUB_BLOCKS || !data) return -1;
+    unsigned char *slot = disk + cap->blockno * BSIZE;
+    if (write)
+        memcpy(slot, data, BSIZE);
+    else
+        memcpy(data, slot, BSIZE);
+    return 0;
+}
+
+int exo_read_disk(exo_blockcap cap, void *dst, uint64_t off, uint64_t n) {
+    if (cap.blockno >= STUB_BLOCKS || !dst) return -1;
+    if (off + n > BSIZE) return -1;
+    memcpy(dst, disk + cap.blockno * BSIZE + off, n);
+    return (int)n;
+}
+
+int exo_write_disk(exo_blockcap cap, const void *src, uint64_t off, uint64_t n) {
+    if (cap.blockno >= STUB_BLOCKS || !src) return -1;
+    if (off + n > BSIZE) return -1;
+    memcpy(disk + cap.blockno * BSIZE + off, src, n);
+    return (int)n;
+}
+

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -3,9 +3,17 @@ posix_tests = files('../../src-uland/posix_file_test.c',
                     '../../src-uland/posix_pipe_test.c',
                     '../../src-uland/user/posix_misc_test.c',
                     '../../src-uland/user/posix_socket_test.c')
+libos_srcs = files('../../libos/posix.c',
+                   '../../libos/fs.c',
+                   '../../libos/file.c',
+                   '../../libos/fs_ufs.c',
+                   '../../tests/libos_host_stubs.c')
 foreach src : posix_tests
   exe_name = src.stem()
-  executable(exe_name, src,
-             include_directories: include_directories('../../src-headers'),
+  executable(exe_name, [src] + libos_srcs,
+             include_directories: include_directories('../../',
+                                                    '../../src-headers',
+                                                    '../../libos/include',
+                                                    '../../tests/include'),
              install: false)
 endforeach

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -16,12 +16,28 @@ SRC_FILES = [
 def compile_and_run(source: pathlib.Path) -> None:
     with tempfile.TemporaryDirectory() as td:
         exe = pathlib.Path(td) / 'test'
-        subprocess.check_call([
+        inc_dir = pathlib.Path(td) / 'include'
+        inc_dir.mkdir()
+        (inc_dir / 'exokernel.h').write_text(
+            '#include <stddef.h>\n#include "../src-headers/exokernel.h"\n'
+        )
+        cmd = [
             'gcc', '-std=c2x', '-Wall', '-Werror',
+            '-I', str(td),
+            '-I', str(ROOT),
+            '-I', str(ROOT / 'libos/include'),
+            '-I', str(ROOT / 'libos'),
+            '-I', str(ROOT / 'src-headers/libos'),
             '-idirafter', str(ROOT / 'src-headers'),
             str(source),
+            str(ROOT / 'libos/posix.c'),
+            str(ROOT / 'libos/fs.c'),
+            str(ROOT / 'libos/file.c'),
+            str(ROOT / 'libos/fs_ufs.c'),
+            str(ROOT / 'tests/libos_host_stubs.c'),
             '-o', str(exe),
-        ])
+        ]
+        subprocess.check_call(cmd)
         subprocess.check_call([str(exe)])
 
 


### PR DESCRIPTION
## Summary
- drop the stub `libos_*` implementations from the POSIX test programs
- compile the tests with the real libos sources
- add simple host stubs for exokernel primitives
- update Meson build and python helper to use the new stubs

## Testing
- `pytest -q tests/test_posix_apis.py::test_posix_file_ops -q` *(fails: Command '['gcc', '-std=c2x', ...] returned non-zero exit status 1)*