### PR TITLE
Extend door IPC with async operations

### DIFF
--- a/docs/sphinx/source/door_ipc.rst
+++ b/docs/sphinx/source/door_ipc.rst
@@ -1,0 +1,28 @@
+Door IPC
+========
+
+The door IPC API provides a thin wrapper around simple call/return
+semantics. A door is either local, invoking a handler directly, or
+remote, forwarding messages through a capability endpoint.
+
+Typical usage::
+
+    static void handler(zipc_msg_t *m) {
+        m->w0++;
+    }
+
+    door_t d = door_create_local(handler);
+    zipc_msg_t msg = {0};
+    door_call(&d, &msg);
+
+The ``door_server_loop`` function can be used to service incoming
+requests for remote doors.
+
+Asynchronous calls are also supported. A client can issue a message
+without blocking and later collect the reply::
+
+    door_call_async(&remote_door, &msg);
+    door_recv(&remote_door, &msg);
+
+Servers that implement custom dispatch logic may use ``door_recv`` and
+``door_reply`` directly instead of ``door_server_loop``.

--- a/docs/sphinx/source/index.rst
+++ b/docs/sphinx/source/index.rst
@@ -7,6 +7,7 @@ Welcome to exov6's documentation!
 
    usage
    lattice_ipc
+   door_ipc
 
 .. doxygenindex::
    :project: exov6

--- a/include/door.h
+++ b/include/door.h
@@ -6,16 +6,88 @@
 extern "C" {
 #endif
 
+/**
+ * @brief Lightweight abstraction representing a synchronous door.
+ *
+ * A door is either local, in which case @c handler is invoked directly,
+ * or remote and messages are forwarded through @c dest.
+ */
 typedef struct door {
-  exo_cap dest;
-  void (*handler)(zipc_msg_t *msg);
-  int is_local;
+  exo_cap dest;                     /**< Capability for remote invocation. */
+  void (*handler)(zipc_msg_t *msg); /**< Local handler for incoming calls. */
+  int is_local;                     /**< Non-zero if the door is local. */
 } door_t;
 
+/**
+ * @brief Create a door that dispatches to a local handler.
+ *
+ * @param handler Function invoked when @ref door_call is used on this door.
+ * @return Initialized door descriptor.
+ */
 door_t door_create_local(void (*handler)(zipc_msg_t *msg));
+
+/**
+ * @brief Create a door that forwards calls to a remote endpoint.
+ *
+ * @param dest Capability designating the remote endpoint.
+ * @return Initialized door descriptor.
+ */
 door_t door_create_remote(exo_cap dest);
+
+/**
+ * @brief Invoke the door using the provided message.
+ *
+ * For local doors the handler is executed directly. For remote doors the
+ * message is sent and a reply is awaited.
+ *
+ * @param d Door to invoke.
+ * @param msg Message passed to the handler or remote endpoint.
+ * @return 0 on success, -1 on failure.
+ */
 EXO_NODISCARD int door_call(door_t *d, zipc_msg_t *msg);
+
+/**
+ * @brief Service incoming requests on a remote door.
+ *
+ * This function blocks and repeatedly receives messages on @c d->dest,
+ * dispatches them to @c d->handler and sends the response back.
+ *
+ * @param d Door descriptor with a valid handler.
+ */
 void door_server_loop(door_t *d);
+
+/**
+ * @brief Send a message without waiting for the reply.
+ *
+ * This is useful when issuing an asynchronous request to a remote
+ * door.  The response can later be obtained with @ref door_recv.
+ *
+ * @param d   Door descriptor.
+ * @param msg Message to transmit.
+ * @return 0 on success, -1 on failure.
+ */
+EXO_NODISCARD int door_call_async(door_t *d, const zipc_msg_t *msg);
+
+/**
+ * @brief Receive a message or reply on a door.
+ *
+ * @param d   Door descriptor.
+ * @param msg Output buffer for the received message.
+ * @return 0 on success, -1 on failure.
+ */
+EXO_NODISCARD int door_recv(door_t *d, zipc_msg_t *msg);
+
+/**
+ * @brief Send a reply for a previously received request.
+ *
+ * Typically used by custom service loops in place of
+ * @ref door_server_loop.
+ *
+ * @param d   Door descriptor.
+ * @param msg Message to transmit.
+ * @return 0 on success, -1 on failure.
+ */
+EXO_NODISCARD int door_reply(door_t *d, const zipc_msg_t *msg);
 
 #ifdef __cplusplus
 }

