### PR TITLE
Introduce quaternion spinlock for lattice IPC

### DIFF
--- a/docs/sphinx/source/lattice_ipc.rst
+++ b/docs/sphinx/source/lattice_ipc.rst
@@ -14,5 +14,7 @@ The following snippet illustrates a basic workflow::
         lattice_close(&ch);
     }
 
-Each channel maintains a sequence counter and authentication token to
-support future cryptographic extensions.
+Each channel maintains a sequence counter and authentication token.
+Mutable channel state is protected by a *quaternion spinlock* allowing
+recursive locking. The sequence counter increments atomically with
+each successful send or receive.

--- a/include/lattice_ipc.h
+++ b/include/lattice_ipc.h
@@ -1,16 +1,22 @@
 #pragma once
 #include "exo_ipc.h"
 #include "lattice_types.h"
+#include "../kernel/quaternion_spinlock.h"
 #include <stddef.h>
 #include <stdint.h>
 
 /**
  * @brief Lattice-based IPC channel descriptor.
+ *
+ * Access to mutable fields is serialized using a quaternion spinlock.
+ * The sequence counter is incremented atomically on successful
+ * send and receive operations.
  */
 typedef struct lattice_channel {
-    exo_cap        cap; /**< Capability handle for peer communication. */
-    uint64_t       seq; /**< Sequence number for messages. */
-    lattice_sig_t  key; /**< Authentication token. */
+  quaternion_spinlock_t lock; /**< Protects channel state. */
+  exo_cap cap;                /**< Capability handle for peer communication. */
+  _Atomic uint64_t seq;       /**< Sequence number for messages. */
+  lattice_sig_t key;          /**< Authentication token. */
 } lattice_channel_t;
 
 /**
@@ -29,8 +35,12 @@ typedef struct lattice_channel {
  * @param buf  Data buffer to transmit.
  * @param len  Number of bytes to send.
  * @return 0 on success, negative value on failure.
+ *
+ * The sequence counter is updated atomically while the quaternion
+ * lock guards the channel state.
  */
-[[nodiscard]] int lattice_send(lattice_channel_t *chan, const void *buf, size_t len);
+[[nodiscard]] int lattice_send(lattice_channel_t *chan, const void *buf,
+                               size_t len);
 
 /**
  * @brief Receive a message from the channel.
@@ -39,6 +49,9 @@ typedef struct lattice_channel {
  * @param buf  Buffer to store received data.
  * @param len  Maximum number of bytes to read.
  * @return Number of bytes received on success, negative value on failure.
+ *
+ * The call acquires the quaternion lock and increments the sequence
+ * counter atomically on success.
  */
 [[nodiscard]] int lattice_recv(lattice_channel_t *chan, void *buf, size_t len);
 
