### PR TITLE
Add pre-commit configuration and docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,13 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v16.0.0
+    hooks:
+      - id: clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-tidy
+    rev: v16.0.0
+    hooks:
+      - id: clang-tidy
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,8 @@ To run formatting and static analysis checks automatically on commit, this repos
 pip install pre-commit
 ```
 
-Once installed, set up the hooks with:
+Once installed, set up the hooks with the configuration in
+`.pre-commit-config.yaml` using:
 
 ```sh
 pre-commit install

--- a/README
+++ b/README
@@ -143,7 +143,10 @@ Heavy machine learning frameworks are intentionally omitted to keep the
 environment small.  Formatting and linting tools like ``clang-format`` and
 ``clang-tidy`` can be run manually when needed.
 
-The checks will run on every commit thereafter.
+For automated formatting and linting the repository provides a
+``.pre-commit-config.yaml`` file. Install the hooks with ``pre-commit
+install`` to run these checks automatically. The checks will run on every
+commit thereafter.
 
 
 TESTING


### PR DESCRIPTION
## Summary
- add a `.pre-commit-config.yaml` with clang-format, clang-tidy and flake8
- reference the configuration in `CONTRIBUTING.md`
- document optional pre-commit setup in the README

## Testing
- `pytest -q` *(fails: invalid use of undefined type 'struct sigaction')*