### PR TITLE
Fix include path in posix extra test

### DIFF
--- a/engine/user/user/test_posix_extra.py
+++ b/engine/user/user/test_posix_extra.py
@@ -38,7 +38,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         subprocess.check_call([
             "gcc","-std=c11",
-            "-I", str(ROOT/"src-headers"),
+            "-I", str(ROOT/"engine/include"),
             str(src),
             "-o", str(exe),
         ])


### PR DESCRIPTION
## Summary
- update old reference to `src-headers` in test

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit` *(fails: command not found)*
- `bats tests` *(fails: command not found)*