### PR TITLE
Implement rename/unlink wrappers

### DIFF
--- a/doc/posix_progress.md
+++ b/doc/posix_progress.md
@@ -38,8 +38,8 @@ This log tracks implementation status of the POSIX wrappers provided by the Phoe
 | `libos_connect` | Implemented | N/A | [posix.c](../libos/posix.c) |
 | `libos_send` | Implemented | N/A | [posix.c](../libos/posix.c) |
 | `libos_recv` | Implemented | N/A | [posix.c](../libos/posix.c) |
-| `libos_rename` | Missing | N/A | N/A |
-| `libos_unlink` | Missing | [unlink](ben-books/susv4-2018/utilities/unlink.html) | N/A |
+| `libos_rename` | Implemented | N/A | [posix.c](../libos/posix.c) |
+| `libos_unlink` | Implemented | [unlink](ben-books/susv4-2018/utilities/unlink.html) | [posix.c](../libos/posix.c) |
 | `libos_chdir` | Implemented | N/A | [posix.c](../libos/posix.c) |
 | `libos_getcwd` | Implemented | N/A | [posix.c](../libos/posix.c) |
 

--- a/doc/posix_wrapper_matrix.md
+++ b/doc/posix_wrapper_matrix.md
@@ -49,8 +49,8 @@ This table lists every wrapper provided by the Phoenix libOS. "Status" records w
 | `libos_sem_wait` | Implemented | N/A | [ipc.c](../engine/libos/ipc.c) | wait on semaphore via recv |
 | `libos_shm_alloc` | Implemented | N/A | [ipc.c](../engine/libos/ipc.c) | allocate page capability |
 | `libos_shm_free` | Implemented | N/A | [ipc.c](../engine/libos/ipc.c) | unbind page capability |
-| `libos_rename` | Missing | N/A | N/A | |
-| `libos_unlink` | Missing | [unlink](ben-books/susv4-2018/utilities/unlink.html) | N/A | |
+| `libos_rename` | Implemented | N/A | [posix.c](../engine/libos/posix.c) | |
+| `libos_unlink` | Implemented | [unlink](ben-books/susv4-2018/utilities/unlink.html) | [posix.c](../engine/libos/posix.c) | |
 | `libos_chdir` | Implemented | N/A | [posix.c](../engine/libos/posix.c) | |
 | `libos_getcwd` | Implemented | N/A | [posix.c](../engine/libos/posix.c) | |
 

--- a/engine/include/libos/libfs.h
+++ b/engine/include/libos/libfs.h
@@ -12,3 +12,5 @@ struct file *libfs_open(const char *path, int flags);
 int libfs_read(struct file *f, void *buf, size_t n);
 int libfs_write(struct file *f, const void *buf, size_t n);
 void libfs_close(struct file *f);
+int libfs_unlink(const char *path);
+int libfs_rename(const char *oldpath, const char *newpath);

--- a/engine/include/libos/posix.h
+++ b/engine/include/libos/posix.h
@@ -56,6 +56,9 @@ int libos_connect(int fd, const struct sockaddr *addr, socklen_t len);
 long libos_send(int fd, const void *buf, size_t len, int flags);
 long libos_recv(int fd, void *buf, size_t len, int flags);
 
+int libos_rename(const char *oldpath, const char *newpath);
+int libos_unlink(const char *path);
+
 int libos_setenv(const char *name, const char *value);
 const char *libos_getenv(const char *name);
 int libos_chdir(const char *path);

--- a/engine/libos/fs_ufs.c
+++ b/engine/libos/fs_ufs.c
@@ -66,3 +66,23 @@ void libfs_close(struct file *f) {
     fileclose(f);
 }
 
