### PR TITLE
Add optional SIMD math routines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ project(xv6 LANGUAGES C CXX)
 option(USE_TICKET_LOCK "Use ticket-based spinlocks" OFF)
 option(IPC_DEBUG "Enable IPC debug logging" OFF)
 option(USE_CAPNP "Build Cap'n Proto support" OFF)
+option(USE_SIMD "Enable SIMD math routines" OFF)
 
 set(CMAKE_C_STANDARD 23)
 set(CMAKE_C_STANDARD_REQUIRED ON)
@@ -73,6 +74,9 @@ target_include_directories(libos PUBLIC
   ${CMAKE_SOURCE_DIR}/engine/libos/include
   ${CMAKE_SOURCE_DIR}/engine/libos/capnp
 )
+if(USE_SIMD)
+  target_compile_definitions(libos PUBLIC USE_SIMD)
+endif()
 
 if(USE_CAPNP)
   add_custom_command(
@@ -103,6 +107,9 @@ if(USE_TICKET_LOCK)
 endif()
 if(IPC_DEBUG)
   target_compile_definitions(kernel PRIVATE IPC_DEBUG)
+endif()
+if(USE_SIMD)
+  target_compile_definitions(kernel PRIVATE USE_SIMD)
 endif()
 
 # QEMU executable used for run targets

--- a/README
+++ b/README
@@ -308,16 +308,21 @@ environment for Meson:
     Enable additional lock sanity checks.
 ``USE_CAPNP``
     Build Cap'n Proto helpers and example programs.
+``USE_SIMD``
+    Enable optional SIMD implementations of math routines when supported by the
+    target CPU. Requires SSE2 on x86 or NEON on ARM.
 
 Example CMake usage::
 
     cmake -S . -B build -DUSE_TICKET_LOCK=ON && ninja -C build
     cmake -S . -B build -DUSE_CAPNP=ON && ninja -C build
+    cmake -S . -B build -DUSE_SIMD=ON && ninja -C build
 
 Using Meson::
 
     USE_TICKET_LOCK=1 meson setup build && ninja -C build
     USE_CAPNP=1 meson setup build && ninja -C build
+    USE_SIMD=1 meson setup build && ninja -C build
 
 To switch back to qspinlocks::
 

--- a/engine/user/math_core.c
+++ b/engine/user/math_core.c
@@ -1,10 +1,46 @@
 #include "math_core.h"
 
+#ifdef USE_SIMD
+#  if defined(__SSE2__) && __has_include(<emmintrin.h>)
+#    include <emmintrin.h>
+#    define SIMD_SSE2 1
+#  elif (defined(__ARM_NEON) || defined(__ARM_NEON__)) && __has_include(<arm_neon.h>)
+#    include <arm_neon.h>
+#    define SIMD_NEON 1
+#  endif
+#endif
+
 // Return the golden ratio constant.
 double phi(void) { return 1.618033988749895; }
 
 // Compute the n-th Fibonacci number with F(0) = 0 and F(1) = 1.
 uint64_t fib(uint32_t n) {
+#if defined(SIMD_SSE2)
+  if (n == 0)
+    return 0;
+  union {
+    __m128i v;
+    uint64_t u[2];
+  } state;
+  state.u[0] = 0;
+  state.u[1] = 1;
+  for (uint32_t i = 1; i < n; i++) {
+    __m128i shifted = _mm_slli_si128(state.v, 8);
+    __m128i sum = _mm_add_epi64(state.v, shifted);
+    state.v = _mm_unpackhi_epi64(sum, state.v);
+  }
+  return state.u[1];
+#elif defined(SIMD_NEON)
+  if (n == 0)
+    return 0;
+  uint64x2_t v = {0, 1};
+  for (uint32_t i = 1; i < n; i++) {
+    uint64x2_t shifted = vextq_u64(v, v, 1);
+    uint64x2_t sum = vaddq_u64(v, shifted);
+    v = vextq_u64(v, sum, 1);
+  }
+  return vgetq_lane_u64(v, 1);
+#else
   if (n == 0)
     return 0;
   uint64_t a = 0;
@@ -15,6 +51,7 @@ uint64_t fib(uint32_t n) {
     b = t;
   }
   return b;
+#endif
 }
 
 #ifdef __BITINT_MAXWIDTH__
@@ -42,6 +79,37 @@ uint64_t fib_big(uint32_t n) {
 
 // Compute the greatest common divisor using Euclid's algorithm.
 uint64_t gcd(uint64_t a, uint64_t b) {
+#if defined(SIMD_SSE2)
+  while (a != b) {
+    if (a > b) {
+      __m128i va = _mm_set_epi64x(0, a);
+      __m128i vb = _mm_set_epi64x(0, b);
+      va = _mm_sub_epi64(va, vb);
+      a = (uint64_t)_mm_cvtsi128_si64(va);
+    } else {
+      __m128i va = _mm_set_epi64x(0, b);
+      __m128i vb = _mm_set_epi64x(0, a);
+      va = _mm_sub_epi64(va, vb);
+      b = (uint64_t)_mm_cvtsi128_si64(va);
+    }
+  }
+  return a;
+#elif defined(SIMD_NEON)
+  while (a != b) {
+    if (a > b) {
+      uint64x2_t va = {0, a};
+      uint64x2_t vb = {0, b};
+      uint64x2_t res = vsubq_u64(va, vb);
+      a = vgetq_lane_u64(res, 1);
+    } else {
+      uint64x2_t va = {0, b};
+      uint64x2_t vb = {0, a};
+      uint64x2_t res = vsubq_u64(va, vb);
+      b = vgetq_lane_u64(res, 1);
+    }
+  }
+  return a;
+#else
   // Euclid's algorithm without division to avoid libgcc helpers
   while (a != b) {
     if (a > b)
@@ -50,6 +118,7 @@ uint64_t gcd(uint64_t a, uint64_t b) {
       b -= a;
   }
   return a;
+#endif
 }
 
 // Round up to the nearest Fibonacci number or integer multiple of phi.

--- a/meson.build
+++ b/meson.build
@@ -4,12 +4,16 @@ add_project_arguments('-Wall', '-Werror', language: ['c', 'cpp'])
 use_ticket_lock = get_option('use_ticket_lock')
 ipc_debug = get_option('ipc_debug')
 use_capnp = get_option('use_capnp')
+use_simd = get_option('use_simd')
 common_cargs = []
 if use_ticket_lock
   common_cargs += ['-DUSE_TICKET_LOCK']
 endif
 if ipc_debug
   common_cargs += ['-DIPC_DEBUG']
+endif
+if use_simd
+  common_cargs += ['-DUSE_SIMD']
 endif
 
 clang_tidy = find_program('clang-tidy', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,3 +1,4 @@
 option('use_ticket_lock', type: 'boolean', value : false, description : 'Use ticket-based spinlocks instead of qspinlock')
 option('ipc_debug', type: 'boolean', value : false, description : 'Enable IPC debug logging')
 option('use_capnp', type: 'boolean', value : false, description : 'Build Cap\'n Proto support')
+option('use_simd', type: 'boolean', value : false, description : 'Enable SIMD math routines')


### PR DESCRIPTION
## Summary
- add a USE_SIMD build option to CMake and Meson
- implement optional SSE2/NEON versions of fibonacci and gcd
- document USE_SIMD flag in README

## Testing
- `shellcheck setup.sh` *(fails: command not found)*
- `pre-commit run --files engine/user/math_core.c README meson.build meson_options.txt CMakeLists.txt` *(fails: command not found)*
- `bats -r tests` *(fails: command not found)*