### PR TITLE
Fix build settings, remove merge artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,7 @@ QEMU := $(shell which qemu-system-aarch64 2>/dev/null || \
 endif
 
 ARCH ?= x86_64
-CSTD ?= gnu2x
+CSTD ?= c2x
 CLANG_TIDY ?= clang-tidy
 TIDY_SRCS := $(wildcard $(KERNEL_DIR)/*.c $(ULAND_DIR)/*.c $(LIBOS_DIR)/*.c)
 

--- a/kernel/bootmain.c
+++ b/kernel/bootmain.c
@@ -16,23 +16,12 @@
 void readseg(uint8_t*, uint32_t, uint32_t);
 
 void
-<<<<<<< HEAD
 bootmain(void)
 {
   struct elfhdr *elf;
   struct proghdr *ph, *eph;
   void (*entry)(void);
   uint8_t* pa;
-=======
-bootmain(uint32_t kaslr_physical_offset) // Renamed parameter
-{
-  struct elfhdr *elf;
-  // struct proghdr *ph, *eph; // Original
-  void (*entry)(void);
-  // uint8_t* pa; // Original, replaced by segment_actual_physical_load_addr
-
-  uintptr_t actual_kernel_physical_base = (uintptr_t)EXTMEM + kaslr_physical_offset; // New calculation
->>>>>>> origin/feature/epoch-cache-design-progress
 
   elf = (struct elfhdr*)0x10000;  // scratch space
 
@@ -44,7 +33,6 @@ bootmain(uint32_t kaslr_physical_offset) // Renamed parameter
     return;  // let bootasm.S handle error
 
   // Load each program segment (ignores ph flags).
-<<<<<<< HEAD
   ph = (struct proghdr*)((uint8_t*)elf + elf->phoff);
   eph = ph + elf->phnum;
   for(; ph < eph; ph++){
@@ -58,41 +46,6 @@ bootmain(uint32_t kaslr_physical_offset) // Renamed parameter
   // Does not return!
   entry = (void(*)(void))(uintptr_t)(elf->entry);
   entry();
-=======
-  // ph = (struct proghdr*)((uint8_t*)elf + elf->phoff); // Original
-  // eph = ph + elf->phnum; // Original
-  // for(; ph < eph; ph++){ // Original
-  //   pa = (uint8_t*)(uintptr_t)ph->paddr; // Original
-  //   readseg(pa, ph->filesz, ph->off); // Original
-  //   if(ph->memsz > ph->filesz) // Original
-  //     stosb(pa + ph->filesz, 0, ph->memsz - ph->filesz); // Original
-  // } // Original
-
-  struct proghdr *ph_elf_offset, *eph_elf_offset;
-  ph_elf_offset = (struct proghdr*)((uint8_t*)elf + elf->phoff); // ph_elf_offset is based on physical elf pointer
-  eph_elf_offset = ph_elf_offset + elf->phnum;
-
-  for(; ph_elf_offset < eph_elf_offset; ph_elf_offset++){
-    // ph_elf_offset->paddr is the LINK address of the segment.
-    // KERNLINK is the LINK address of the kernel base.
-    // actual_kernel_physical_base is the new randomized PHYSICAL address where kernel base is loaded.
-    uintptr_t segment_link_virtual_address = (uintptr_t)ph_elf_offset->paddr;
-    uintptr_t segment_offset_from_kernlink = segment_link_virtual_address - (uintptr_t)KERNLINK; // KERNLINK comes from memlayout.h
-    uintptr_t segment_actual_physical_load_addr = actual_kernel_physical_base + segment_offset_from_kernlink;
-
-    readseg((uint8_t*)segment_actual_physical_load_addr, ph_elf_offset->filesz, ph_elf_offset->off);
-    if(ph_elf_offset->memsz > ph_elf_offset->filesz)
-      stosb((uint8_t*)segment_actual_physical_load_addr + ph_elf_offset->filesz, 0, ph_elf_offset->memsz - ph_elf_offset->filesz);
-  }
-
-  // Call the entry point from the ELF header.
-  // This is the fixed VIRTUAL address (e.g., KERNLINK + offset).
-  // The page tables set up in bootasm64.S are responsible for mapping this
-  // virtual address to the randomized physical memory.
-  void (*kernel_virtual_entry)(void);
-  kernel_virtual_entry = (void(*)(void))(uintptr_t)elf->entry; // elf->entry is KERNLINK-based
-  kernel_virtual_entry();
->>>>>>> origin/feature/epoch-cache-design-progress
 }
 
 void

--- a/tests/microbench/Makefile
+++ b/tests/microbench/Makefile
@@ -1,5 +1,5 @@
 HOSTCC ?= clang
-HOSTCFLAGS ?= -Wall -O2 -std=c23 -I../../include -I../..
+HOSTCFLAGS ?= -Wall -O2 -std=c2x -I../../include -I../..
 
 PROGS := cap_verify_bench exo_yield_to_bench proc_cap_test lattice_pipe_bench
 

--- a/tests/test_arbitrate.py
+++ b/tests/test_arbitrate.py
@@ -53,7 +53,7 @@ def compile_and_run(code: str) -> int:
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(code)
-        subprocess.check_call([CC, "-std=c23", "-Wall", "-Werror", src, "-o", exe])
+        subprocess.check_call([CC, "-std=c2x", "-Wall", "-Werror", src, "-o", exe])
         return subprocess.run([exe]).returncode
 
 

--- a/tests/test_cap_newtypes.py
+++ b/tests/test_cap_newtypes.py
@@ -49,7 +49,7 @@ def compile_and_run():
         (pathlib.Path(td)/"mmu.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_cap_revoke.py
+++ b/tests/test_cap_revoke.py
@@ -42,7 +42,7 @@ def compile_and_run(code: str) -> int:
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(code)
-        subprocess.check_call([CC, "-std=c23", "-Wall", "-Werror", src, "-o", exe])
+        subprocess.check_call([CC, "-std=c2x", "-Wall", "-Werror", src, "-o", exe])
         return subprocess.run([exe]).returncode
 
 

--- a/tests/test_cap_types.py
+++ b/tests/test_cap_types.py
@@ -50,7 +50,7 @@ def compile_and_run():
         (pathlib.Path(td)/"mmu.h").write_text("")
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_chan_endpoint.py
+++ b/tests/test_chan_endpoint.py
@@ -46,7 +46,7 @@ def compile_and_run():
         src = pathlib.Path(td) / "test.c"
         exe = pathlib.Path(td) / "test"
         src.write_text(C_CODE)
-        subprocess.check_call(["gcc", "-std=c23", "-Wall", "-Werror", str(src), "-o", str(exe)])
+        subprocess.check_call(["gcc", "-std=c2x", "-Wall", "-Werror", str(src), "-o", str(exe)])
         subprocess.check_call([str(exe)])
 
 

--- a/tests/test_door.py
+++ b/tests/test_door.py
@@ -40,7 +40,7 @@ def compile_and_run() -> None:
         subprocess.check_call(
             [
                 CC,
-                "-std=c23",
+                "-std=c2x",
                 "-Wall",
                 "-Werror","-Wno-unused-function",
                 "-I",
@@ -88,7 +88,7 @@ def compile_and_run_fail() -> None:
         subprocess.check_call(
             [
                 CC,
-                "-std=c23",
+                "-std=c2x",
                 "-Wall",
                 "-Werror","-Wno-unused-function",
                 "-I",

--- a/tests/test_exo_ipc_direct.py
+++ b/tests/test_exo_ipc_direct.py
@@ -82,7 +82,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
         )
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_exo_recv_timed.py
+++ b/tests/test_exo_recv_timed.py
@@ -60,7 +60,7 @@ def compile_and_run():
             "#ifndef TEST_STDINT_H\n#define TEST_STDINT_H\n#include </usr/include/stdint.h>\n#endif\n"
         )
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_iommu.py
+++ b/tests/test_iommu.py
@@ -51,7 +51,7 @@ def compile_and_run():
         )
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            CC, "-std=c23", "-Wall", "-Werror","-Wno-unused-function",
+            CC, "-std=c2x", "-Wall", "-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_irq.py
+++ b/tests/test_irq.py
@@ -62,7 +62,7 @@ def compile_and_run():
         subprocess.check_call(
             [
                 CC,
-                "-std=c23",
+                "-std=c2x",
                 "-Wall",
                 "-Werror","-Wno-unused-function",
                 "-I",

--- a/tests/test_lattice_channel_dag.py
+++ b/tests/test_lattice_channel_dag.py
@@ -48,7 +48,7 @@ def test_lattice_channel_dag():
         subprocess.check_call(
             [
                 CC,
-                "-std=c23",
+                "-std=c2x",
                 "-Wall",
                 "-Werror",
                 "-I",

--- a/tests/test_lattice_ipc.py
+++ b/tests/test_lattice_ipc.py
@@ -102,7 +102,7 @@ def compile_and_run(code: str) -> int:
         )
         subprocess.check_call([
             CC,
-            "-std=c23",
+            "-std=c2x",
             "-Wall",
             "-Werror",
             "-Wno-unused-function",

--- a/tests/test_libos_env.py
+++ b/tests/test_libos_env.py
@@ -24,7 +24,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),
             str(src), str(ROOT/"libos/env.c"),

--- a/tests/test_locks.py
+++ b/tests/test_locks.py
@@ -62,7 +62,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function","-DSPINLOCK_NO_STUBS",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"include/libos"),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_lockstress.py
+++ b/tests/test_lockstress.py
@@ -88,7 +88,7 @@ def compile_and_run():
         src.write_text(C_CODE)
         exe = pathlib.Path(td)/"test"
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function","-pthread","-DSPINLOCK_NO_STUBS",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function","-pthread","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"include/libos"),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_mailbox_isolation.py
+++ b/tests/test_mailbox_isolation.py
@@ -76,7 +76,7 @@ def compile_and_run():
             "struct proc{ struct mailbox *mailbox; };\n")
         (pathlib.Path(td)/"defs.h").write_text("void wakeup(void*); void sleep(void*, struct spinlock*); void panic(char*);\n")
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_octonion.py
+++ b/tests/test_octonion.py
@@ -57,7 +57,7 @@ def compile_and_run():
         subprocess.check_call(
             [
                 CC,
-                "-std=c23",
+                "-std=c2x",
                 "-O3",
                 "-march=native",
                 "-ffast-math",

--- a/tests/test_posix_apis.py
+++ b/tests/test_posix_apis.py
@@ -27,7 +27,7 @@ def compile_and_run(source: pathlib.Path) -> None:
         )
         cmd = [
             "gcc",
-            "-std=c23",
+            "-std=c2x",
             "-Wall",
             "-Werror",
             "-I",

--- a/tests/test_posix_compat.py
+++ b/tests/test_posix_compat.py
@@ -47,7 +47,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),
             str(src),

--- a/tests/test_ptrace_concurrent.py
+++ b/tests/test_ptrace_concurrent.py
@@ -54,7 +54,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             str(src),
             "-o", str(exe)
         ])

--- a/tests/test_spinlock_align.py
+++ b/tests/test_spinlock_align.py
@@ -25,7 +25,7 @@ def compile_and_run(use_stub):
         if use_stub:
             (pathlib.Path(td)/"spinlock.h").write_text('#include "include/libos/spinlock.h"\n')
         cmd = [
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_sys_ipc.py
+++ b/tests/test_sys_ipc.py
@@ -73,7 +73,7 @@ def compile_and_run():
         (pathlib.Path(td)/"defs.h").write_text("")
         (pathlib.Path(td)/"mmu.h").write_text("")
         subprocess.check_call([
-            CC, "-std=c23", "-Wall", "-Werror","-Wno-unused-function",
+            CC, "-std=c2x", "-Wall", "-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_ticket_spinlock_processes.py
+++ b/tests/test_ticket_spinlock_processes.py
@@ -68,7 +68,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-DSPINLOCK_NO_STUBS",
+            CC,"-std=c2x","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"include/libos"),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_ticket_spinlock_threads.py
+++ b/tests/test_ticket_spinlock_threads.py
@@ -87,7 +87,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-pthread","-DSPINLOCK_NO_STUBS",
+            CC,"-std=c2x","-pthread","-DSPINLOCK_NO_STUBS",
             "-I", str(ROOT),
             "-I", str(ROOT/"include/libos"),
             "-idirafter", str(ROOT/"include"),

--- a/tests/test_uv_spinlock_processes.py
+++ b/tests/test_uv_spinlock_processes.py
@@ -56,7 +56,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),
             str(src),

--- a/tests/test_uv_spinlock_threads.py
+++ b/tests/test_uv_spinlock_threads.py
@@ -43,7 +43,7 @@ def compile_and_run():
         exe = pathlib.Path(td)/"test"
         src.write_text(C_CODE)
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function","-pthread",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function","-pthread",
             "-I", str(ROOT),
             "-idirafter", str(ROOT/"include"),
             str(src),

--- a/tests/test_zone.py
+++ b/tests/test_zone.py
@@ -58,7 +58,7 @@ def compile_and_run(body):
         (pathlib.Path(td)/"mmu.h").write_text('#include "include/types.h"\n#include "include/mmu.h"\n')
         (pathlib.Path(td)/"memlayout.h").write_text('#include "include/memlayout.h"\n')
         subprocess.check_call([
-            CC,"-std=c23","-Wall","-Werror","-Wno-unused-function",
+            CC,"-std=c2x","-Wall","-Werror","-Wno-unused-function",
             "-I", str(td),
             "-I", str(ROOT),
             str(src),


### PR DESCRIPTION
## Summary
- set CSTD to `c2x` in Makefile
- resolve merge markers in `kernel/bootmain.c`
- update all tests to compile with `-std=c2x`
- adjust microbench Makefile to use `c2x`
- drop stored setup logs

## Testing
- `shellcheck setup.sh`
- `pytest -q` *(fails: FileNotFoundError and compilation issues)*
- `doxygen docs/Doxyfile` *(fails: dot errors)*
- `make -C docs/sphinx`

------
https://chatgpt.com/codex/tasks/task_e_688a4be785a4833192bbfeac825c9228