+int libfs_unlink(const char *path) {
+    struct vfile *vf = lookup_vfile(path);
+    if(!vf)
+        return -1;
+    vf->used = 0;
+    return 0;
+}
+
+int libfs_rename(const char *oldpath, const char *newpath) {
+    struct vfile *vf = lookup_vfile(oldpath);
+    if(!vf)
+        return -1;
+    struct vfile *dst = lookup_vfile(newpath);
+    if(dst)
+        dst->used = 0;
+    strncpy(vf->path, newpath, sizeof(vf->path)-1);
+    vf->path[sizeof(vf->path)-1] = '\0';
+    return 0;
+}
+

--- a/engine/libos/posix.c
+++ b/engine/libos/posix.c
@@ -104,6 +104,12 @@ int libos_mkdir(const char *path) { return mkdir(path, 0777); }
 
 int libos_rmdir(const char *path) { return unlink((char *)path); }
 
+int libos_unlink(const char *path) { return libfs_unlink(path); }
+
+int libos_rename(const char *oldpath, const char *newpath) {
+  return libfs_rename(oldpath, newpath);
+}
+
 int libos_dup(int fd) {
   ensure_fd_table();
   if (fd < 0 || fd >= fd_table_cap || !fd_table[fd])

--- a/engine/user/posix_rename_unlink_test.c
+++ b/engine/user/posix_rename_unlink_test.c
@@ -1,0 +1,36 @@
+#include <assert.h>
+#include <fcntl.h>
+#include <string.h>
+#include "libos/posix.h"
+
+int main(void){
+    const char *msg = "hi";
+    int fd = libos_open("src.txt", O_RDWR | O_CREAT, 0600);
+    assert(fd >= 0);
+    assert(libos_write(fd, msg, strlen(msg)) == (int)strlen(msg));
+    assert(libos_close(fd) == 0);
+
+    assert(libos_rename("src.txt", "dst.txt") == 0);
+
+    fd = libos_open("dst.txt", O_RDONLY, 0);
+    char buf[8];
+    int n = libos_read(fd, buf, sizeof(buf)-1);
+    assert(n == (int)strlen(msg));
+    buf[n] = '\0';
+    assert(strcmp(buf, msg) == 0);
+    assert(libos_close(fd) == 0);
+
+    fd = libos_open("src.txt", O_RDONLY, 0);
+    n = libos_read(fd, buf, sizeof(buf));
+    assert(n == 0);
+    libos_close(fd);
+
+    assert(libos_unlink("dst.txt") == 0);
+    fd = libos_open("dst.txt", O_RDONLY, 0);
+    n = libos_read(fd, buf, sizeof(buf));
+    assert(n == 0);
+    libos_close(fd);
+    libos_unlink("dst.txt");
+    libos_unlink("src.txt");
+    return 0;
+}

--- a/tests/posix/meson.build
+++ b/tests/posix/meson.build
@@ -1,6 +1,7 @@
 posix_tests = files('../../engine/user/posix_file_test.c',
                     '../../engine/user/posix_signal_test.c',
                     '../../engine/user/posix_pipe_test.c',
+                    '../../engine/user/posix_rename_unlink_test.c',
                     '../../engine/user/user/posix_misc_test.c',
                     '../../engine/user/user/posix_socket_test.c',
                     '../../engine/user/user/posix_cwd_test.c')

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -8,6 +8,7 @@ SRC_FILES = [
     ROOT / "engine/user/posix_file_test.c",
     ROOT / "engine/user/posix_signal_test.c",
     ROOT / "engine/user/posix_pipe_test.c",
+    ROOT / "engine/user/posix_rename_unlink_test.c",
     ROOT / "engine/user/user/posix_misc_test.c",
     ROOT / "engine/user/user/posix_socket_test.c",
     ROOT / "engine/user/user/posix_cwd_test.c",


### PR DESCRIPTION
## Summary
- implement `libfs_rename`/`libfs_unlink` helpers
- add `libos_rename` and `libos_unlink`
- document new wrappers in POSIX docs
- add simple rename/unlink test

## Testing
- `pytest -q` *(fails: Command '['/tmp/tmpn3cxl83x/test']' died with <Signals.SIGABRT: 6>.)*