### PR TITLE
Add stub source files for user libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,6 +116,10 @@ target_include_directories(simd_dispatch PUBLIC
   ${CMAKE_SOURCE_DIR}/tools
 )
 
+file(GLOB LIBPOSIX_SOURCES userspace/libposix/*.c)
+file(GLOB LIBBAREMETAL_SOURCES userspace/libbaremetal/*.c)
+file(GLOB LIB9P_SOURCES userspace/lib9p/*.c)
+
 set(LIBOS_SOURCES
   engine/user/ulib.c
   engine/user/printf.c
@@ -137,9 +141,9 @@ set(LIBOS_SOURCES
   engine/libos/microkernel/msg_router.c
   engine/libos/microkernel/resource_account.c
   engine/libos/microkernel/registration.c
-  userspace/libposix/*.c
-  userspace/libbaremetal/*.c
-  userspace/lib9p/*.c
+  ${LIBPOSIX_SOURCES}
+  ${LIBBAREMETAL_SOURCES}
+  ${LIB9P_SOURCES}
 )
 add_library(libos STATIC ${LIBOS_SOURCES})
 target_include_directories(libos PUBLIC

--- a/userspace/lib9p/stub.c
+++ b/userspace/lib9p/stub.c
@@ -1,0 +1,2 @@
+/* Minimal stub source to ensure library builds */
+void lib9p_stub(void) {}

--- a/userspace/libbaremetal/stub.c
+++ b/userspace/libbaremetal/stub.c
@@ -1,0 +1,2 @@
+/* Minimal stub source to ensure library builds */
+void libbaremetal_stub(void) {}

--- a/userspace/libposix/stub.c
+++ b/userspace/libposix/stub.c
@@ -1,0 +1,2 @@
+/* Minimal stub source to ensure library builds */
+void libposix_stub(void) {}


### PR DESCRIPTION
## Summary
- ensure CMake handles empty library directories
- add stub.c to libposix, libbaremetal, and lib9p

## Testing
- `cmake -S . -B build`
- `pytest -q` *(fails: test_chan_endpoint_validation, test_libnstr_graph.py, test_posix_apis.py)*