### PR TITLE
Introduce octonion capability tokens

### DIFF
--- a/include/lattice_ipc.h
+++ b/include/lattice_ipc.h
@@ -16,7 +16,7 @@ typedef struct lattice_channel {
   quaternion_spinlock_t lock; /**< Protects channel state. */
   exo_cap cap;                /**< Capability handle for peer communication. */
   _Atomic uint64_t seq;       /**< Sequence number for messages. */
-  lattice_sig_t key;          /**< Authentication token. */
+  octonion_t key;             /**< Authentication token. */
 } lattice_channel_t;
 
 /**

--- a/include/lattice_types.h
+++ b/include/lattice_types.h
@@ -8,32 +8,55 @@
 
 // Placeholder values for typical lattice scheme parameters
 #define LATTICE_DIMENSION_N 256 // Example: n for Kyber/Dilithium
-#define LATTICE_KEY_BYTES (LATTICE_DIMENSION_N * 12 / 8 * 2) // Approx for Kyber public key (k*n*logq/8 for k=2)
-#define LATTICE_SIG_BYTES 2420 // Example: Dilithium2 signature size (CRYSTALS-Dilithium M(L2) with N=256)
-#define LATTICE_POLY_VEC_ELEMENTS LATTICE_DIMENSION_N // Number of coefficients in a polynomial vector element
+#define LATTICE_KEY_BYTES                                                      \
+  (LATTICE_DIMENSION_N * 12 / 8 *                                              \
+   2) // Approx for Kyber public key (k*n*logq/8 for k=2)
+#define LATTICE_SIG_BYTES                                                      \
+  2420 // Example: Dilithium2 signature size (CRYSTALS-Dilithium M(L2) with
+       // N=256)
+#define LATTICE_POLY_VEC_ELEMENTS                                              \
+  LATTICE_DIMENSION_N // Number of coefficients in a polynomial vector element
 
 typedef struct {
-    uint16_t coeffs[LATTICE_POLY_VEC_ELEMENTS]; // Example: a polynomial vector (e.g. n elements of uint16_t)
-    // int dimension; // Could be implicit from LATTICE_POLY_VEC_ELEMENTS
+  uint16_t coeffs[LATTICE_POLY_VEC_ELEMENTS]; // Example: a polynomial vector
+                                              // (e.g. n elements of uint16_t)
+  // int dimension; // Could be implicit from LATTICE_POLY_VEC_ELEMENTS
 } lattice_poly_vec_t; // More specific than generic lattice_pt for resource_id
 
 typedef struct {
-    uint8_t key_data[LATTICE_KEY_BYTES];
-    // size_t key_size; // Could be implicit from LATTICE_KEY_BYTES
+  uint8_t key_data[LATTICE_KEY_BYTES];
+  // size_t key_size; // Could be implicit from LATTICE_KEY_BYTES
 } lattice_public_key_t; // More specific
 
 typedef struct {
-    uint8_t sig_data[LATTICE_SIG_BYTES];
-    // size_t sig_size; // Could be implicit from LATTICE_SIG_BYTES
+  uint8_t sig_data[LATTICE_SIG_BYTES];
+  // size_t sig_size; // Could be implicit from LATTICE_SIG_BYTES
 } lattice_sig_t; // More specific
 
+/**
+ * @brief Octonion capability token consisting of eight components.
+ */
+typedef union {
+  struct {
+    double e0;
+    double e1;
+    double e2;
+    double e3;
+    double e4;
+    double e5;
+    double e6;
+    double e7;
+  } coeffs;                          /**< Named coefficient access. */
+  double v[8];                       /**< Array-style coefficient access. */
+  uint8_t bytes[8 * sizeof(double)]; /**< Raw byte representation. */
+} octonion_t;
 
-// Original generic lattice_pt (can be kept if used elsewhere, or removed if fully replaced)
-// For now, we will replace its use in cap_entry with the more specific lattice_poly_vec_t*
+// Original generic lattice_pt (can be kept if used elsewhere, or removed if
+// fully replaced) For now, we will replace its use in cap_entry with the more
+// specific lattice_poly_vec_t*
 typedef struct {
-    void *data;    // Pointer to the actual point data
-    int dimension; // Dimension of the vector or number of coefficients
+  void *data;    // Pointer to the actual point data
+  int dimension; // Dimension of the vector or number of coefficients
 } lattice_pt;
-
 
 #endif // LATTICE_TYPES_H

--- a/include/octonion.h
+++ b/include/octonion.h
@@ -10,6 +10,8 @@
 
 /* Quaternion and octonion type definitions. */
 
