### PR TITLE
Add Codex environment automation files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "postCreateCommand": "npm i -g @openai/codex && codex -q 'doctor setup.sh'"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Codex rules
+
+- On entry, diff `setup.sh` against https://raw.githubusercontent.com/Oichkatzelesfrettschen/exov6/master/setup.sh. If differences exist, update this file and commit with message `auto-heal setup.sh`.
+- Always run `shellcheck setup.sh` and `pre-commit` before committing changes.
+- Run `bats` tests under `tests` if they are present before committing.
+- Prefer offline caches in `offline_packages/` when network access fails.

--- a/README
+++ b/README
@@ -565,3 +565,14 @@ Example::
 
     from streams_log import strlog_json
     strlog_json("info", "module loaded", name="xor_encrypt")
+
+AUTOMATED SETUP WITH CODEX
+--------------------------
+An optional workflow installs the Codex CLI and executes `setup.sh` automatically. A sample systemd unit file is provided at `scripts/codex-setup.service`. Enable it to heal and run the setup script before networking finishes starting:
+
+    sudo cp scripts/codex-setup.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable codex-setup.service
+
+A minimal dev container configuration lives under `.devcontainer`. Opening the project in a Codespace installs Codex and runs `codex -q 'doctor setup.sh'` during initialization.
+

--- a/scripts/codex-setup.service
+++ b/scripts/codex-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add guidance for Codex automation in `AGENTS.md`
- provide a `.devcontainer` config that installs Codex and runs doctor on `setup.sh`
- include a sample `codex-setup.service` systemd unit
- document Codex workflow in the README

## Testing
- `apt-get update` *(fails: Could not connect to proxy)*
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files setup.sh AGENTS.md .devcontainer/devcontainer.json scripts/codex-setup.service README` *(fails: command not found)*
- `pytest -q` *(fails: multiple compilation errors)*