### PR TITLE
Implement lattice IPC interface

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -6,6 +6,7 @@ Welcome to exov6's documentation!
    :caption: Contents:
 
    usage
+   lattice_ipc
 
 .. doxygenindex::
    :project: exov6

--- a/docs/sphinx/source/lattice_ipc.rst
+++ b/docs/sphinx/source/lattice_ipc.rst
@@ -1,0 +1,18 @@
+Lattice IPC
+===========
+
+The lattice IPC layer provides a simple capability-based interface for
+message passing. Applications open a channel using ``lattice_connect``
+and then exchange messages with ``lattice_send`` and ``lattice_recv``.
+The following snippet illustrates a basic workflow::
+
+    lattice_channel_t ch;
+    if (lattice_connect(&ch, server_cap) == 0) {
+        lattice_send(&ch, "hello", 5);
+        char buf[16];
+        lattice_recv(&ch, buf, sizeof(buf));
+        lattice_close(&ch);
+    }
+
+Each channel maintains a sequence counter and authentication token to
+support future cryptographic extensions.

--- a/include/lattice_ipc.h
+++ b/include/lattice_ipc.h
@@ -1,0 +1,60 @@
+#pragma once
+#include "exo_ipc.h"
+#include "lattice_types.h"
+#include <stddef.h>
+#include <stdint.h>
+
+/**
+ * @brief Lattice-based IPC channel descriptor.
+ */
+typedef struct lattice_channel {
+    exo_cap        cap; /**< Capability handle for peer communication. */
+    uint64_t       seq; /**< Sequence number for messages. */
+    lattice_sig_t  key; /**< Authentication token. */
+} lattice_channel_t;
+
+/**
+ * @brief Establish a connection to a remote capability.
+ *
+ * @param chan Channel structure to initialize.
+ * @param dest Capability of the remote endpoint.
+ * @return 0 on success, negative value on failure.
+ */
+[[nodiscard]] int lattice_connect(lattice_channel_t *chan, exo_cap dest);
+
+/**
+ * @brief Send a message over the channel.
+ *
+ * @param chan Channel previously initialized with lattice_connect.
+ * @param buf  Data buffer to transmit.
+ * @param len  Number of bytes to send.
+ * @return 0 on success, negative value on failure.
+ */
+[[nodiscard]] int lattice_send(lattice_channel_t *chan, const void *buf, size_t len);
+
+/**
+ * @brief Receive a message from the channel.
+ *
+ * @param chan Channel previously initialized with lattice_connect.
+ * @param buf  Buffer to store received data.
+ * @param len  Maximum number of bytes to read.
+ * @return Number of bytes received on success, negative value on failure.
+ */
+[[nodiscard]] int lattice_recv(lattice_channel_t *chan, void *buf, size_t len);
+
+/**
+ * @brief Close a previously opened channel.
+ *
+ * @param chan Channel to close.
+ */
+void lattice_close(lattice_channel_t *chan);
+
+/**
+ * @brief Yield the CPU to the remote endpoint if possible.
+ *
+ * @param chan Channel describing the destination.
+ * @return 0 on success, negative value on failure.
+ */
+[[nodiscard]] int lattice_yield_to(const lattice_channel_t *chan);
+
+

--- a/kernel/lattice_ipc.c
+++ b/kernel/lattice_ipc.c
@@ -1,0 +1,68 @@
+#include "lattice_ipc.h"
+#include "caplib.h"
+#include <string.h>
+
+/**
+ * @brief Establish a connection to a remote capability.
+ */
+int lattice_connect(lattice_channel_t *chan, exo_cap dest) {
+    if (!chan) {
+        return -1;
+    }
+    chan->cap = dest;
+    chan->seq = 0;
+    memset(&chan->key, 0, sizeof(chan->key));
+    return 0;
+}
+
+/**
+ * @brief Send a message over the channel.
+ */
+int lattice_send(lattice_channel_t *chan, const void *buf, size_t len) {
+    if (!chan) {
+        return -1;
+    }
+    int ret = exo_send(chan->cap, buf, (uint64_t)len);
+    if (ret == 0) {
+        chan->seq++;
+    }
+    return ret;
+}
+
+/**
+ * @brief Receive a message from the channel.
+ */
+int lattice_recv(lattice_channel_t *chan, void *buf, size_t len) {
+    if (!chan) {
+        return -1;
+    }
+    int ret = exo_recv(chan->cap, buf, (uint64_t)len);
+    if (ret >= 0) {
+        chan->seq++;
+    }
+    return ret;
+}
+
+/**
+ * @brief Close a previously opened channel.
+ */
+void lattice_close(lattice_channel_t *chan) {
+    if (!chan) {
+        return;
+    }
+    chan->cap = 0;
+    chan->seq = 0;
+    memset(&chan->key, 0, sizeof(chan->key));
+}
+
+/**
+ * @brief Yield the CPU to the remote endpoint if possible.
+ */
+int lattice_yield_to(const lattice_channel_t *chan) {
+    if (!chan) {
+        return -1;
+    }
+    return cap_yield_to_cap(chan->cap);
+}
+
+


### PR DESCRIPTION
## Summary
- add lattice IPC API for capability-based channels
- document lattice IPC usage in Sphinx docs
- reference lattice IPC docs from index

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh` *(fails: prompted for GitHub credentials)*
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `pytest -q` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684d087f010c8331ad42b9fca3624e5d