### PR TITLE
Update CI metrics build path

### DIFF
--- a/.github/workflows/phoenix_ci.yml
+++ b/.github/workflows/phoenix_ci.yml
@@ -20,7 +20,7 @@ jobs:
           # Build PowerPC AltiVec variant
           ARCH=ppc64 ISA_VARIANT="altivec" ./scripts/build_isa_variants.sh
       - name: Build metrics tool
-        run: clang -std=c2x -O2 tools/phoenix_metrics.c -o tools/phoenix_metrics
+        run: clang -std=c2x -O2 tools/profiling/phoenix_metrics.c -o tools/phoenix_metrics
       - name: Run tests and benchmarks
         run: |
           mkdir bench_results
@@ -28,7 +28,7 @@ jobs:
           for v in $variants; do
             make -C tests/microbench run > bench_results/${v}_bench.txt
             pytest -q > bench_results/${v}_tests.txt || true
-            ./tools/phoenix_metrics engine/kernel 1 > bench_results/${v}_metrics.txt || true
+            tools/phoenix_metrics engine/kernel 1 > bench_results/${v}_metrics.txt || true
           done
       - name: Check purity
         run: |

--- a/docs/profiling_metrics.md
+++ b/docs/profiling_metrics.md
@@ -5,6 +5,12 @@ development builds.  It exposes counters for SIMD instruction usage and
 scalar fallbacks along with timing hooks for IPC latency and context
 switch duration.
 
+For automated testing the same source is compiled as a standalone
+binary named `tools/phoenix_metrics`. The CI pipeline invokes this
+helper to gather SIMD counts, scalar fallbacks and latency numbers from
+the microbenchmark suite. The collected metrics are used to monitor
+performance trends across ISA variants.
+
 ## Building
 
 The tool is built as part of the standard build process:


### PR DESCRIPTION
## Summary
- build profiling metrics tool from `tools/profiling/phoenix_metrics.c`
- call the helper using the new location
- mention CI usage in the profiling metrics documentation

## Testing
- `pytest -q` *(fails: posix tests abort)*