### PR TITLE
Clean up old engine paths

### DIFF
--- a/README
+++ b/README
@@ -390,9 +390,8 @@ scheduler. Both helpers are invoked automatically when registered through
                 USER DEMO
     : EXO_YIELD_TO AND STREAMS
       -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -The example
-      program ``exo_stream_demo`` under ``engine
-                / user / user
-                /`` is a minimal illustration of switching contexts
+      program ``exo_stream_demo`` under ``examples/demos`` is a minimal
+      illustration of switching contexts
                  with ``exo_yield_to`` and using the placeholder
                  STREAMS ``stop`` and ``yield`` calls.Build the system with
 ``cmake

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -35,8 +35,6 @@ def compile_and_run(source: pathlib.Path) -> None:
             "-I",
             str(ROOT),
             "-I",
-            str(ROOT / "engine"),
-            "-I",
             str(ROOT / "libos"),
             "-I",
             str(ROOT / "include/libos"),


### PR DESCRIPTION
## Summary
- fix outdated reference to the now removed `engine` directory in README
- update POSIX API tests to use correct include paths after restructuring

## Testing
- `pytest -q`