### PR TITLE
Fix docs build warnings

### DIFF
--- a/docs/sphinx/source/lattice_ipc.rst
+++ b/docs/sphinx/source/lattice_ipc.rst
@@ -13,26 +13,28 @@ Applications continue to use the same simple API but gain strong, quantum-resist
 
 Basic usage example::
 
-```c
-lattice_channel_t ch;
-if (lattice_connect(&ch, server_cap) == 0) {
-    // Channel.key now holds the shared Kyber-derived secret
-    lattice_send(&ch, "hello", 5);          // encrypts + updates sequence counter
-    char buf[16];
-    lattice_recv(&ch, buf, sizeof(buf));    // decrypts + updates sequence counter
-    lattice_close(&ch);
-}
-— underneath:
+   .. code-block:: c
+
+      lattice_channel_t ch;
+      if (lattice_connect(&ch, server_cap) == 0) {
+          /* Channel.key now holds the shared Kyber-derived secret */
+          lattice_send(&ch, "hello", 5);          /* encrypt + update sequence counter */
+          char buf[16];
+          lattice_recv(&ch, buf, sizeof(buf));    /* decrypt + update sequence counter */
+          lattice_close(&ch);
+      }
+
+Below is the underlying process:
 
 lattice_connect(&ch, cap)
-• generates two Kyber key-pairs, exchanges public keys, derives ch.key via establish_secret(…).
-• initializes ch.seq = 0, ch.auth_token = HMAC(ch.key, seq).
+- generates two Kyber key-pairs, exchanges public keys, derives ch.key via establish_secret(…)
+- initializes ch.seq = 0, ch.auth_token = HMAC(ch.key, seq)
 
 lattice_send(&ch, data, len)
-• locks ch.lock (quaternion spinlock), increments ch.seq, recomputes ch.auth_token.
-• XOR-encrypts data with a keystream derived from ch.key || ch.seq, appends ch.auth_token, and queues or transmits.
-• unlocks ch.lock.
+- locks ch.lock (quaternion spinlock), increments ch.seq, recomputes ch.auth_token
+- XOR-encrypts data with a keystream derived from ch.key || ch.seq, appends ch.auth_token, and queues or transmits
+- unlocks ch.lock
 
 lattice_recv(&ch, buf, buflen)
-• locks ch.lock, checks and decrypts incoming payload, verifies auth_token, increments ch.seq.
-• copies plaintext into buf, unlocks ch.lock.
+- locks ch.lock, checks and decrypts incoming payload, verifies auth_token, increments ch.seq
+- copies plaintext into buf, unlocks ch.lock


### PR DESCRIPTION
## Summary
- fix quoting in `lattice_ipc.rst` to resolve Sphinx warnings
- ensure Graphviz `dot` is available for image generation

## Testing
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `shellcheck setup.sh`
- `pytest` *(fails: subprocess failures)*
- `pre-commit` *(fails: network access to GitHub blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684f3b3c69ec83318ca6d12d606b2678

## Summary by Sourcery

Fix documentation build warnings and ensure required tools are available

Build:
- Ensure Graphviz 'dot' is available for image generation

Documentation:
- Fix quoting in lattice_ipc.rst to resolve Sphinx warnings