### PR TITLE
Add ABI alignment assert

### DIFF
--- a/engine/include/cap.h
+++ b/engine/include/cap.h
@@ -28,6 +28,12 @@ static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
 #else
 _Static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
 #endif
+// Verify alignment remains stable across compilers
+#ifdef __cplusplus
+static_assert(_Alignof(struct cap_entry) == 4, "struct cap_entry alignment incorrect");
+#else
+_Static_assert(_Alignof(struct cap_entry) == 4, "struct cap_entry alignment incorrect");
+#endif
 
 extern uint32_t global_epoch;
 


### PR DESCRIPTION
## Summary
- verify `struct cap_entry` alignment is 4 bytes

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files engine/include/cap.h` *(fails: command not found)*
- `bats tests` *(fails: command not found)*