+#include "lattice_types.h"
+
 typedef struct {
   double w;
   double x;
@@ -17,23 +19,21 @@ typedef struct {
   double z;
 } quaternion_t;
 
-typedef struct {
-  double e0;
-  double e1;
-  double e2;
-  double e3;
-  double e4;
-  double e5;
-  double e6;
-  double e7;
-} octonion_t;
-
 #include <math.h>      /* sqrt and fabs */
 #include <stdatomic.h> /* atomic operations for spinlocks */
 #include <string.h>    /* memcmp */
 #ifdef USE_SIMD
 #include <immintrin.h> /* SIMD intrinsics */
 #endif
+
+/** Add two octonions component-wise. */
+octonion_t octonion_add(octonion_t a, octonion_t b);
+
+/** Multiply two octonions using the Cayley–Dickson construction. */
+octonion_t octonion_mul(octonion_t a, octonion_t b);
+
+/** Compute the multiplicative inverse of an octonion. */
+octonion_t octonion_inv(octonion_t o);
 
 // Forward declare for use in qspin_lock_t if it were here, but it'll be in its
 // own header.

--- a/kernel/lattice_ipc.c
+++ b/kernel/lattice_ipc.c
@@ -20,9 +20,9 @@ static uint32_t lcg_rand(void) {
  * XOR-based symmetric cipher helper
  *============================================================================*/
 static void xor_crypt(uint8_t *dst, const uint8_t *src, size_t len,
-                      const lattice_sig_t *key) {
+                      const octonion_t *key) {
   for (size_t i = 0; i < len; ++i) {
-    dst[i] = src[i] ^ key->sig_data[i % LATTICE_SIG_BYTES];
+    dst[i] = src[i] ^ key->bytes[i % sizeof(*key)];
   }
 }
 
@@ -64,7 +64,7 @@ static int kyber_stub_exchange(lattice_channel_t *chan) {
   }
 
   return libos_kdf_derive(NULL, 0, shared, sizeof shared, "kyber-stub",
-                          chan->key.sig_data, sizeof chan->key.sig_data);
+                          chan->key.bytes, sizeof chan->key);
 }
 
 /*==============================================================================

--- a/kernel/octonion.c
+++ b/kernel/octonion.c
@@ -1,0 +1,56 @@
+#include "include/octonion.h"
+
+/**
+ * @file octonion.c
+ * @brief Octonion arithmetic helper implementations.
+ */
+
+/** Add two octonions component-wise. */
+octonion_t octonion_add(octonion_t a, octonion_t b) {
+  octonion_t r = {0};
+  for (int i = 0; i < 8; ++i) {
+    r.v[i] = a.v[i] + b.v[i];
+  }
+  return r;
+}
+
+/** Multiply two octonions using the Cayley–Dickson construction. */
+octonion_t octonion_mul(octonion_t a, octonion_t b) {
+  quaternion_t a_l = {a.coeffs.e0, a.coeffs.e1, a.coeffs.e2, a.coeffs.e3};
+  quaternion_t a_r = {a.coeffs.e4, a.coeffs.e5, a.coeffs.e6, a.coeffs.e7};
+  quaternion_t b_l = {b.coeffs.e0, b.coeffs.e1, b.coeffs.e2, b.coeffs.e3};
+  quaternion_t b_r = {b.coeffs.e4, b.coeffs.e5, b.coeffs.e6, b.coeffs.e7};
+
+  quaternion_t left = quaternion_multiply(a_l, b_l);
+  quaternion_t tmp = quaternion_multiply(quaternion_conjugate(b_r), a_r);
+  left.w -= tmp.w;
+  left.x -= tmp.x;
+  left.y -= tmp.y;
+  left.z -= tmp.z;
+
+  quaternion_t right = quaternion_multiply(b_r, a_l);
+  tmp = quaternion_multiply(a_r, quaternion_conjugate(b_l));
+  right.w += tmp.w;
+  right.x += tmp.x;
+  right.y += tmp.y;
+  right.z += tmp.z;
+
+  return (octonion_t){.coeffs = {left.w, left.x, left.y, left.z, right.w,
+                                 right.x, right.y, right.z}};
+}
+
+/** Compute the multiplicative inverse of an octonion. */
+octonion_t octonion_inv(octonion_t o) {
+  double n = 0.0;
+  for (int i = 0; i < 8; ++i) {
+    n += o.v[i] * o.v[i];
+  }
+  if (n == 0.0) {
+    return o; /* zero divisor */
+  }
+  octonion_t conj = octonion_conjugate(o);
+  for (int i = 0; i < 8; ++i) {
+    conj.v[i] /= n;
+  }
+  return conj;
+}


### PR DESCRIPTION
## Summary
- define `octonion_t` capability tokens
- expose arithmetic helpers in new `kernel/octonion.c`
- store octonion keys in `lattice_channel_t`
- adapt lattice IPC for new token type

## Testing
- `shellcheck setup.sh`
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `meson setup build` *(fails: Expecting eof got id)*
- `pre-commit` *(fails: requires network access)*
- `pytest -q` *(fails: compiler errors)*

------
https://chatgpt.com/codex/tasks/task_e_684f42a9a6688331a9b864e25d3acc5a

## Summary by Sourcery

Introduce octonion-based capability tokens by defining a new octonion type, implementing core arithmetic operations, and adapting lattice IPC to use octonion_t for channel authentication.

New Features:
- Define octonion_t union for eight-component capability tokens
- Expose octonion_add, octonion_mul, and octonion_inv arithmetic helpers in the kernel

Enhancements:
- Store and authenticate channel keys as octonion_t instead of lattice_sig_t
- Update IPC routines (xor_crypt and KDF derivation) to use octonion_t byte data