### PR TITLE
Implement pqcrypto helpers and docs

### DIFF
--- a/docs/sphinx/source/lattice_ipc.rst
+++ b/docs/sphinx/source/lattice_ipc.rst
@@ -200,3 +200,14 @@ quaternion spinlock (``WITH_QLOCK(ch.lock)``) guards each critical
 section.  Sequence counters use ``memory_order_relaxed``, relying on
 the spinlock for necessary happens-before ordering.  DAG dependencies
 are enforced at submission time, rejecting cycles to guarantee progress.
+
+Post-Quantum Helpers
+--------------------
+
+Additional helper functions are available in ``libos/crypto.h`` for
+post-quantum operations.  ``pqcrypto_kem_keypair``, ``pqcrypto_kem_enc``
+and ``pqcrypto_kem_dec`` implement a Kyber-like key exchange, while
+``pqcrypto_sign_keypair``, ``pqcrypto_sign`` and ``pqcrypto_verify``
+provide Dilithium-style signatures.  These routines call out to the
+``pqcrypto`` library when present and fall back to deterministic stubs
+otherwise.

--- a/docs/sphinx/source/scheduler.rst
+++ b/docs/sphinx/source/scheduler.rst
@@ -5,7 +5,7 @@ The DAG scheduler manages cooperative tasks by maintaining an acyclic wait-for g
 Each ``struct dag_node`` represents a runnable context associated with an
 ``exo_cap``.  Nodes become ready once all dependencies are satisfied.  The
 scheduler enqueues ready nodes ordered by priority and yields to them using
-``exo_yield_to``.
+``exo_yield_to`` or ``lattice_yield_to`` when a channel is attached.
 
 Edges between nodes are added through ``dag_add_edge`` which checks for cycles
 before insertion.  Once a node has run, ``dag_mark_done`` propagates readiness

--- a/include/libos/crypto.h
+++ b/include/libos/crypto.h
@@ -11,24 +11,24 @@
  * input key material 'ikm'. The 'salt' can be used to add randomness,
  * and 'info' provides context-specific information for the derivation.
  *
- * NOTE: This is currently a STUB implementation and NOT cryptographically secure.
- * It should be replaced with a proper KDF (e.g., HKDF-SHA256) in the future.
+ * NOTE: This is currently a STUB implementation and NOT cryptographically
+ * secure. It should be replaced with a proper KDF (e.g., HKDF-SHA256) in the
+ * future.
  *
  * @param salt Optional salt. Can be NULL if not used.
  * @param salt_len Length of the salt. Must be 0 if salt is NULL.
  * @param ikm Input Key Material. Must not be NULL if ikm_len > 0.
  * @param ikm_len Length of the Input Key Material.
  * @param info Optional context-specific information string. Can be NULL.
- * @param okm Buffer to store the Output Key Material. Must not be NULL if okm_len > 0.
+ * @param okm Buffer to store the Output Key Material. Must not be NULL if
+ * okm_len > 0.
  * @param okm_len Desired length of the Output Key Material in bytes.
- * @return 0 on success, -1 on error (e.g., invalid parameters like NULL ikm/okm for non-zero lengths).
+ * @return 0 on success, -1 on error (e.g., invalid parameters like NULL ikm/okm
+ * for non-zero lengths).
  */
-int libos_kdf_derive(
-    const uint8_t* salt, size_t salt_len,
-    const uint8_t* ikm, size_t ikm_len,
-    const char* info,
-    uint8_t* okm, size_t okm_len
-);
+int libos_kdf_derive(const uint8_t *salt, size_t salt_len, const uint8_t *ikm,
+                     size_t ikm_len, const char *info, uint8_t *okm,
+                     size_t okm_len);
 
 /**
  * @brief Verifies two HMAC digests in constant time.
@@ -43,6 +43,47 @@ int libos_kdf_derive(
  * @param len The length of the digests to compare.
  * @return 1 if the digests are identical, 0 otherwise.
  */
-int hmac_verify_constant_time(const unsigned char *a, const unsigned char *b, size_t len);
+int hmac_verify_constant_time(const unsigned char *a, const unsigned char *b,
+                              size_t len);
+
+/**
+ * @brief Generate a Kyber-style KEM key pair.
+ *
+ * @param pk Output buffer for the public key.
+ * @param sk Output buffer for the secret key.
+ * @return 0 on success, negative on failure.
+ */
+int pqcrypto_kem_keypair(uint8_t *pk, uint8_t *sk);
+
+/**
+ * @brief Encapsulate a shared secret using @p pk.
+ *
+ * @param cipher Buffer to receive the ciphertext.
+ * @param key    Buffer to receive the derived key.
+ * @param pk     Peer public key.
+ * @return 0 on success, negative on failure.
+ */
+int pqcrypto_kem_enc(uint8_t *cipher, uint8_t *key, const uint8_t *pk);
+
+/**
+ * @brief Decapsulate a shared secret using @p sk.
+ *
+ * @param key    Buffer to receive the derived key.
+ * @param cipher Received ciphertext.
+ * @param sk     Private key.
+ * @return 0 on success, negative on failure.
+ */
+int pqcrypto_kem_dec(uint8_t *key, const uint8_t *cipher, const uint8_t *sk);
+
+/** Generate a Dilithium-style signing key pair. */
+int pqcrypto_sign_keypair(uint8_t *pk, uint8_t *sk);
+
+/** Sign a message. */
+int pqcrypto_sign(uint8_t *sig, size_t *sig_len, const uint8_t *msg,
+                  size_t msg_len, const uint8_t *sk);
+
+/** Verify a message signature. */
+int pqcrypto_verify(const uint8_t *sig, size_t sig_len, const uint8_t *msg,
+                    size_t msg_len, const uint8_t *pk);
 
 #endif // LIBOS_CRYPTO_H


### PR DESCRIPTION
## Summary
- extend libos crypto header with post-quantum routines
- implement Dilithium sign helpers in the kernel
- document pqcrypto helpers and scheduler yielding

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh include/libos/crypto.h kernel/crypto.c` *(fails: Repository not found)*
- `pytest -q` *(fails: subprocess.CalledProcessError)*
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`

------
https://chatgpt.com/codex/tasks/task_e_6850b91fa6e483319a8d45e993bd724b