### PR TITLE
Add decimal phi constant and track page capabilities

### DIFF
--- a/README
+++ b/README
@@ -467,6 +467,7 @@ Example ``drivers.conf``::
 
     kbdserv
     pingdriver --timeout=60
+    fileserver
 
 
 IPC DESIGN NOTE

--- a/doc/legacy_analysis.md
+++ b/doc/legacy_analysis.md
@@ -26,3 +26,5 @@ remaining legacy pieces.
 - Memory management uses capability operations exclusively.
 - Filesystem and drivers run entirely in user space.
 - Kernel scheduler logic removed in favour of DAG/Beatty streams.
+- Kernel page allocator now assigns a capability to every page.
+- File services launch in user space under the ``rcrs`` supervisor.

--- a/drivers.conf
+++ b/drivers.conf
@@ -3,3 +3,5 @@ kbdserv
 
 # network driver with a custom ping timeout
 pingdriver --timeout=60
+fileserver
+

--- a/engine/include/cap.h
+++ b/engine/include/cap.h
@@ -37,6 +37,7 @@ _Static_assert(_Alignof(struct cap_entry) == 4, "struct cap_entry alignment inco
 #endif
 
 extern uint32_t global_epoch;
+extern int cap_table_ready;
 
 void cap_table_init(void);
 int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights, uint32_t owner);

--- a/engine/kernel/cap_table.c
+++ b/engine/kernel/cap_table.c
@@ -8,100 +8,103 @@
 static struct spinlock cap_lock;
 static struct cap_entry cap_table[CAP_MAX];
 uint32_t global_epoch;
+int cap_table_ready = 0;
 
 void cap_table_init(void) {
-    initlock(&cap_lock, "captbl");
-    memset(cap_table, 0, sizeof(cap_table));
-    global_epoch = 0;
+  initlock(&cap_lock, "captbl");
+  memset(cap_table, 0, sizeof(cap_table));
+  global_epoch = 0;
+  cap_table_ready = 1;
 }
 
