### PR TITLE
Add variable-size typed channel support

### DIFF
--- a/engine/include/cap.h
+++ b/engine/include/cap.h
@@ -30,7 +30,7 @@ _Static_assert(sizeof(struct cap_entry) == 20, "ABI mismatch");
 #endif
 // Verify alignment remains stable across compilers
 #ifdef __cplusplus
-static_assert(_Alignof(struct cap_entry) == 4, "struct cap_entry alignment incorrect");
+static_assert(alignof(struct cap_entry) == 4, "struct cap_entry alignment incorrect");
 #else
 _Static_assert(_Alignof(struct cap_entry) == 4, "struct cap_entry alignment incorrect");
 #endif

--- a/engine/include/chan.h
+++ b/engine/include/chan.h
@@ -1,11 +1,12 @@
 #pragma once
 #include "types.h"
 #include "caplib.h"
+#include "ipc.h"
 
 // Generic channel descriptor storing expected message size and type
 typedef struct chan {
-  size_t msg_size;
-  const struct msg_type_desc *desc;
+  size_t msg_size;                       // maximum message size
+  const struct msg_type_desc *desc;      // encoding callbacks
 } chan_t;
 
 // Allocate a channel expecting messages of size msg_size bytes
@@ -22,9 +23,12 @@ void chan_destroy(chan_t *c);
 
 // Helper macro to declare a typed channel wrapper
 // Usage: CHAN_DECLARE(mychan, struct mymsg);
-// Provides mychan_t type with create/send/recv functions
+// Provides mychan_t type with create/send/recv functions using a fixed
+// maximum message size defined by `type##_MESSAGE_SIZE`.
 #define CHAN_DECLARE(name, type)                                               \
-  static const struct msg_type_desc name##_typedesc = {type##_MESSAGE_SIZE};   \
+  static const struct msg_type_desc name##_typedesc = {                        \
+      type##_MESSAGE_SIZE, 0, (msg_encode_fn)type##_encode,                    \
+      (msg_decode_fn)type##_decode};                                           \
   typedef struct {                                                             \
     chan_t base;                                                               \
   } name##_t;                                                                  \
@@ -34,13 +38,40 @@ void chan_destroy(chan_t *c);
   static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
   static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
