### PR TITLE
Fix docs warnings

### DIFF
--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -8,5 +8,4 @@ Welcome to exov6's documentation!
    usage
    lattice_ipc
 
-.. doxygenindex::
-   :project: exov6
+


### PR DESCRIPTION
## Summary
- remove embedded Doxygen index because it rendered duplicate function declarations

## Testing
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `shellcheck setup.sh` *(fails: parse errors)*
- `pre-commit run --files docs/sphinx/source/index.rst` *(fails: requires GitHub auth)*
- `pytest -q` *(fails: SyntaxError in tests)*

------
https://chatgpt.com/codex/tasks/task_e_684e6eb31018833187b575cfc54562fb