### PR TITLE
Add formal verification scaffolding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,3 +18,7 @@ You can also run all checks manually with:
 pre-commit run --all-files
 ```
 
+
+Formal models describing parts of the system live under the `formal/`
+directory. See `doc/formal_models.md` for instructions on building and
+extending these models.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,16 @@
-.PHONY: proof
+.PHONY: proof formal
 
 proof:
 	$(MAKE) -C coq all
+
+formal:
+	@if command -v coqc >/dev/null 2>&1; then \
+	  $(MAKE) -C formal/coq all; \
+	else \
+		  echo "coqc not found; skipping Coq build"; \
+	fi
+	@if command -v tlc >/dev/null 2>&1; then \
+		  tlc formal/tla/ExoCap.tla >/dev/null; \
+	else \
+		  echo "tlc not found; skipping TLA+ check"; \
+	fi

--- a/README
+++ b/README
@@ -569,3 +569,10 @@ An optional workflow installs the Codex CLI and executes `setup.sh` automaticall
 
 A minimal dev container configuration lives under `.devcontainer`. Opening the project in a Codespace installs Codex and runs `codex -q 'doctor setup.sh'` during initialization.
 
+
+FORMAL MODELS
+-------------
+Coq and TLA+ specifications live under the `formal/` directory. Run
+`make -C formal/coq` to type-check the Coq proofs and `tlc
+formal/tla/ExoCap.tla` to explore the TLA+ models. See
+`doc/formal_models.md` for details on extending the models.

--- a/doc/formal_models.md
+++ b/doc/formal_models.md
@@ -1,0 +1,31 @@
+# Working with Formal Models
+
+The `formal/` directory houses small Coq developments and TLA+
+specifications.  Contributors can extend these models to capture new
+behaviour or prove additional properties.
+
+## Building
+
+```
+make -C formal/coq
+```
+
+compiles the Coq files. The TLA+ specs can be explored with the
+`tlc` model checker:
+
+```
+tlc formal/tla/ExoCap.tla
+```
+
+Both tools are optional. The build will skip these steps if the
+commands are unavailable.
+
+## Extending the Models
+
+- Place new Coq modules under `formal/coq/` and list them in
+  `formal/coq/_CoqProject`.
+- Add new TLA+ modules under `formal/tla/` and reference them in
+  the documentation or tests as needed.
+
+Formal models should remain lightweight and easy to build so they can
+run as part of the continuous integration tests.

--- a/formal/README.md
+++ b/formal/README.md
@@ -1,0 +1,13 @@
+# Formal Models
+
+This directory collects formal specifications of selected subsystem APIs.
+
+- `coq/` contains Coq proofs.
+- `tla/` contains TLA+ specifications checked with `tlc`.
+
+Run `make -C formal/coq` to type-check the Coq development. To model
+check the TLA+ specs run `tlc formal/tla/ExoCap.tla` if the `tlc`
+command is available.
+
+New `.v` or `.tla` files can be added to extend the models. Update
+`formal/coq/_CoqProject` when adding new Coq modules.

--- a/formal/coq/ExoCap.v
+++ b/formal/coq/ExoCap.v
@@ -1,0 +1,21 @@
+Record exo_cap := { cid : nat; rights : N; owner : nat; tag : N }.
+
+Definition compute_tag (id : nat) (rights : N) (owner : nat) : N :=
+  (N.of_nat id + rights + N.of_nat owner)%N.
+
+Definition cap_new (id : nat) (rights : N) (owner : nat) : exo_cap :=
+  {| cid := id; rights := rights; owner := owner;
+     tag := compute_tag id rights owner |}.
+
+Definition cap_verify (c : exo_cap) : bool :=
+  N.eqb (compute_tag (cid c) (rights c) (owner c)) (tag c).
+
+Definition cap_has_rights (r need : N) : bool :=
+  N.eqb (N.land r need) need.
+
+Lemma cap_new_verify : forall id r o,
+  cap_verify (cap_new id r o) = true.
+Proof.
+  intros; unfold cap_verify, cap_new, compute_tag; simpl.
+  now rewrite N.eqb_refl.
+Qed.

--- a/formal/coq/Makefile
+++ b/formal/coq/Makefile
@@ -1,0 +1,9 @@
+VOFILES=ExoCap.vo
+
+all: $(VOFILES)
+
+%.vo: %.v
+coqc $<
+
+clean:
+rm -f $(VOFILES) *.glob *.vo *.vio

--- a/formal/coq/_CoqProject
+++ b/formal/coq/_CoqProject
@@ -1,0 +1,1 @@
+-Q . ExoCap

--- a/formal/tla/ExoCap.tla
+++ b/formal/tla/ExoCap.tla
@@ -1,0 +1,23 @@
+---- MODULE ExoCap ----
+EXTENDS Naturals, TLC
+
+VARIABLES cid, rights, owner, tag
+
+ComputeTag(id, r, o) == id + r + o
+
+Init == /\ cid \in Nat
+        /\ rights \in Nat
+        /\ owner \in Nat
+        /\ tag = ComputeTag(cid, rights, owner)
+
+HasRights(r, need) == (r /\ need) = need
+Verify == ComputeTag(cid, rights, owner) = tag
+
+Next == UNCHANGED <<cid, rights, owner, tag>>
+
+Spec == Init /\ [][Next]_<<cid, rights, owner, tag>>
+
+Inv == Verify
+
+THEOREM Inv => []Inv
+=============================================================================

--- a/tests/test_formal_models.py
+++ b/tests/test_formal_models.py
@@ -1,0 +1,49 @@
+import os
+import shutil
+import subprocess
+import random
+import pytest
+
+ROOT = os.path.dirname(os.path.dirname(__file__))
+
+# simple python model mirroring formal specs
+
+def compute_tag(i, r, o):
+    return i + r + o
+
+def cap_new(i, r, o):
+    return {"id": i, "rights": r, "owner": o, "tag": compute_tag(i, r, o)}
+
+def cap_verify(c):
+    return compute_tag(c["id"], c["rights"], c["owner"]) == c["tag"]
+
+def cap_has_rights(r, need):
+    return (r & need) == need
+
+
+def test_cap_new_verify():
+    for _ in range(100):
+        i = random.randint(0, 1000)
+        rights = random.randint(0, 15)
+        owner = random.randint(0, 1000)
+        c = cap_new(i, rights, owner)
+        assert cap_verify(c)
+
+
+def test_cap_has_rights_prop():
+    for _ in range(100):
+        rights = random.randint(0, 15)
+        need = random.randint(0, 15)
+        assert cap_has_rights(rights, need) == ((rights & need) == need)
+
+
+def test_coq_build():
+    if not shutil.which("coqc"):
+        pytest.skip("coqc not installed")
+    subprocess.check_call(["make", "-C", os.path.join(ROOT, "formal", "coq")])
+
+
+def test_tla_model():
+    if not shutil.which("tlc"):
+        pytest.skip("tlc not installed")
+    subprocess.check_call(["tlc", os.path.join(ROOT, "formal", "tla", "ExoCap.tla")])


### PR DESCRIPTION
## Summary
- establish `formal/` with Coq and TLA+ examples
- integrate optional `formal` target in Makefile
- provide contributor docs for extending the models
- add property-based tests exercising the models

## Testing
- `pytest -q` *(fails: struct sigaction not defined, g++/clang compile errors)*