### PR TITLE
Improve setup.sh offline package handling

### DIFF
--- a/README
+++ b/README
@@ -123,12 +123,14 @@ directory simply execute::
 
     sudo ./setup.sh
 
-When running without internet access place all required `.deb` files under
+When running without internet access place the required `.deb` files under
 `scripts/offline_packages/` and use::
 
     sudo ./setup.sh --offline
 
-The script installs each package from that directory with `dpkg -i`.
+The setup script now searches `scripts/offline_packages/` for each package
+before invoking `apt-get`. Any package installed from this cache is logged
+to `/var/log/setup.log`.
 
 This script installs bare-metal cross compiler packages such as
 ``gcc-i386-elf``/``g++-i386-elf`` and ``gcc-x86-64-elf``/``g++-x86-64-elf``


### PR DESCRIPTION
## Summary
- search `scripts/offline_packages` for local `.deb` files before using `apt-get`
- log packages installed from the offline cache
- document offline package search logic in README

## Testing
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `pytest -q` *(fails: SyntaxError in tests)*
- `pre-commit` *(fails: prompts for GitHub credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684e6ea85d388331911438b4721ca7c4

## Summary by Sourcery

Improve offline package handling in setup.sh by supporting local .deb cache, logging installs, and updating README

Enhancements:
- Add OFFLINE_DIR and search scripts/offline_packages for .deb files before falling back to apt
- Log successful offline installations and record failures to the failure log
- Refactor apt_pin_install, ensure_command, and install_offline_packages for unified offline and network-aware behavior
- Simplify debug logging, network detection, and log redirection
- Document the offline package search logic in README