-int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights, uint32_t owner) {
-    if(type == CAP_TYPE_NONE || type > CAP_TYPE_HYPERVISOR)
-        return -1;
-    acquire(&cap_lock);
-    for (int i = 1; i < CAP_MAX; i++) {
-        if (cap_table[i].type == CAP_TYPE_NONE) {
-            cap_table[i].type = type;
-            cap_table[i].resource = resource;
-            cap_table[i].rights = rights;
-            cap_table[i].owner = owner;
-            cap_table[i].refcnt = 1;
-            uint32_t id = ((uint32_t)cap_table[i].epoch << 16) | i;
-            release(&cap_lock);
-            return id;
-        }
-    }
-    release(&cap_lock);
+int cap_table_alloc(uint16_t type, uint32_t resource, uint32_t rights,
+                    uint32_t owner) {
+  if (type == CAP_TYPE_NONE || type > CAP_TYPE_HYPERVISOR)
     return -1;
+  acquire(&cap_lock);
+  for (int i = 1; i < CAP_MAX; i++) {
+    if (cap_table[i].type == CAP_TYPE_NONE) {
+      cap_table[i].type = type;
+      cap_table[i].resource = resource;
+      cap_table[i].rights = rights;
+      cap_table[i].owner = owner;
+      cap_table[i].refcnt = 1;
+      uint32_t id = ((uint32_t)cap_table[i].epoch << 16) | i;
+      release(&cap_lock);
+      return id;
+    }
+  }
+  release(&cap_lock);
+  return -1;
 }
 
 int cap_table_lookup(uint32_t id, struct cap_entry *out) {
-    uint16_t idx = id & 0xffff;
-    uint16_t epoch = id >> 16;
-    acquire(&cap_lock);
-    if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
-        cap_table[idx].epoch != epoch) {
-        release(&cap_lock);
-        return -1;
-    }
-    if (out)
-        *out = cap_table[idx];
+  uint16_t idx = id & 0xffff;
+  uint16_t epoch = id >> 16;
+  acquire(&cap_lock);
+  if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
+      cap_table[idx].epoch != epoch) {
     release(&cap_lock);
-    return 0;
+    return -1;
+  }
+  if (out)
+    *out = cap_table[idx];
+  release(&cap_lock);
+  return 0;
 }
 
 void cap_table_inc(uint32_t id) {
-    uint16_t idx = id & 0xffff;
-    uint16_t epoch = id >> 16;
-    acquire(&cap_lock);
-    if (idx < CAP_MAX && cap_table[idx].type != CAP_TYPE_NONE &&
-        cap_table[idx].epoch == epoch)
-        cap_table[idx].refcnt++;
-    release(&cap_lock);
+  uint16_t idx = id & 0xffff;
+  uint16_t epoch = id >> 16;
+  acquire(&cap_lock);
+  if (idx < CAP_MAX && cap_table[idx].type != CAP_TYPE_NONE &&
+      cap_table[idx].epoch == epoch)
+    cap_table[idx].refcnt++;
+  release(&cap_lock);
 }
 
 void cap_table_dec(uint32_t id) {
-    uint16_t idx = id & 0xffff;
-    uint16_t epoch = id >> 16;
-    acquire(&cap_lock);
-    if (idx < CAP_MAX && cap_table[idx].type != CAP_TYPE_NONE &&
-        cap_table[idx].epoch == epoch) {
-        if (--cap_table[idx].refcnt == 0)
-            cap_table[idx].type = CAP_TYPE_NONE;
-    }
-    release(&cap_lock);
+  uint16_t idx = id & 0xffff;
+  uint16_t epoch = id >> 16;
+  acquire(&cap_lock);
+  if (idx < CAP_MAX && cap_table[idx].type != CAP_TYPE_NONE &&
+      cap_table[idx].epoch == epoch) {
+    if (--cap_table[idx].refcnt == 0)
+      cap_table[idx].type = CAP_TYPE_NONE;
+  }
+  release(&cap_lock);
 }
 
 int cap_table_remove(uint32_t id) {
-    uint16_t idx = id & 0xffff;
-    uint16_t epoch = id >> 16;
-    acquire(&cap_lock);
-    if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
-        cap_table[idx].epoch != epoch) {
-        release(&cap_lock);
-        return -1;
-    }
-    cap_table[idx].type = CAP_TYPE_NONE;
+  uint16_t idx = id & 0xffff;
+  uint16_t epoch = id >> 16;
+  acquire(&cap_lock);
+  if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
+      cap_table[idx].epoch != epoch) {
     release(&cap_lock);
-    return 0;
+    return -1;
+  }
+  cap_table[idx].type = CAP_TYPE_NONE;
+  release(&cap_lock);
+  return 0;
 }
 
 int cap_revoke(uint32_t id) {
-    uint16_t idx = id & 0xffff;
-    uint16_t epoch = id >> 16;
-    acquire(&cap_lock);
-    if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
-        cap_table[idx].epoch != epoch) {
-        release(&cap_lock);
-        return -1;
-    }
-    if (cap_table[idx].epoch == 0xffff) {
-        release(&cap_lock);
-        return -1;
-    }
-    cap_table[idx].epoch++;
-    cap_table[idx].type = CAP_TYPE_NONE;
-    cap_table[idx].refcnt = 0;
+  uint16_t idx = id & 0xffff;
+  uint16_t epoch = id >> 16;
+  acquire(&cap_lock);
+  if (idx >= CAP_MAX || cap_table[idx].type == CAP_TYPE_NONE ||
+      cap_table[idx].epoch != epoch) {
     release(&cap_lock);
-    return 0;
+    return -1;
+  }
+  if (cap_table[idx].epoch == 0xffff) {
+    release(&cap_lock);
+    return -1;
+  }
+  cap_table[idx].epoch++;
+  cap_table[idx].type = CAP_TYPE_NONE;
+  cap_table[idx].refcnt = 0;
+  release(&cap_lock);
+  return 0;
 }

