### PR TITLE
Improve offline package README

### DIFF
--- a/offline_packages/README.md
+++ b/offline_packages/README.md
@@ -1,7 +1,21 @@
-This directory holds Debian package files (.deb) for offline installation.
-Place each required package listed below in this directory before running
-`./setup.sh --offline`. Obtain packages with `apt-get download <package>=<version>`
-on a machine with network access.
+This directory holds Debian package files (`.deb`) used when running
+`./setup.sh --offline`.  Collect the packages on a machine with network
+access and copy them here before invoking the setup script.
+
+Steps to gather the packages:
+
+1. On an Ubuntu 24.04 system run `sudo apt-get update`.
+2. For each package listed below run
+   `apt-cache policy <package>` to determine the exact version
+   that `setup.sh` will install.
+3. Download that version with `apt-get download <package>=<version>`.
+4. Verify each file with `dpkg-deb -f <package>.deb Version` and ensure the
+   version matches what you recorded from step&nbsp;2.
+5. Copy all downloaded `.deb` files into this directory.
+
+`setup.sh` uses `apt-cache` to determine package versions when it runs.
+If the versions here do not match those it expects, installation will fail
+in offline mode, so double-check each file.
 
 Example package versions tested on Ubuntu 24.04:
 


### PR DESCRIPTION
## Summary
- clarify how to gather `.deb` files for offline installation
- explain verifying package versions to match `setup.sh`

## Testing
- `bats tests` *(fails: command not found)*
- `curl -L https://raw.githubusercontent.com/Oichkatzel/exov6/master/setup.sh` *(fails: network unreachable)*