### PR TITLE
Modernize microbench POSIX

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -167,7 +167,7 @@ export MAKEFLAGS="${MAKEFLAGS:--j$(nproc)}"
 # for cross-compilers and legacy support.
 for pkg in \
   build-essential gcc g++ g++-13 clang clang-16 lld llvm llvm-bolt \
-  clang-format clang-tidy clangd clang-tools ccache uncrustify astyle editorconfig \
+  clang-format clang-tidy clangd clang-tools shellcheck ccache uncrustify astyle editorconfig \
   make bmake ninja-build cmake meson \
   autoconf automake libtool m4 gawk flex bison byacc \
   pkg-config file ca-certificates curl git unzip graphviz \

--- a/tests/microbench/cap_verify_bench.c
+++ b/tests/microbench/cap_verify_bench.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -26,7 +26,7 @@ static uint64_t fnv64(const uint8_t *data, size_t len, uint64_t seed) {
 
 static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
     const uint64_t basis = 14695981039346656037ULL;
-    for(int i=0;i<4;i++)
+    for(size_t i = 0; i < 4; ++i)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 

--- a/tests/microbench/exo_yield_to_bench.c
+++ b/tests/microbench/exo_yield_to_bench.c
@@ -1,4 +1,4 @@
-#define _POSIX_C_SOURCE 199309L
+#define _POSIX_C_SOURCE 200809L
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>
@@ -26,7 +26,7 @@ static uint64_t fnv64(const uint8_t *data, size_t len, uint64_t seed) {
 
 static void hash256(const uint8_t *data, size_t len, hash256_t *out) {
     const uint64_t basis = 14695981039346656037ULL;
-    for(int i=0;i<4;i++)
+    for(size_t i = 0; i < 4; ++i)
         out->parts[i] = fnv64(data, len, basis + i);
 }
 


### PR DESCRIPTION
## Summary
- add shellcheck to apt install list
- modernize microbenchmark code and update POSIX feature level

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files setup.sh tests/microbench/exo_yield_to_bench.c tests/microbench/cap_verify_bench.c` *(fails: command not found)*
- `bats tests` *(fails: command not found)*