### PR TITLE
Implement octonion algebra

### DIFF
--- a/include/octonion.h
+++ b/include/octonion.h
@@ -3,77 +3,177 @@
 #ifndef OCTONION_H
 #define OCTONION_H
 
-// Placeholder for quaternion and octonion types
+/**
+ * @file octonion.h
+ * @brief Quaternion and octonion algebra utilities.
+ */
+
+/* Quaternion and octonion type definitions. */
 
 typedef struct {
-    double w;
-    double x;
-    double y;
-    double z;
+  double w;
+  double x;
+  double y;
+  double z;
 } quaternion_t;
 
 typedef struct {
-    double e0;
-    double e1;
-    double e2;
-    double e3;
-    double e4;
-    double e5;
-    double e6;
-    double e7;
+  double e0;
+  double e1;
+  double e2;
+  double e3;
+  double e4;
+  double e5;
+  double e6;
+  double e7;
 } octonion_t;
 
-#include <math.h> // For sqrt in norm, fabs
-#include <stdatomic.h> // For atomic operations (will be used in spinlock)
-#include <string.h> // For memcmp
+#include <math.h>      /* sqrt and fabs */
+#include <stdatomic.h> /* atomic operations for spinlocks */
+#include <string.h>    /* memcmp */
+#ifdef USE_SIMD
+#include <immintrin.h> /* SIMD intrinsics */
+#endif
 
-// Forward declare for use in qspin_lock_t if it were here, but it'll be in its own header.
+// Forward declare for use in qspin_lock_t if it were here, but it'll be in its
+// own header.
 