--- a/user/door.c
+++ b/user/door.c
@@ -2,12 +2,25 @@
 #include "exo_ipc.h"
 #include <stddef.h>
 
+/**
+ * @file door.c
+ * @brief Implementation of the door IPC abstraction.
+ */
+
+/**
+ * @brief Zero a capability structure.
+ *
+ * This helper clears @p c to prevent leaking uninitialized bits.
+ */
 static void clear_cap(exo_cap *c) {
   unsigned char *p = (unsigned char *)c;
   for (size_t i = 0; i < sizeof(*c); i++)
     p[i] = 0;
 }
 
+/**
+ * @brief Construct a door that directly invokes @p handler.
+ */
 door_t door_create_local(void (*handler)(zipc_msg_t *msg)) {
   door_t d;
   clear_cap(&d.dest);
@@ -16,6 +29,9 @@ door_t door_create_local(void (*handler)(zipc_msg_t *msg)) {
   return d;
 }
 
+/**
+ * @brief Construct a door that forwards requests to @p dest.
+ */
 door_t door_create_remote(exo_cap dest) {
   door_t d;
   d.dest = dest;
@@ -24,6 +40,9 @@ door_t door_create_remote(exo_cap dest) {
   return d;
 }
 
+/**
+ * @brief Call a door using the provided message.
+ */
 EXO_NODISCARD int door_call(door_t *d, zipc_msg_t *msg) {
   if (!d)
     return -1;
@@ -39,6 +58,9 @@ EXO_NODISCARD int door_call(door_t *d, zipc_msg_t *msg) {
   return 0;
 }
 
+/**
+ * @brief Run a blocking service loop for a door.
+ */
 void door_server_loop(door_t *d) {
   if (!d || !d->handler)
     return;
@@ -49,4 +71,31 @@ void door_server_loop(door_t *d) {
     d->handler(&msg);
     (void)cap_send(d->dest, &msg, sizeof(msg));
   }
+}
+
+/**
+ * @brief Send a message without waiting for the reply.
+ */
+EXO_NODISCARD int door_call_async(door_t *d, const zipc_msg_t *msg) {
+  if (!d || d->is_local)
+    return -1;
+  return cap_send(d->dest, msg, sizeof(*msg)) == IPC_STATUS_SUCCESS ? 0 : -1;
+}
+
+/**
+ * @brief Receive a pending message on a door.
+ */
+EXO_NODISCARD int door_recv(door_t *d, zipc_msg_t *msg) {
+  if (!d)
+    return -1;
+  return cap_recv(d->dest, msg, sizeof(*msg)) == IPC_STATUS_SUCCESS ? 0 : -1;
+}
+
+/**
+ * @brief Send a reply for a previously received message.
+ */
+EXO_NODISCARD int door_reply(door_t *d, const zipc_msg_t *msg) {
+  if (!d)
+    return -1;
+  return cap_send(d->dest, msg, sizeof(*msg)) == IPC_STATUS_SUCCESS ? 0 : -1;
 }


### PR DESCRIPTION
## Summary
- synchronize setup.sh with upstream
- add asynchronous helpers to the door API
- document async usage in Sphinx docs

## Testing
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx` *(with warnings)*
- `pytest` *(fails: SyntaxError in tests)*
- `pre-commit` *(fails: requires network credentials)*

------
https://chatgpt.com/codex/tasks/task_e_684e6eb875cc83318063dd4cf34896e7