### PR TITLE
Add MMX registration

### DIFF
--- a/arch/simd_dispatch.h
+++ b/arch/simd_dispatch.h
@@ -12,6 +12,7 @@ enum simd_feature {
   SIMD_FEATURE_AVX512,
   SIMD_FEATURE_NEON,
   SIMD_FEATURE_ALTIVEC,
+  SIMD_FEATURE_MMX,
 };
 
 typedef int (*cap_validate_fn_t)(void);

--- a/arch/x86/legacy/simd_mmx_cap.c
+++ b/arch/x86/legacy/simd_mmx_cap.c
@@ -1,4 +1,5 @@
 #include <mmintrin.h>
+#include "../../simd_dispatch.h"
 
 int cap_validate_mmx(void) {
   __m64 z = _mm_setzero_si64();
@@ -10,4 +11,9 @@ void dag_process_mmx(void) {
   __m64 b = _mm_add_pi16(a, a);
   (void)b;
   _mm_empty();
+}
+
+__attribute__((constructor))
+static void register_mmx(void) {
+  simd_register(SIMD_FEATURE_MMX, cap_validate_mmx, dag_process_mmx);
 }


### PR DESCRIPTION
## Summary
- register MMX capability on startup
- expose SIMD_FEATURE_MMX constant

## Testing
- `pytest -q` *(fails: subprocess.CalledProcessError)*