-static inline int octonion_equals(const octonion_t* o1, const octonion_t* o2) {
-    if (!o1 || !o2) return (o1 == o2);
-    return memcmp(o1, o2, sizeof(octonion_t)) == 0;
+static inline int octonion_equals(const octonion_t *o1, const octonion_t *o2) {
+  if (!o1 || !o2)
+    return (o1 == o2);
+  return memcmp(o1, o2, sizeof(octonion_t)) == 0;
 }
 
-static inline quaternion_t quaternion_create(double w, double x, double y, double z) {
-    quaternion_t q = {w, x, y, z};
-    return q;
+static inline quaternion_t quaternion_create(double w, double x, double y,
+                                             double z) {
+  quaternion_t q = {w, x, y, z};
+  return q;
 }
 
-static inline quaternion_t quaternion_multiply(quaternion_t q1, quaternion_t q2) {
-    quaternion_t result;
-    result.w = q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z;
-    result.x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y;
-    result.y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z * q2.x;
-    result.z = q1.w * q2.z + q1.x * q2.y - q1.y * q2.x + q1.z * q2.w;
-    return result;
+static inline quaternion_t quaternion_multiply(quaternion_t q1,
+                                               quaternion_t q2) {
+  quaternion_t result;
+  result.w = q1.w * q2.w - q1.x * q2.x - q1.y * q2.y - q1.z * q2.z;
+  result.x = q1.w * q2.x + q1.x * q2.w + q1.y * q2.z - q1.z * q2.y;
+  result.y = q1.w * q2.y - q1.x * q2.z + q1.y * q2.w + q1.z * q2.x;
+  result.z = q1.w * q2.z + q1.x * q2.y - q1.y * q2.x + q1.z * q2.w;
+  return result;
+}
+
+/** Return the quaternion conjugate. */
+static inline quaternion_t quaternion_conjugate(quaternion_t q) {
+  return (quaternion_t){q.w, -q.x, -q.y, -q.z};
 }
 
 // Squared norm, often used to avoid sqrt
 static inline double quaternion_norm_sq(quaternion_t q) {
-    return q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z;
+  return q.w * q.w + q.x * q.x + q.y * q.y + q.z * q.z;
 }
 
 // Actual norm
 static inline double quaternion_norm(quaternion_t q) {
-    return sqrt(quaternion_norm_sq(q));
+  return sqrt(quaternion_norm_sq(q));
 }
 
 // Quaternion representing a CPU (simplified)
 static inline quaternion_t quaternion_from_cpu_id(int cpu_id) {
-    // This is a simplistic representation. The framework paper might imply
-    // a more sophisticated mapping or use of quaternion properties.
-    return quaternion_create((double)cpu_id, 0.0, 0.0, 0.0);
+  // This is a simplistic representation. The framework paper might imply
+  // a more sophisticated mapping or use of quaternion properties.
+  return quaternion_create((double)cpu_id, 0.0, 0.0, 0.0);
+}
+
+/** Create an octonion from eight coefficients. */
+static inline octonion_t octonion_create(double e0, double e1, double e2,
+                                         double e3, double e4, double e5,
+                                         double e6, double e7) {
+  return (octonion_t){e0, e1, e2, e3, e4, e5, e6, e7};
+}
+
+/** Conjugate an octonion by negating the imaginary parts. */
+static inline octonion_t octonion_conjugate(octonion_t o) {
+  return (octonion_t){o.e0, -o.e1, -o.e2, -o.e3, -o.e4, -o.e5, -o.e6, -o.e7};
+}
+
+/**
+ * Multiply two octonions using the Cayley-Dickson construction.
+ */
+static inline octonion_t octonion_multiply(octonion_t a, octonion_t b) {
+  quaternion_t a_l = {a.e0, a.e1, a.e2, a.e3};
+  quaternion_t a_r = {a.e4, a.e5, a.e6, a.e7};
+  quaternion_t b_l = {b.e0, b.e1, b.e2, b.e3};
+  quaternion_t b_r = {b.e4, b.e5, b.e6, b.e7};
+
+  quaternion_t left = quaternion_multiply(a_l, b_l);
+  quaternion_t temp = quaternion_multiply(quaternion_conjugate(b_r), a_r);
+  left.w -= temp.w;
+  left.x -= temp.x;
+  left.y -= temp.y;
+  left.z -= temp.z;
+
+  quaternion_t right = quaternion_multiply(b_r, a_l);
+  quaternion_t temp2 = quaternion_multiply(a_r, quaternion_conjugate(b_l));
+  right.w += temp2.w;
+  right.x += temp2.x;
+  right.y += temp2.y;
+  right.z += temp2.z;
+
+  return (octonion_t){left.w,  left.x,  left.y,  left.z,
+                      right.w, right.x, right.y, right.z};
+}
+
+/** Squared norm of an octonion. */
+static inline double octonion_norm_sq(octonion_t o) {
+#ifdef USE_SIMD
+  __m256d v0 = _mm256_loadu_pd(&o.e0);
+  __m256d v1 = _mm256_loadu_pd(&o.e4);
+  v0 = _mm256_mul_pd(v0, v0);
+  v1 = _mm256_mul_pd(v1, v1);
+  __m256d sum = _mm256_add_pd(v0, v1);
+  __m128d hi =
+      _mm_add_pd(_mm256_extractf128_pd(sum, 1), _mm256_castpd256_pd128(sum));
+  hi = _mm_hadd_pd(hi, hi);
+  double out;
+  _mm_store_sd(&out, hi);
+  return out;
+#else
+  return o.e0 * o.e0 + o.e1 * o.e1 + o.e2 * o.e2 + o.e3 * o.e3 + o.e4 * o.e4 +
+         o.e5 * o.e5 + o.e6 * o.e6 + o.e7 * o.e7;
+#endif
+}
+
+/** Norm of an octonion. */
+static inline double octonion_norm(octonion_t o) {
+  return sqrt(octonion_norm_sq(o));
+}
+
+/** Compute the multiplicative inverse of an octonion. */
+static inline octonion_t octonion_inverse(octonion_t o) {
+  double n = octonion_norm_sq(o);
+  octonion_t conj = octonion_conjugate(o);
+  if (n == 0.0)
+    return conj; /* Return zero divisor unchanged. */
+  double inv_n = 1.0 / n;
+  conj.e0 *= inv_n;
+  conj.e1 *= inv_n;
+  conj.e2 *= inv_n;
+  conj.e3 *= inv_n;
+  conj.e4 *= inv_n;
+  conj.e5 *= inv_n;
+  conj.e6 *= inv_n;
+  conj.e7 *= inv_n;
+  return conj;
 }
 
 // Placeholder for hyperbolic pause - for now, just a busy loop scaled by norm.
 // The actual "hyperbolic_pause" from the paper might be more complex.
 static inline void hyperbolic_pause(double norm_val) {
-    // Avoid issues with zero or very small norms in loop bound
-    unsigned long delay = (unsigned long)(fabs(norm_val) * 100.0);
-    if (delay == 0) delay = 1; // Minimum delay
-    for (volatile unsigned long i = 0; i < delay; ++i) {
-        // Busy wait
-    }
+  // Avoid issues with zero or very small norms in loop bound
+  unsigned long delay = (unsigned long)(fabs(norm_val) * 100.0);
+  if (delay == 0)
+    delay = 1; // Minimum delay
+  for (volatile unsigned long i = 0; i < delay; ++i) {
+    // Busy wait
+  }
 }
 
 #endif // OCTONION_H

--- a/tests/test_octonion.py
+++ b/tests/test_octonion.py
@@ -1,0 +1,77 @@
+import os
+import subprocess
+import tempfile
+import pathlib
+import textwrap
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+CC = os.environ.get("CC", "clang")
+
+C_CODE = textwrap.dedent(
+    """
+#include <assert.h>
+#include <math.h>
+#include "include/octonion.h"
+
+static int nearly_equal(double a, double b) {
+  return fabs(a - b) < 1e-9;
+}
+
+int main(void) {
+  octonion_t a = {1, 2, 3, 4, 5, 6, 7, 8};
+  octonion_t b = {2, -1, 0.5, -3, 1, -1, 0.1, 2.5};
+  octonion_t c = {0.3, 0.2, 0.1, -0.4, 1, 0, -0.2, 0.5};
+
+  octonion_t ab = octonion_multiply(a, b);
+  octonion_t bc = octonion_multiply(b, c);
+  octonion_t ab_c = octonion_multiply(ab, c);
+  octonion_t a_bc = octonion_multiply(a, bc);
+  assert(!octonion_equals(&ab_c, &a_bc));
+
+  double norm_ab = octonion_norm(ab);
+  double expected = octonion_norm(a) * octonion_norm(b);
+  assert(nearly_equal(norm_ab, expected));
+
+  octonion_t inv_a = octonion_inverse(a);
+  octonion_t one = octonion_multiply(a, inv_a);
+  assert(nearly_equal(one.e0, 1.0));
+  assert(nearly_equal(one.e1, 0.0));
+  assert(nearly_equal(one.e2, 0.0));
+  assert(nearly_equal(one.e3, 0.0));
+  assert(nearly_equal(one.e4, 0.0));
+  assert(nearly_equal(one.e5, 0.0));
+  assert(nearly_equal(one.e6, 0.0));
+  assert(nearly_equal(one.e7, 0.0));
+
+  return 0;
+}
+"""
+)
+
+
+def compile_and_run():
+    with tempfile.TemporaryDirectory() as td:
+        src = pathlib.Path(td) / "test.c"
+        src.write_text(C_CODE)
+        exe = pathlib.Path(td) / "test"
+        subprocess.check_call(
+            [
+                CC,
+                "-std=c23",
+                "-Wall",
+                "-Werror",
+                "-I",
+                str(ROOT),
+                "-idirafter",
+                str(ROOT / "include"),
+                str(src),
+                "-lm",
+                "-o",
+                str(exe),
+            ]
+        )
+        return subprocess.run([str(exe)]).returncode
+
+
+def test_octonion_algebra():
+    assert compile_and_run() == 0


### PR DESCRIPTION
## Summary
- finalize octonion algebra implementation
- add SIMD-enabled norm calculation
- test octonion algebraic identities

## Testing
- `pre-commit` *(fails: prompts for credentials)*
- `bats tests`
- `pytest -q tests/test_octonion.py`
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`

------
https://chatgpt.com/codex/tasks/task_e_684e6b2ae6648331924317af984af64b

## Summary by Sourcery

Implement full octonion algebra in C with supporting quaternion utilities, optional SIMD speedups, and accompanying validation tests.

New Features:
- Implement quaternion and octonion algebra with creation, conjugation, multiplication, norm and inverse operations

Enhancements:
- Add optional SIMD-accelerated squared norm calculation for octonions

Documentation:
- Add file-level Doxygen comments to octonion.h

Tests:
- Introduce C-based tests to verify octonion non-associativity, norm multiplicativity, and inverse correctness