### PR TITLE
Document runtime SIMD dispatch

### DIFF
--- a/doc/multi_architecture.md
+++ b/doc/multi_architecture.md
@@ -18,6 +18,41 @@ Supported values include:
 Additional architectures can be added by extending the CMake configuration
 and providing the necessary run scripts.
 
+## Runtime Feature Detection
+
+When `USE_SIMD` is enabled the runtime checks the host CPU before
+dispatching any vectorised routine.  `arch/simd_dispatch.c` performs the
+detection using the CPUID instruction on x86 and `getauxval()` on Linux
+for ARM and PowerPC.  The first supported extension found selects the
+implementation used by the math helpers.
+
+### Supported SIMD Backends
+
+The dispatch table currently recognises the following instruction sets:
+
+* x87 scalar floating point
+* MMX
+* SSE2 / SSE3
+* AVX and AVX2+FMA
+* AVX‑512
+* NEON (ARM)
+* AltiVec/VSX (PowerPC)
+
+The order of preference on x86 ranges from AVX‑512 down through AVX2,
+AVX, SSE3/2, MMX and finally x87.  ARM prefers NEON while PowerPC tries
+AltiVec.  If none of these are available the plain C implementations are
+used instead.
+
+## POSIX Wrappers and SIMD
+
+User programs link against `libos.a` which exposes POSIX-style wrappers.
+Those wrappers in turn call helper functions from
+`engine/user/math_core.c`.  At run time these helpers forward to the
+dispatch library so applications automatically benefit from the best
+available SIMD backend.  When compiled without `USE_SIMD` or when the
+required extension is missing the same wrappers transparently fall back
+to the scalar code paths.
+
 ## SIMD and CPU Feature Flags
 
 The optional `USE_SIMD` flag builds architecture specific math routines.
@@ -29,9 +64,10 @@ resulting binaries run on any compatible processor.
 ### Fallback Order
 
 At run time the SIMD dispatch library probes the host CPU and chooses the
-best available implementation.  On x86 the preference order is AVX, SSE2, MMX
-and finally x87.  ARM builds attempt NEON while PowerPC tries AltiVec/VSX.
-When none of these extensions are present the scalar routines are used.
+best available implementation.  On x86 the dispatcher prefers AVX‑512,
+then AVX2 with FMA, AVX, SSE3/SSE2, MMX and finally x87.  ARM builds
+attempt NEON while PowerPC tries AltiVec/VSX.  When none of these
+extensions are present the scalar routines are used.
 
 The script `scripts/build_isa_variants.sh` demonstrates building kernels for
 many of these feature sets.  Each variant ends up under `build/isa/` for

--- a/doc/phoenixkernel.md
+++ b/doc/phoenixkernel.md
@@ -79,6 +79,10 @@ cmake -S . -B build -G Ninja && ninja -C build
 The CMake build compiles the kernel and a handful of demo programs but
 does not generate the full set of utilities.
 
+For an overview of supported CPU architectures, SIMD backends and the
+runtime detection logic see
+[multi_architecture.md](multi_architecture.md).
+
 ## POSIX Compatibility in User Space
 
 Phoenix itself does not provide a POSIX interface. Instead the libOS layers POSIX system calls on top of the capability primitives. Files, processes and IPC endpoints are implemented in user space, allowing multiple runtimes to coexist. Programs written against POSIX headers simply link against `libos.a` and run unmodified on the exokernel.


### PR DESCRIPTION
## Summary
- explain runtime CPU feature detection
- enumerate SIMD backends from x87 to AVX-512, NEON and AltiVec
- note how the POSIX wrappers use these implementations
- add link from phoenixkernel.md

## Testing
- `pytest -q` *(fails: CalledProcessError, Assertion failed)*