@@ -46,6 +59,9 @@ typedef struct lattice_channel {
  * @brief Close a previously opened channel.
  *
  * @param chan Channel to close.
+ *
+ * The operation resets the sequence counter and authentication token
+ * under the channel lock.
  */
 void lattice_close(lattice_channel_t *chan);
 
@@ -56,5 +72,3 @@ void lattice_close(lattice_channel_t *chan);
  * @return 0 on success, negative value on failure.
  */
 [[nodiscard]] int lattice_yield_to(const lattice_channel_t *chan);
-
-

--- a/kernel/lattice_ipc.c
+++ b/kernel/lattice_ipc.c
@@ -1,68 +1,81 @@
 #include "lattice_ipc.h"
 #include "caplib.h"
 #include <string.h>
+#include <stdatomic.h>
 
 /**
  * @brief Establish a connection to a remote capability.
  */
 int lattice_connect(lattice_channel_t *chan, exo_cap dest) {
-    if (!chan) {
-        return -1;
-    }
+  if (!chan) {
+    return -1;
+  }
+  WITH_QLOCK(&chan->lock) {
     chan->cap = dest;
-    chan->seq = 0;
+    atomic_store(&chan->seq, 0);
     memset(&chan->key, 0, sizeof(chan->key));
-    return 0;
+  }
+  return 0;
 }
 
 /**
  * @brief Send a message over the channel.
  */
 int lattice_send(lattice_channel_t *chan, const void *buf, size_t len) {
-    if (!chan) {
-        return -1;
-    }
-    int ret = exo_send(chan->cap, buf, (uint64_t)len);
+  if (!chan) {
+    return -1;
+  }
+  int ret;
+  WITH_QLOCK(&chan->lock) {
+    ret = exo_send(chan->cap, buf, (uint64_t)len);
     if (ret == 0) {
-        chan->seq++;
+      atomic_fetch_add(&chan->seq, 1);
     }
-    return ret;
+  }
+  return ret;
 }
 
 /**
  * @brief Receive a message from the channel.
  */
 int lattice_recv(lattice_channel_t *chan, void *buf, size_t len) {
-    if (!chan) {
-        return -1;
-    }
-    int ret = exo_recv(chan->cap, buf, (uint64_t)len);
+  if (!chan) {
+    return -1;
+  }
+  int ret;
+  WITH_QLOCK(&chan->lock) {
+    ret = exo_recv(chan->cap, buf, (uint64_t)len);
     if (ret >= 0) {
-        chan->seq++;
+      atomic_fetch_add(&chan->seq, 1);
     }
-    return ret;
+  }
+  return ret;
 }
 
 /**
  * @brief Close a previously opened channel.
  */
 void lattice_close(lattice_channel_t *chan) {
-    if (!chan) {
-        return;
-    }
+  if (!chan) {
+    return;
+  }
+  WITH_QLOCK(&chan->lock) {
     chan->cap = 0;
-    chan->seq = 0;
+    atomic_store(&chan->seq, 0);
     memset(&chan->key, 0, sizeof(chan->key));
+  }
 }
 
 /**
  * @brief Yield the CPU to the remote endpoint if possible.
  */
 int lattice_yield_to(const lattice_channel_t *chan) {
-    if (!chan) {
-        return -1;
-    }
-    return cap_yield_to_cap(chan->cap);
+  if (!chan) {
+    return -1;
+  }
+  exo_cap dest;
+  WITH_QLOCK((quaternion_spinlock_t *)&chan->lock) { // cast away const for lock
+    dest = chan->cap;
+  }
+  return cap_yield_to_cap(dest);
 }
-
-

--- a/kernel/quaternion_spinlock.h
+++ b/kernel/quaternion_spinlock.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "rspinlock.h"
+#include <stdbool.h>
+
+/**
+ * @brief Quaternion spinlock providing recursive locking semantics.
+ */
+typedef struct quaternion_spinlock {
+  struct rspinlock spin; /**< underlying recursive lock */
+  int level;             /**< recursion level modulo four */
+} quaternion_spinlock_t;
+
+static inline void qlock_init(quaternion_spinlock_t *q, char *name) {
+  rinitlock(&q->spin, name);
+  q->level = 0;
+}
+
+static inline void qlock_acquire(quaternion_spinlock_t *q) {
+  racquire(&q->spin);
+  q->level = (q->level + 1) % 4;
+}
+
+static inline void qlock_release(quaternion_spinlock_t *q) {
+  q->level = (q->level - 1 + 4) % 4;
+  rrelease(&q->spin);
+}
+
+static inline bool qlock_holding(quaternion_spinlock_t *q) {
+  return rholding(&q->spin);
+}
+
+#define WITH_QLOCK(q)                                                          \
+  for (int _once = (qlock_acquire(q), 0); !_once; qlock_release(q), _once = 1)


### PR DESCRIPTION
## Summary
- add recursive quaternion spinlock implementation
- guard `lattice_channel_t` state with new lock
- apply atomic increments to channel sequence counter
- update documentation to cover new concurrency semantics

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh include/lattice_ipc.h kernel/lattice_ipc.c kernel/quaternion_spinlock.h docs/sphinx/source/lattice_ipc.rst` *(fails: prompts for GitHub credentials)*
- `pytest -q` *(fails: SyntaxError and missing modules)*
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`


------
https://chatgpt.com/codex/tasks/task_e_684e6e9678f88331ac23282a1b017e16