### PR TITLE
Document qspinlock usage for RPC

### DIFF
--- a/engine/kernel/qspinlock.c
+++ b/engine/kernel/qspinlock.c
@@ -1,4 +1,7 @@
 #include "qspinlock.h"
+// Implementation of the randomized spinlock variant.
+// See doc/qspinlock.md for usage notes and the danger of holding
+// a lock across RPC calls.
 #include <stdint.h>
 #include <compiler_attrs.h>
 #if __has_include(<config.h>)

--- a/engine/kernel/spinlock.c
+++ b/engine/kernel/spinlock.c
@@ -1,4 +1,6 @@
 // Mutual exclusion spin locks.
+// See doc/qspinlock.md for guidelines on using qspinlocks in
+// STREAMS and RPC handlers.
 
 #include "types.h"
 #include "defs.h"


### PR DESCRIPTION
## Summary
- expand qspinlock guide with STREAMS and RPC guidance
- warn about holding locks across RPC calls
- cross-reference the doc in spinlock and qspinlock code

## Testing
- `pytest -q` *(fails: g++/clang not available)*