### PR TITLE
Fix REPO_ROOT path handling

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,9 @@ debug() {
   fi
 }
 
-REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+## Resolve the directory of this script even when invoked via symlink.
+## shellcheck disable=SC2155
+REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
 OFFLINE_DIR="$REPO_ROOT/scripts/offline_packages"
 
 # This script installs all build dependencies. It logs actions to


### PR DESCRIPTION
## Summary
- ensure setup.sh resolves its own location correctly

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh` *(fails: Authentication failed for 'https://github.com/pre-commit/mirrors-clang-tidy/')*
- `pytest -q`
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `cc -std=c2x /tmp/test.c -o /tmp/test`

------
https://chatgpt.com/codex/tasks/task_e_684f519ea80c8331bbdb1afa682f19f4

## Summary by Sourcery

Fix REPO_ROOT resolution in setup.sh to correctly handle symlinks and improve shellcheck compliance

Bug Fixes:
- Use BASH_SOURCE[0] with cd -- and pwd -P to resolve the script directory through symlinks

Enhancements:
- Add shellcheck disable comment for SC2155 when defining REPO_ROOT