### PR TITLE
Fix Doxygen input

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -1,6 +1,6 @@
 PROJECT_NAME = exov6
 OUTPUT_DIRECTORY = docs/build
-INPUT = src
+INPUT = src kernel
 RECURSIVE = YES
 GENERATE_LATEX = NO
 QUIET = YES


### PR DESCRIPTION
## Summary
- include the `kernel` folder in the Doxygen input paths

## Testing
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `pytest` *(fails: subprocess.CalledProcessError)*
- `pre-commit` *(fails: requires network access)*


------
https://chatgpt.com/codex/tasks/task_e_684f51a750848331bcf4d5826a6160b5

## Summary by Sourcery

Include the `kernel` directory in Doxygen inputs to ensure its sources are documented.

Enhancements:
- Add the `kernel` folder to the Doxygen INPUT paths.

Documentation:
- Update Doxyfile to include the `kernel` directory in documentation generation.