### PR TITLE
Add metrics tool and CI workflow

### DIFF
--- a/.github/workflows/phoenix_ci.yml
+++ b/.github/workflows/phoenix_ci.yml
@@ -1,0 +1,42 @@
+name: Phoenix CI
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install deps
+        run: sudo apt-get update && sudo apt-get install -y clang make cmake ninja-build
+      - name: Build ISA variants
+        run: |
+          chmod +x scripts/build_isa_variants.sh
+          ./scripts/build_isa_variants.sh
+      - name: Build metrics tool
+        run: clang -std=c2x -O2 tools/phoenix_metrics.c -o tools/phoenix_metrics
+      - name: Run benchmarks
+        run: |
+          mkdir bench_results
+          for v in $(ls build/isa); do
+            make -C tests/microbench run > bench_results/${v}_bench.txt
+            ./tools/phoenix_metrics engine/kernel 1 > bench_results/${v}_metrics.txt || true
+          done
+      - name: Check purity
+        run: |
+          fail=0
+          for f in bench_results/*_metrics.txt; do
+            purity=$(grep '^PURITY' "$f" | cut -d':' -f2)
+            if awk "BEGIN{exit !( $purity >= 1 )}"; then
+              echo "Purity for $f ok ($purity)"
+            else
+              echo "Purity below threshold: $purity"
+              fail=1
+            fi
+          done
+          exit $fail
+      - uses: actions/upload-artifact@v3
+        with:
+          name: bench-results
+          path: bench_results

--- a/tools/phoenix_metrics.c
+++ b/tools/phoenix_metrics.c
@@ -1,0 +1,115 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <ctype.h>
+#include <dirent.h>
+#include <sys/stat.h>
+#include <stdbool.h>
+
+static bool has_suffix(const char *name, const char *suf) {
+  size_t n = strlen(name), m = strlen(suf);
+  return n >= m && strcmp(name + n - m, suf) == 0;
+}
+
+static int count_sloc_in_file(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (!f)
+    return 0;
+  int sloc = 0;
+  bool in_block = false;
+  char line[512];
+  while (fgets(line, sizeof(line), f)) {
+    char *p = line;
+    while (isspace((unsigned char)*p))
+      p++;
+    if (*p == '\0')
+      continue;
+    if (in_block) {
+      char *end = strstr(p, "*/");
+      if (end)
+        in_block = false;
+      continue;
+    }
+    if (strncmp(p, "//", 2) == 0)
+      continue;
+    if (strncmp(p, "/*", 2) == 0) {
+      if (!strstr(p + 2, "*/"))
+        in_block = true;
+      continue;
+    }
+    sloc++;
+  }
+  fclose(f);
+  return sloc;
+}
+
+static int count_structs_in_file(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (!f)
+    return 0;
+  int count = 0;
+  char line[512];
+  while (fgets(line, sizeof(line), f)) {
+    char *p = strstr(line, "struct ");
+    if (p && strstr(p, "{"))
+      count++;
+  }
+  fclose(f);
+  return count;
+}
+
+static int count_simd_in_file(const char *path) {
+  FILE *f = fopen(path, "r");
+  if (!f)
+    return 0;
+  int count = 0;
+  char line[512];
+  while (fgets(line, sizeof(line), f)) {
+    if (strstr(line, "_mm") || strstr(line, "SIMD") || strstr(line, "sse") ||
+        strstr(line, "avx") || strstr(line, "neon"))
+      count++;
+  }
+  fclose(f);
+  return count;
+}
+
+static void scan_dir(const char *dir, int *sloc, int *structs, int *simd) {
+  DIR *d = opendir(dir);
+  if (!d)
+    return;
+  struct dirent *ent;
+  while ((ent = readdir(d))) {
+    if (strcmp(ent->d_name, ".") == 0 || strcmp(ent->d_name, "..") == 0)
+      continue;
+    char path[512];
+    snprintf(path, sizeof(path), "%s/%s", dir, ent->d_name);
+    struct stat st;
+    if (stat(path, &st) < 0)
+      continue;
+    if (S_ISDIR(st.st_mode)) {
+      scan_dir(path, sloc, structs, simd);
+    } else if (has_suffix(ent->d_name, ".c") || has_suffix(ent->d_name, ".h")) {
+      *sloc += count_sloc_in_file(path);
+      *structs += count_structs_in_file(path);
+      *simd += count_simd_in_file(path);
+    }
+  }
+  closedir(d);
+}
+
+int main(int argc, char *argv[]) {
+  const char *root = argc > 1 ? argv[1] : "engine/kernel";
+  double threshold = -1.0;
+  if (argc > 2)
+    threshold = atof(argv[2]);
+  int sloc = 0, structs = 0, simd = 0;
+  scan_dir(root, &sloc, &structs, &simd);
+  double purity = sloc ? ((double)structs / (double)sloc) * 100.0 : 0.0;
+  printf("SLOC:%d\nABSTRACTIONS:%d\nSIMD:%d\nPURITY:%.2f\n", sloc, structs,
+         simd, purity);
+  if (threshold >= 0.0 && purity < threshold) {
+    fprintf(stderr, "Purity %.2f below threshold %.2f\n", purity, threshold);
+    return 1;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary
- implement `phoenix_metrics.c` for kernel SLOC, abstraction and SIMD counts
- add CI workflow to build architecture variants, run microbenchmarks and check purity score

## Testing
- `pytest -q` *(fails: invalid application of ‘sizeof’ to incomplete type)*
