### PR TITLE
Implement DAG IPC yielding

### DIFF
--- a/include/dag.h
+++ b/include/dag.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "types.h"
 #include "exo.h"
+#include "lattice_ipc.h"
 
 struct dag_node;
 
@@ -12,6 +13,7 @@ struct dag_node_list {
 
 struct dag_node {
   exo_cap ctx;
+  lattice_channel_t *chan;
   int pending;
   int priority;
   struct dag_node_list *children;
@@ -26,6 +28,7 @@ struct dag_node {
 
 void dag_node_init(struct dag_node *n, exo_cap ctx);
 void dag_node_set_priority(struct dag_node *n, int priority);
+void dag_node_set_channel(struct dag_node *n, lattice_channel_t *chan);
 void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
 int dag_sched_submit(struct dag_node *node);
 void dag_sched_init(void);

--- a/kernel/dag.h
+++ b/kernel/dag.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "types.h"
 #include "exo.h"
+#include "lattice_ipc.h"
 
 struct dag_node;
 
@@ -12,6 +13,7 @@ struct dag_node_list {
 
 struct dag_node {
   exo_cap ctx;
+  lattice_channel_t *chan;
   int pending;
   int priority;
   struct dag_node_list *children;
@@ -26,6 +28,7 @@ struct dag_node {
 
 void dag_node_init(struct dag_node *n, exo_cap ctx);
 void dag_node_set_priority(struct dag_node *n, int priority);
+void dag_node_set_channel(struct dag_node *n, lattice_channel_t *chan);
 void dag_node_add_dep(struct dag_node *parent, struct dag_node *child);
 int dag_sched_submit(struct dag_node *node);
 void dag_sched_init(void);


### PR DESCRIPTION
## Summary
- enable DAG scheduler to yield through lattice channels
- verify DAG acyclicity in capability table
- document DAG-based scheduling with octonion channels

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files kernel/dag_sched.c kernel/cap_table.c docs/sphinx/source/lattice_ipc.rst include/dag.h kernel/dag.h` *(fails: Username for 'https://github.com')*
- `pytest -q` *(fails: multiple CalledProcessError)*
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx` 
- `meson setup build` *(fails: Expecting eof got id.)*


------
https://chatgpt.com/codex/tasks/task_e_684f42ae71cc8331acc05ed58f839679

## Summary by Sourcery

Implement lattice-based IPC yielding for DAG tasks, integrate cycle detection into the capability table, and document the new scheduling mechanism.

New Features:
- Enable yielding of DAG scheduler tasks through lattice IPC channels
- Provide API to set lattice IPC channel for a DAG node
- Add depth-first cycle detection for DAGs in the capability table

Enhancements:
- Extend dag_node struct with a channel pointer and update scheduler to use lattice_yield when a channel is attached

Documentation:
- Document DAG-based scheduling with octonion lattice channels