### PR TITLE
Document STREAMS helpers and add flow control demo

### DIFF
--- a/TODO_STREAMS.md
+++ b/TODO_STREAMS.md
@@ -5,7 +5,14 @@ This file collects outstanding tasks for the prototype STREAMS implementation. T
 ## Core functionality
 
 - Integrate the STREAMS callbacks with the kernel scheduler to replace the current stubs.
-- Flesh out `streams_stop()` and `streams_yield()` so that modules can halt or yield control as intended.
+- Flesh out `streams_stop()` and `streams_yield()` so that modules can halt or
+  yield control as intended. `streams_stop()` should tear down the current
+  pipeline and wake the scheduler so that resources can be reclaimed.  Modules
+  calling this helper must ensure any outbound messages are flushed before the
+  thread exits. `streams_yield()` should temporarily hand execution back to the
+  scheduler while preserving the module's state, allowing other STREAMS threads
+  to make progress. The function needs to save the context of the yielding
+  module and mark it runnable so that the scheduler can resume it later.
 
 ## Testing and tooling
 

--- a/demos/examples/fc_tuning_demo.py
+++ b/demos/examples/fc_tuning_demo.py
@@ -1,0 +1,25 @@
+"""Example showing dynamic tuning of STREAMS flow control constants."""
+
+import os
+from pathlib import Path
+
+import sys
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import flow_pid
+
+
+def main() -> None:
+    """Demonstrate adjusting Kp, Ki and Kd via procfs entries."""
+    flow_pid.flow_pid_init()
+    print("Initial constants:", flow_pid.constants)
+
+    flow_pid.set_kp(flow_pid.constants["Kp"] * 1.5)
+    flow_pid.set_ki(0.1)
+    flow_pid.set_kd(0.05)
+
+    print("Updated constants:", flow_pid.constants)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- expand `streams_stop()` and `streams_yield()` notes in `TODO_STREAMS.md`
- add `fc_tuning_demo.py` example for adjusting `/proc/streams/fc/`

## Testing
- `bats tests` *(fails: `bash: bats: command not found`)*