-    type##_encode(m, buf);                                                     \
-    return chan_endpoint_send(&c->base, dest, buf, type##_MESSAGE_SIZE);       \
+    size_t len = type##_encode(m, buf);                                        \
+    return chan_endpoint_send(&c->base, dest, buf, len);                       \
   }                                                                            \
   static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
     unsigned char buf[type##_MESSAGE_SIZE];                                    \
     int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
-    if (r == 0)                                                                \
+    if (r >= 0)                                                                \
+      type##_decode(m, buf);                                                   \
+    return r;                                                                  \
+  }
+
+// Declare a typed channel for variable-size messages. The Cap'n Proto
+// helpers must encode into a buffer of `type##_MESSAGE_SIZE` bytes and
+// return the actual length written.
+#define CHAN_DECLARE_VAR(name, type)                                           \
+  static const struct msg_type_desc name##_typedesc = {                        \
+      type##_MESSAGE_SIZE, 0, (msg_encode_fn)type##_encode,                    \
+      (msg_decode_fn)type##_decode};                                           \
+  typedef struct {                                                             \
+    chan_t base;                                                               \
+  } name##_t;                                                                  \
+  static inline name##_t *name##_create(void) {                                \
+    return (name##_t *)chan_create(&name##_typedesc);                          \
+  }                                                                            \
+  static inline void name##_destroy(name##_t *c) { chan_destroy(&c->base); }   \
+  static inline int name##_send(name##_t *c, exo_cap dest, const type *m) {    \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    size_t len = type##_encode(m, buf);                                        \
+    return chan_endpoint_send(&c->base, dest, buf, len);                       \
+  }                                                                            \
+  static inline int name##_recv(name##_t *c, exo_cap src, type *m) {           \
+    unsigned char buf[type##_MESSAGE_SIZE];                                    \
+    int r = chan_endpoint_recv(&c->base, src, buf, type##_MESSAGE_SIZE);       \
+    if (r >= 0)                                                                \
       type##_decode(m, buf);                                                   \
     return r;                                                                  \
   }

--- a/engine/include/ipc.h
+++ b/engine/include/ipc.h
@@ -22,8 +22,15 @@ typedef struct {
   uint64_t w3;
 } zipc_msg_t;
 
+typedef size_t (*msg_size_fn)(const void *msg);
+typedef size_t (*msg_encode_fn)(const void *msg, unsigned char *buf);
+typedef size_t (*msg_decode_fn)(void *msg, const unsigned char *buf);
+
 typedef struct msg_type_desc {
-  size_t msg_size; // total message size in bytes
+  size_t msg_size;      // maximum message size in bytes
+  msg_size_fn size_cb;  // optional callback to compute encoded size
+  msg_encode_fn encode; // encode `msg` into `buf`, return bytes written
+  msg_decode_fn decode; // decode from `buf` into `msg`, return bytes read
 } msg_type_desc;
 
 static inline size_t msg_desc_size(const struct msg_type_desc *d) {

--- a/engine/kernel/chan.c
+++ b/engine/kernel/chan.c
@@ -9,8 +9,8 @@
     return -1;
   }
   size_t expected = msg_desc_size(c->desc);
-  if (len != expected) {
-    cprintf("chan_endpoint_send: size %d != %d\n", (int)len, (int)expected);
+  if (len > expected) {
+    cprintf("chan_endpoint_send: size %d > %d\n", (int)len, (int)expected);
     return -1;
   }
   return exo_send(dest, msg, len);
@@ -24,8 +24,8 @@
     return -1;
   }
   size_t expected = msg_desc_size(c->desc);
-  if (len != expected) {
-    cprintf("chan_endpoint_recv: size %d != %d\n", (int)len, (int)expected);
+  if (len > expected) {
+    cprintf("chan_endpoint_recv: size %d > %d\n", (int)len, (int)expected);
     return -1;
   }
   return exo_recv(src, msg, len);

--- a/engine/user/chan.c
+++ b/engine/user/chan.c
@@ -15,20 +15,20 @@ void chan_destroy(chan_t *c) { free(c); }
 
 [[nodiscard]] int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg,
                                      size_t len) {
-  if (len != c->msg_size) {
-    printf(2, "chan_endpoint_send: size %d != %d\n", (int)len,
+  if (len > c->msg_size) {
+    printf(2, "chan_endpoint_send: size %d > %d\n", (int)len,
            (int)c->msg_size);
     return -1;
   }
-  return cap_send(dest, msg, c->msg_size);
+  return cap_send(dest, msg, len);
 }
 
 [[nodiscard]] int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg,
                                      size_t len) {
-  if (len != c->msg_size) {
-    printf(2, "chan_endpoint_recv: size %d != %d\n", (int)len,
+  if (len > c->msg_size) {
+    printf(2, "chan_endpoint_recv: size %d > %d\n", (int)len,
            (int)c->msg_size);
     return -1;
   }
-  return cap_recv(src, msg, c->msg_size);
+  return cap_recv(src, msg, len);
 }

--- a/engine/user/user/typed_chan_demo.c
+++ b/engine/user/user/typed_chan_demo.c
@@ -2,34 +2,51 @@
 #include "user.h"
 #include "chan.h"
 #include "capnp_helpers.h"
-#include "proto/driver.capnp.h"
 
-CHAN_DECLARE(ping_chan, DriverPing);
+typedef struct {
+    uint8_t len;
+    char data[8];
+} VarMsg;
+
+static size_t VarMsg_encode(const VarMsg *m, unsigned char *buf) {
+    if(buf){
+        buf[0] = m->len;
+        for(size_t i=0;i<m->len;i++)
+            buf[1+i] = m->data[i];
+    }
+    return 1 + m->len;
+}
+
+static size_t VarMsg_decode(VarMsg *m, const unsigned char *buf) {
+    m->len = buf[0];
+    for(size_t i=0;i<m->len;i++)
+        m->data[i] = buf[1+i];
+    m->data[m->len] = '\0';
+    return 1 + m->len;
+}
+
+#define VarMsg_MESSAGE_SIZE 9
+
+CHAN_DECLARE_VAR(ping_chan, VarMsg);
 
 int
 main(int argc, char *argv[])
 {
     (void)argc; (void)argv;
     ping_chan_t *c = ping_chan_create();
-    DriverPing msg = { .value = 123 };
+    VarMsg msg = { .len = 5, .data = "hello" };
     exo_cap cap = {0};
     ping_chan_send(c, cap, &msg);
-    DriverPing out = {0};
+    VarMsg out = {0};
     ping_chan_recv(c, cap, &out);
-    printf(1, "typed channel message %d\n", out.value);
+    printf(1, "variable message: %s\n", out.data);
 
-    // Demonstrate failure when message sizes do not match
-    char bad[1] = {0};
-    int r = chan_endpoint_send(&c->base, cap, bad, sizeof(bad));
-    printf(1, "bad send result %d\n", r);
-    r = chan_endpoint_recv(&c->base, cap, bad, sizeof(bad));
-    printf(1, "bad recv result %d\n", r);
-
-    // Correct usage again
+    msg.len = 3;
+    msg.data[0] = 'b'; msg.data[1] = 'y'; msg.data[2] = 'e';
     ping_chan_send(c, cap, &msg);
     memset(&out, 0, sizeof(out));
     ping_chan_recv(c, cap, &out);
-    printf(1, "typed channel message %d\n", out.value);
+    printf(1, "variable message: %s\n", out.data);
     ping_chan_destroy(c);
     exit();
 }

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -11,28 +11,30 @@ C_CODE = textwrap.dedent(
 #include <stddef.h>
 
 typedef struct { unsigned int id; } exo_cap;
-typedef struct { size_t msg_size; } msg_type_desc;
+typedef size_t (*msg_size_fn)(const void *msg);
+typedef size_t (*msg_encode_fn)(const void *msg, unsigned char *buf);
+typedef size_t (*msg_decode_fn)(void *msg, const unsigned char *buf);
+typedef struct { size_t msg_size; msg_size_fn size_cb; msg_encode_fn encode; msg_decode_fn decode; } msg_type_desc;
 typedef struct { size_t msg_size; const msg_type_desc *desc; } chan_t;
 
 int chan_endpoint_send(chan_t *c, exo_cap dest, const void *msg, size_t len) {
-    (void)dest;
-    if (!c || len != c->msg_size)
+    (void)dest; (void)msg;
+    if (!c || len > c->msg_size)
         return -1;
-    return 0;
+    return (int)len;
 }
 int chan_endpoint_recv(chan_t *c, exo_cap src, void *msg, size_t len) {
-    (void)src;
-    (void)msg;
-    if (!c || len != c->msg_size)
+    (void)src; (void)msg;
+    if (!c || len > c->msg_size)
         return -1;
-    return 0;
+    return (int)len;
 }
 
 int main(void) {
-    msg_type_desc d = {sizeof(int)};
+    msg_type_desc d = {sizeof(int), 0, 0, 0};
     chan_t c = {d.msg_size, &d};
     int m = 5;
-    assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == 0);
+    assert(chan_endpoint_send(&c, (exo_cap){0}, &m, sizeof(m)) == sizeof(m));
     unsigned char bad = 0;
     assert(chan_endpoint_send(&c, (exo_cap){0}, &bad, sizeof(bad)) < 0);
     return 0;


### PR DESCRIPTION
## Summary
- extend `msg_type_desc` with runtime callbacks
- allow channel helpers to work with variable sized messages
- add `CHAN_DECLARE_VAR` macro
- update demos to send variable length buffers
- document variable typed channels

## Testing
- `pytest -q` *(fails: missing dependencies or build issues)*