### PR TITLE
Add SIMD capability placeholders

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 add_compile_options(-Wall -Werror)
 
-# Enable decimal floating point when supported
+#Enable decimal floating point when supported
 check_c_compiler_flag("-mdecimal-float" HAVE_DECIMAL_FLOAT)
 if(HAVE_DECIMAL_FLOAT)
   add_compile_options(-mdecimal-float)
@@ -79,20 +79,26 @@ if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "i.
     arch/x86/simd_x87.c
     arch/x86/simd_mmx.c
     arch/x86/simd_sse2.c
-    arch/x86/simd_avx.c)
+    arch/x86/simd_avx.c
+    arch/x86/legacy/simd_mmx_cap.c
+    arch/x86/modern/simd_avx2_cap.c)
   set_source_files_properties(arch/x86/simd_mmx.c PROPERTIES COMPILE_OPTIONS "-mmmx")
   set_source_files_properties(arch/x86/simd_sse2.c PROPERTIES COMPILE_OPTIONS "-msse2")
   set_source_files_properties(arch/x86/simd_avx.c PROPERTIES COMPILE_OPTIONS "-mavx")
+  set_source_files_properties(arch/x86/legacy/simd_mmx_cap.c PROPERTIES COMPILE_OPTIONS "-mmmx")
+  set_source_files_properties(arch/x86/modern/simd_avx2_cap.c PROPERTIES COMPILE_OPTIONS "-mavx2")
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" OR CMAKE_SYSTEM_PROCESSOR MATCHES "arm")
-  list(APPEND SIMD_SOURCES arch/arm/simd_neon.c)
+  list(APPEND SIMD_SOURCES arch/arm/simd_neon.c arch/arm/simd_neon_cap.c)
   set_source_files_properties(arch/arm/simd_neon.c PROPERTIES COMPILE_OPTIONS "-mfpu=neon")
+  set_source_files_properties(arch/arm/simd_neon_cap.c PROPERTIES COMPILE_OPTIONS "-mfpu=neon")
 endif()
 
 if(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc")
-  list(APPEND SIMD_SOURCES arch/ppc/simd_altivec.c)
+  list(APPEND SIMD_SOURCES arch/ppc/simd_altivec.c arch/ppc/simd_altivec_cap.c)
   set_source_files_properties(arch/ppc/simd_altivec.c PROPERTIES COMPILE_OPTIONS "-maltivec")
+  set_source_files_properties(arch/ppc/simd_altivec_cap.c PROPERTIES COMPILE_OPTIONS "-maltivec")
 endif()
 
 add_library(simd_dispatch STATIC ${SIMD_SOURCES})

--- a/arch/arm/simd_neon_cap.c
+++ b/arch/arm/simd_neon_cap.c
@@ -1,0 +1,12 @@
+#include <arm_neon.h>
+
+int cap_validate_neon(void) {
+  uint8x8_t z = vdup_n_u8(0);
+  return vget_lane_u8(z, 0);
+}
+
+void dag_process_neon(void) {
+  uint8x8_t a = vdup_n_u8(1);
+  uint8x8_t r = vadd_u8(a, a);
+  (void)r;
+}

--- a/arch/ppc/simd_altivec_cap.c
+++ b/arch/ppc/simd_altivec_cap.c
@@ -1,0 +1,14 @@
+#include <altivec.h>
+
+typedef __vector unsigned int v4u32;
+
+int cap_validate_altivec(void) {
+  v4u32 z = vec_splats((unsigned int)0);
+  return (int)vec_extract(z, 0);
+}
+
+void dag_process_altivec(void) {
+  v4u32 a = vec_splats((unsigned int)1);
+  v4u32 r = vec_add(a, a);
+  (void)r;
+}

--- a/arch/x86/legacy/simd_mmx_cap.c
+++ b/arch/x86/legacy/simd_mmx_cap.c
@@ -1,0 +1,13 @@
+#include <mmintrin.h>
+
+int cap_validate_mmx(void) {
+  __m64 z = _mm_setzero_si64();
+  return _mm_cvtsi64_si32(z);
+}
+
+void dag_process_mmx(void) {
+  __m64 a = _mm_set1_pi16(1);
+  __m64 b = _mm_add_pi16(a, a);
+  (void)b;
+  _mm_empty();
+}

--- a/arch/x86/modern/simd_avx2_cap.c
+++ b/arch/x86/modern/simd_avx2_cap.c
@@ -1,0 +1,12 @@
+#include <immintrin.h>
+
+int cap_validate_avx2(void) {
+  __m256i z = _mm256_setzero_si256();
+  return _mm256_extract_epi32(z, 0);
+}
+
+void dag_process_avx2(void) {
+  __m256i a = _mm256_set1_epi64x(1);
+  __m256i b = _mm256_add_epi64(a, a);
+  (void)b;
+}


### PR DESCRIPTION
## Summary
- add placeholder implementations for cap/dag intrinsics
- compile them for each supported ISA when available

## Testing
- `pytest -q` *(fails: CalledProcessError)*