### PR TITLE
Implement STREAMS helpers

### DIFF
--- a/TODO_STREAMS.md
+++ b/TODO_STREAMS.md
@@ -1,18 +1,18 @@
-# STREAMS Prototype TODOs
+#STREAMS Prototype TODOs
 
 This file collects outstanding tasks for the prototype STREAMS implementation. The list is non-exhaustive and mainly serves as a placeholder for future development notes.
 
 ## Core functionality
 
 - Integrate the STREAMS callbacks with the kernel scheduler to replace the current stubs.
-- Flesh out `streams_stop()` and `streams_yield()` so that modules can halt or
+- ~~Flesh out `streams_stop()` and `streams_yield()` so that modules can halt or
   yield control as intended. `streams_stop()` should tear down the current
   pipeline and wake the scheduler so that resources can be reclaimed.  Modules
   calling this helper must ensure any outbound messages are flushed before the
   thread exits. `streams_yield()` should temporarily hand execution back to the
   scheduler while preserving the module's state, allowing other STREAMS threads
   to make progress. The function needs to save the context of the yielding
-  module and mark it runnable so that the scheduler can resume it later.
+  module and mark it runnable so that the scheduler can resume it later.~~
 
 ## Testing and tooling
 

--- a/engine/user/user/exo_stream_demo.c
+++ b/engine/user/user/exo_stream_demo.c
@@ -1,9 +1,12 @@
 #include <stdio.h>
 #include <stdint.h>
+#include "spinlock.h"
+#include "exo_stream.h"
+#include "defs.h"
 
 typedef struct exo_cap {
-    uint32_t pa;
-    uint32_t id;
+  uint32_t pa;
+  uint32_t id;
 } exo_cap;
 
 // Minimal stub implementations used when kernel support is absent.
@@ -13,21 +16,42 @@ int exo_yield_to(exo_cap *target) {
 }
 
 // Simple user-level demonstration for exo_yield_to
-int exo_yield_to_demo(exo_cap target)
-{
-    printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
-    return 0;
+int exo_yield_to_demo(exo_cap target) {
+  printf(1, "exo_yield_to called with cap %p\n", (void *)target.id);
+  return 0;
 }
 
-void streams_stop(void) { printf("streams_stop called\n"); }
-void streams_yield(void) { printf("streams_yield called\n"); }
+static struct spinlock streams_lock;
+
+/*
+ * Stop processing the current STREAMS pipeline. Release any held lock and
+ * wake the scheduler so resources can be reclaimed.
+ */
+void streams_stop(void) {
+  if (streams_lock.name)
+    release(&streams_lock);
+  exo_stream_halt();
+  yield();
+}
+
+/*
+ * Yield execution of the current STREAMS module. The lock guarding the
+ * stream state is released before returning control to the scheduler.
+ */
+void streams_yield(void) {
+  if (streams_lock.name)
+    release(&streams_lock);
+  exo_stream_yield();
+  yield();
+}
 
 int main(int argc, char **argv) {
-    (void)argc; (void)argv;
-    exo_cap other = {0, 42};
-    exo_yield_to(&other);
-    exo_yield_to_demo(other);
-    streams_yield();
-    streams_stop();
-    return 0;
+  (void)argc;
+  (void)argv;
+  exo_cap other = {0, 42};
+  exo_yield_to(&other);
+  exo_yield_to_demo(other);
+  streams_yield();
+  streams_stop();
+  return 0;
 }


### PR DESCRIPTION
## Summary
- implement real `streams_stop()` and `streams_yield()`
- mark STREAMS TODOs as complete

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError due to missing build deps)*