### PR TITLE
Fix setup path detection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 ULAND_DIR  := src-uland
 LIBOS_DIR  := libos
 
-<<<<<<< HEAD
 OBJS = \
     $(KERNEL_DIR)/bio.o \
     $(KERNEL_DIR)/console.o \
@@ -473,7 +472,6 @@ qemu-memfs: $(XV6_MEMFS_IMG)
 	        echo "QEMU not found. Kernel built but not executed."; \
 	else \
 	        $(QEMU) -drive file=$(XV6_MEMFS_IMG),index=0,media=disk,format=raw -smp $(CPUS) -m 256; \
-=======
 proof:
 	$(MAKE) -C formal/coq all
 
@@ -487,7 +485,6 @@ formal:
 	tlc formal/specs/tla/ExoCap.tla >/dev/null; \
 	else \
 	echo "tlc not found; skipping TLA+ check"; \
->>>>>>> origin/feature/epoch-cache-design-progress
 	fi
 
 qemu-nox: $(FS_IMG) $(XV6_IMG)

--- a/setup.sh
+++ b/setup.sh
@@ -12,9 +12,10 @@ debug() {
   fi
 }
 
-## Resolve the directory of this script even when invoked via symlink.
+## Resolve the repository root, following symlinks to this script.
 ## shellcheck disable=SC2155
-REPO_ROOT="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+REPO_ROOT="$(cd -- "$(dirname -- "$(readlink -f -- "${BASH_SOURCE[0]}")")" \
+  && pwd -P)"
 OFFLINE_DIR="$REPO_ROOT/scripts/offline_packages"
 
 # This script installs all build dependencies. It logs actions to


### PR DESCRIPTION
## Summary
- sync setup.sh with upstream then resolve symlink for REPO_ROOT
- remove leftover merge conflict markers from Makefile

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files setup.sh` *(fails: prompts for GitHub credentials)*
- `pytest` *(fails: 26 failed, 12 passed, 3 skipped, 10 xfailed)*
- `doxygen docs/Doxyfile`
- `make -C docs/sphinx`
- `make` *(fails: missing src-kernel/arch/x64/bootasm64.S)*

------
https://chatgpt.com/codex/tasks/task_e_6850b922e0d4833182de3acc0f397f79