### PR TITLE
Add Codex environment automation files

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,3 @@
+{
+  "postCreateCommand": "npm i -g @openai/codex && codex -q 'doctor setup.sh'"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,6 @@
+# Repository Codex rules
+
+- On entry, diff `setup.sh` against https://raw.githubusercontent.com/Oichkatzelesfrettschen/exov6/master/setup.sh. If differences exist, update this file and commit with message `auto-heal setup.sh`.
+- Always run `shellcheck setup.sh` and `pre-commit` before committing changes.
+- Run `bats` tests under `tests` if they are present before committing.
+- Prefer offline caches in `offline_packages/` when network access fails.

--- a/README
+++ b/README
@@ -565,3 +565,14 @@ Example::
 
     from streams_log import strlog_json
     strlog_json("info", "module loaded", name="xor_encrypt")
+
+AUTOMATED SETUP WITH CODEX
+--------------------------
+An optional workflow installs the Codex CLI and executes `setup.sh` automatically. A sample systemd unit file is provided at `scripts/codex-setup.service`. Enable it to heal and run the setup script before networking finishes starting:
+
+    sudo cp scripts/codex-setup.service /etc/systemd/system/
+    sudo systemctl daemon-reload
+    sudo systemctl enable codex-setup.service
+
+A minimal dev container configuration lives under `.devcontainer`. Opening the project in a Codespace installs Codex and runs `codex -q 'doctor setup.sh'` during initialization.
+

--- a/libos/file.c
+++ b/libos/file.c
@@ -5,10 +5,11 @@
 #include "spinlock.h"
 #include "types.h"
 #include "user.h"
+#include <sys/stat.h>
+#include <stdlib.h>
 
 // Basic wrappers to illustrate linking a user-space filesystem library.
 
-static struct file dummy_file;
 
 void fileinit(void) {}
 
@@ -36,7 +37,7 @@ void fileclose(struct file *f) {
 int filestat(struct file *f, struct stat *st) {
   if (!f || !st)
     return -1;
-  st->size = BSIZE; // minimal single-block file
+  st->st_size = BSIZE; // minimal single-block file
   return 0;
 }
 

--- a/scripts/codex-setup.service
+++ b/scripts/codex-setup.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Heal and run setup.sh before networking
+DefaultDependencies=no
+Before=network-pre.target
+Wants=network-pre.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/codex -q -a full-auto "doctor setup.sh" && /usr/local/bin/setup.sh
+RemainAfterExit=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/src-headers/libos/file.h
+++ b/src-headers/libos/file.h
@@ -1,6 +1,10 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
 #include "include/exokernel.h"
+#include "fs.h"
+#include "sleeplock.h"
 
 struct file {
   enum { FD_NONE, FD_CAP } type;
@@ -37,3 +41,13 @@ struct devsw {
 extern struct devsw devsw[];
 
 #define CONSOLE 1
+
+#include <sys/stat.h>
+
+void fileinit(void);
+struct file *filealloc(void);
+struct file *filedup(struct file *f);
+void fileclose(struct file *f);
+int filestat(struct file *f, struct stat *st);
+int fileread(struct file *f, char *addr, size_t n);
+int filewrite(struct file *f, char *addr, size_t n);

--- a/src-headers/libos/fs.h
+++ b/src-headers/libos/fs.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <stdint.h>
 
 // On-disk file system format.
 // Both the kernel and user programs use this header file.

--- a/src-headers/libos/posix.h
+++ b/src-headers/libos/posix.h
@@ -1,4 +1,6 @@
 #pragma once
+#include <stddef.h>
+#include <signal.h>
 #include "types.h"
 #include "exo.h"
 
@@ -17,7 +19,6 @@ int libos_fork(void);
 int libos_waitpid(int pid, int *status, int flags);
 int libos_sigsend(int pid, int sig);
 int libos_sigcheck(void);
-struct sigaction;
 int libos_sigaction(int sig, const struct sigaction *act,
                     struct sigaction *oact);
 typedef unsigned long libos_sigset_t;

--- a/src-headers/user.h
+++ b/src-headers/user.h
@@ -1,2 +1,6 @@
 #pragma once
-// placeholder user-space headers
+#include <sys/types.h>
+
+int exec(char *path, char **argv);
+int sigsend(int pid, int sig);
+int sigcheck(void);

--- a/tests/libos_host_stubs.c
+++ b/tests/libos_host_stubs.c
@@ -57,3 +57,19 @@ int exo_write_disk(exo_blockcap cap, const void *src, uint64_t off, uint64_t n) 
     return (int)n;
 }
 
+int exec(char *path, char **argv) {
+    (void)path;
+    (void)argv;
+    return -1;
+}
+
+int sigsend(int pid, int sig) {
+    (void)pid;
+    (void)sig;
+    return 0;
+}
+
+int sigcheck(void) {
+    return 0;
+}
+


### PR DESCRIPTION
## Summary
- add guidance for Codex automation in `AGENTS.md`
- provide a `.devcontainer` config that installs Codex and runs doctor on `setup.sh`
- include a sample `codex-setup.service` systemd unit
- document Codex workflow in the README
- fix build headers and stub missing functions

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files setup.sh AGENTS.md .devcontainer/devcontainer.json scripts/codex-setup.service README` *(fails: command not found)*
- `pytest -q` *(fails: 5 failed, 27 passed, 10 xfailed)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.