--- a/engine/kernel/kalloc.c
+++ b/engine/kernel/kalloc.c
@@ -9,6 +9,7 @@
 #include "mmu.h"
 #include "spinlock.h"
 #include "proc.h"
+#include "exo.h"
 #include <string.h>
 
 void freerange(void *vstart, void *vend);
@@ -17,13 +18,10 @@ extern char end[]; // first address after kernel loaded from ELF file
 
 struct run {
   struct run *next;
+  exo_cap cap;
 };
 
-static inline int
-node_of(uintptr_t pa)
-{
-  return (pa / PGSIZE) % NNODES;
-}
+static inline int node_of(uintptr_t pa) { return (pa / PGSIZE) % NNODES; }
 
 struct {
   struct spinlock lock[NNODES];
@@ -31,85 +29,92 @@ struct {
   struct run *freelist[NNODES];
 } kmem;
 
+static exo_cap page_caps[PHYSTOP / PGSIZE];
+extern int cap_table_ready;
+
 // Initialization happens in two phases.
 // 1. main() calls kinit1() while still using entrypgdir to place just
 // the pages mapped by entrypgdir on free list.
 // 2. main() calls kinit2() with the rest of the physical pages
 // after installing a full page table that maps them on all cores.
-void
-kinit1(void *vstart, void *vend)
-{
-  for(int i=0;i<NNODES;i++)
+void kinit1(void *vstart, void *vend) {
+  for (int i = 0; i < NNODES; i++)
     initlock(&kmem.lock[i], "kmem");
   kmem.use_lock = 0;
   freerange(vstart, vend);
 }
 
-void
-kinit2(void *vstart, void *vend)
-{
+void kinit2(void *vstart, void *vend) {
   freerange(vstart, vend);
   kmem.use_lock = 1;
 }
 
-void
-freerange(void *vstart, void *vend)
-{
+void freerange(void *vstart, void *vend) {
   char *p;
-  p = (char*)PGROUNDUP((uintptr_t)vstart);
-  for(; p + PGSIZE <= (char*)vend; p += PGSIZE)
+  p = (char *)PGROUNDUP((uintptr_t)vstart);
+  for (; p + PGSIZE <= (char *)vend; p += PGSIZE)
     kfree(p);
 }
-//PAGEBREAK: 21
-// Free the page of physical memory pointed at by v,
-// which normally should have been returned by a
-// call to kalloc().  (The exception is when
-// initializing the allocator; see kinit above.)
-void
-kfree(char *v)
-{
+// PAGEBREAK: 21
+//  Free the page of physical memory pointed at by v,
+//  which normally should have been returned by a
+//  call to kalloc().  (The exception is when
+//  initializing the allocator; see kinit above.)
+void kfree(char *v) {
   struct run *r;
 
-  if((uintptr_t)v % PGSIZE || v < end || V2P(v) >= PHYSTOP)
+  if ((uintptr_t)v % PGSIZE || v < end || V2P(v) >= PHYSTOP)
     panic("kfree");
 
   // Fill with junk to catch dangling refs.
   memset(v, 1, PGSIZE);
 
   int node = node_of(V2P(v));
-  if(kmem.use_lock)
+  if (kmem.use_lock)
     acquire(&kmem.lock[node]);
-  r = (struct run*)v;
+  r = (struct run *)v;
+  int idx = V2P(v) / PGSIZE;
+  r->cap = page_caps[idx];
+  if (cap_table_ready && page_caps[idx].id == 0) {
+    int id = cap_table_alloc(CAP_TYPE_PAGE, V2P(v), 0, 0);
+    if (id >= 0)
+      page_caps[idx] = cap_new(id, 0, 0);
+    r->cap = page_caps[idx];
+  }
   r->next = kmem.freelist[node];
   kmem.freelist[node] = r;
-  if(kmem.use_lock)
+  if (kmem.use_lock)
     release(&kmem.lock[node]);
 }
 
 // Allocate one 4096-byte page of physical memory.
 // Returns a pointer that the kernel can use.
 // Returns 0 if the memory cannot be allocated.
-char*
-kalloc(void)
-{
+char *kalloc(void) {
   struct run *r = 0;
   int start = 0;
   struct proc *p = myproc();
-  if(p)
+  if (p)
     start = p->preferred_node % NNODES;
-  for(int i=0;i<NNODES;i++){
+  for (int i = 0; i < NNODES; i++) {
     int node = (start + i) % NNODES;
-    if(kmem.use_lock)
+    if (kmem.use_lock)
       acquire(&kmem.lock[node]);
     r = kmem.freelist[node];
-    if(r){
+    if (r) {
       kmem.freelist[node] = r->next;
-      if(kmem.use_lock)
+      if (kmem.use_lock)
         release(&kmem.lock[node]);
+      int idx = V2P(r) / PGSIZE;
+      if (cap_table_ready && page_caps[idx].id == 0) {
+        int id = cap_table_alloc(CAP_TYPE_PAGE, V2P(r), 0, 0);
+        if (id >= 0)
+          page_caps[idx] = cap_new(id, 0, 0);
+      }
       break;
     }
-    if(kmem.use_lock)
+    if (kmem.use_lock)
       release(&kmem.lock[node]);
   }
-  return (char*)r;
+  return (char *)r;
 }

--- a/engine/user/fileserver.c
+++ b/engine/user/fileserver.c
@@ -1,0 +1,22 @@
+#include "types.h"
+#include "user.h"
+#include "ipc.h"
+
+#define PING 1
+#define PONG 2
+
+int main(int argc, char *argv[]) {
+  (void)argc;
+  (void)argv;
+  printf(1, "fileserver: started\n");
+  zipc_msg_t m;
+  for (;;) {
+    if (endpoint_recv(&m) < 0)
+      continue;
+    if (m.w0 == PING) {
+      m.w0 = PONG;
+      endpoint_send(&m);
+    }
+  }
+  return 0;
+}

--- a/engine/user/math_core.c
+++ b/engine/user/math_core.c
@@ -1,7 +1,10 @@
 #include "math_core.h"
 
 #ifdef HAVE_DECIMAL_FLOAT
-_Decimal64 phi(void) { return (_Decimal64)1.618033988749895; }
+// Return the golden ratio constant using a decimal floating literal when
+// the compiler supports decimal floats.  The literal uses the `dd` suffix
+// for `_Decimal64` precision.
+_Decimal64 phi(void) { return 1.618033988749895dd; }
 
 double dec64_to_double(_Decimal64 x) { return (double)x; }
 _Decimal64 double_to_dec64(double x) { return (_Decimal64)x; }

--- a/meson.build
+++ b/meson.build
@@ -173,6 +173,7 @@ uprogs = {
   'beatty_dag_demo': 'engine/user/user/beatty_dag_demo.c',
   'ipc_test': 'engine/user/ipc_test.c',
   'nbtest': 'engine/user/nbtest.c',
+  'fileserver': 'engine/user/fileserver.c',
   'rcrs': 'engine/user/rcrs.c',
   'libos_posix_test': 'engine/user/libos_posix_test.c',
   'libos_posix_extra_test': 'engine/user/user/libos_posix_extra_test.c',


### PR DESCRIPTION
## Summary
- provide `_Decimal64` literal for golden ratio
- track capability IDs for pages in the kernel allocator
- expose `cap_table_ready` flag
- include a minimal `fileserver` demo and launch it via `rcrs`
- document migrations

## Testing
- `clang-format -i engine/user/math_core.c engine/kernel/kalloc.c engine/kernel/cap_table.c engine/user/fileserver.c`
- `make -n`