### PR TITLE
Add fib_big with BitInt support and demo

### DIFF
--- a/demos/examples/fib_big_demo.c
+++ b/demos/examples/fib_big_demo.c
@@ -1,0 +1,18 @@
+#include <stdio.h>
+#include "math_core.h"
+
+int main(void) {
+    unsigned n = 100;
+#ifdef __BITINT_MAXWIDTH__
+    uint256_t val = fib_big(n);
+    printf("fib_big(%u) = 0x", n);
+    for (int i = 3; i >= 0; i--) {
+        unsigned long long part = (unsigned long long)(val >> (i * 64));
+        printf("%016llx", part);
+    }
+    printf("\n");
+#else
+    printf("fib_big(%u) = %llu (fallback)\n", n, (unsigned long long)fib_big(n));
+#endif
+    return 0;
+}

--- a/engine/include/math_core.h
+++ b/engine/include/math_core.h
@@ -3,5 +3,12 @@
 
 double phi(void);
 uint64_t fib(uint32_t n);
+
+#ifdef __BITINT_MAXWIDTH__
+typedef unsigned _BitInt(256) uint256_t;
+uint256_t fib_big(uint32_t n);
+#else
+uint64_t fib_big(uint32_t n);
+#endif
 uint64_t gcd(uint64_t a, uint64_t b);
 size_t phi_align(size_t n);

--- a/engine/user/math_core.c
+++ b/engine/user/math_core.c
@@ -17,6 +17,29 @@ uint64_t fib(uint32_t n) {
   return b;
 }
 
+#ifdef __BITINT_MAXWIDTH__
+// 256-bit unsigned integer type for wide Fibonacci calculations.
+typedef unsigned _BitInt(256) uint256_t;
+
+uint256_t fib_big(uint32_t n) {
+  if (n == 0)
+    return 0;
+  uint256_t a = 0;
+  uint256_t b = 1;
+  for (uint32_t i = 1; i < n; i++) {
+    uint256_t t = a + b;
+    a = b;
+    b = t;
+  }
+  return b;
+}
+#else
+// Fallback implementation using 64-bit integers when _BitInt is unavailable.
+uint64_t fib_big(uint32_t n) {
+  return fib(n);
+}
+#endif
+
 // Compute the greatest common divisor using Euclid's algorithm.
 uint64_t gcd(uint64_t a, uint64_t b) {
   // Euclid's algorithm without division to avoid libgcc helpers


### PR DESCRIPTION
## Summary
- extend math_core to support big Fibonacci numbers using `_BitInt(256)`
- provide fallback implementation when `_BitInt` is unavailable
- expose the new interface in the public header
- add a simple example program showing `fib_big`

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files engine/user/math_core.c engine/include/math_core.h demos/examples/fib_big_demo.c` *(fails: command not found)*
- `bats tests` *(fails: command not found)*