### PR TITLE
Fix attribute syntax

### DIFF
--- a/ddekit/thread.h
+++ b/ddekit/thread.h
@@ -117,7 +117,7 @@ void ddekit_thread_wakeup(ddekit_thread_t *thread);
  *
  * \ingroup DDEKit_threads
  */
-void ddekit_thread_exit(void) __attribute__((noreturn));
+void ddekit_thread_exit(void) [[noreturn]];
 
 /** Terminate a thread 
  *

--- a/engine/include/ddekit.h
+++ b/engine/include/ddekit.h
@@ -10,7 +10,7 @@ void ddekit_init(void);
 int ddekit_process_spawn(struct ddekit_process *p, const char *path,
                          char *const argv[]);
 int ddekit_process_wait(struct ddekit_process *p);
-void ddekit_process_exit(int code) __attribute__((noreturn));
+void ddekit_process_exit(int code) [[noreturn]];
 void ddekit_yield(void);
 
 exo_cap ddekit_cap_alloc_page(void);

--- a/engine/include/mp.h
+++ b/engine/include/mp.h
@@ -11,7 +11,7 @@ struct mp {             // floating pointer
   uint8_t type;                   // MP system config type
   uint8_t imcrp;
   uint8_t reserved[3];
-} __attribute__((packed));
+} [[gnu::packed]];
 
 struct mpconf {         // configuration table header
   uint8_t signature[4];           // "PCMP"
@@ -26,7 +26,7 @@ struct mpconf {         // configuration table header
   uint16_t xlength;               // extended table length
   uint8_t xchecksum;              // extended table checksum
   uint8_t reserved;
-} __attribute__((packed));
+} [[gnu::packed]];
 
 struct mpproc {         // processor table entry
   uint8_t type;                   // entry type (0)
@@ -37,7 +37,7 @@ struct mpproc {         // processor table entry
   uint8_t signature[4];           // CPU signature
   uint32_t feature;                 // feature flags from CPUID instruction
   uint8_t reserved[8];
-} __attribute__((packed));
+} [[gnu::packed]];
 
 struct mpioapic {       // I/O APIC table entry
   uint8_t type;                   // entry type (2)
@@ -45,7 +45,7 @@ struct mpioapic {       // I/O APIC table entry
   uint8_t version;                // I/O APIC version
   uint8_t flags;                  // I/O APIC flags
   uint32_t *addr;                  // I/O APIC address
-} __attribute__((packed));
+} [[gnu::packed]];
 
 // Table entry types
 #define MPPROC    0x00  // One per processor

--- a/engine/kernel/main.c
+++ b/engine/kernel/main.c
@@ -14,7 +14,7 @@
 #include <string.h>
 
 static void startothers(void);
-static void mpmain(void) __attribute__((noreturn));
+static void mpmain(void) [[noreturn]];
 #ifdef __x86_64__
 extern pml4e_t *kpgdir;
 #else
@@ -130,7 +130,7 @@ static void startothers(void) {
 // PTE_PS in a page directory entry enables 4Mbyte pages.
 
 #ifndef __x86_64__
-__attribute__((__aligned__(PGSIZE))) pde_t entrypgdir[NPDENTRIES] = {
+[[gnu::aligned(PGSIZE)]] pde_t entrypgdir[NPDENTRIES] = {
     // Map VA's [0, 4MB) to PA's [0, 4MB)
     [0] = (0) | PTE_P | PTE_W | PTE_PS,
     // Map VA's [KERNBASE, KERNBASE+4MB) to PA's [0, 4MB)

--- a/engine/libos/include/procwrap.h
+++ b/engine/libos/include/procwrap.h
@@ -8,4 +8,4 @@ typedef struct {
 
 int proc_spawn(proc_handle_t *p, const char *path, char *const argv[]);
 int proc_wait(proc_handle_t *p);
-void proc_exit(int code) __attribute__((noreturn));
+void proc_exit(int code) [[noreturn]];

--- a/engine/user/sh.c
+++ b/engine/user/sh.c
@@ -56,11 +56,11 @@ struct cmd *parsecmd(char *);
 int runbuiltin(struct cmd *);
 
 // Annotate as noreturn so modern compilers know runcmd exits
-static void __attribute__((noreturn)) runcmd(struct cmd *cmd);
+static void [[noreturn]] runcmd(struct cmd *cmd);
 
 // Execute cmd.  Never returns.
 
-static void __attribute__((noreturn)) runcmd(struct cmd *cmd) {
+static void [[noreturn]] runcmd(struct cmd *cmd) {
   int p[2];
   struct backcmd *bcmd;
   struct execcmd *ecmd;


### PR DESCRIPTION
## Summary
- modernize noreturn attribute usage in engine and ddekit
- modernize packed and aligned attributes
- build with C23 configuration

## Testing
- `cmake -S . -B build -G Ninja`
- `ninja -C build` *(fails: use of undeclared identifier 'write', etc.)*