### PR TITLE
Fix build configuration and header declarations

### DIFF
--- a/engine/kernel/spinlock.h
+++ b/engine/kernel/spinlock.h
@@ -1,59 +1,65 @@
 #pragma once
 
+#include <stdatomic.h>
 #include <stddef.h>
 #include <stdint.h>
 #include "config.h"
 
-// Forward declaration of struct cpu, representing a CPU structure used in spinlock debugging.
+/**
+ * Forward declaration of CPU descriptor used for debugging ownership.
+ */
 struct cpu;
 
-// Ticket-based mutual exclusion lock.
+/** Ticket-based mutual exclusion lock. */
 struct ticketlock {
-  _Atomic uint16_t head;
-  _Atomic uint16_t tail;
+  _Atomic uint16_t head; /**< Next ticket to serve. */
+  _Atomic uint16_t tail; /**< Next ticket to issue. */
 };
 
+/** Spinlock implemented via a ticket lock with debug information. */
 struct spinlock {
-  struct ticketlock ticket; // Ticket lock implementation
-  char *lock_name_ptr;  // Pointer to the name of the lock (null-terminated string).
-  // For debugging:
-  uint32_t pcs[10]; // Stores the call stack for debugging purposes.
-                    // The call stack (an array of program counters) that locked the lock.
-                    // This array is intended to store up to 10 program counters (return addresses)
-                    // from the call stack at the time the lock was acquired. It is primarily used
-                    // for debugging purposes to trace the code path that led to the lock being held.
-                    // The exact mechanism for capturing these program counters is implementation-specific
-                    // and may involve walking the stack or using compiler-provided intrinsics.
-  struct cpu *cpu;  // The cpu holding the lock.
+  struct ticketlock ticket; /**< Ticket lock state. */
+  char *name;               /**< Human-readable lock identifier. */
+  uint32_t pcs[10];         /**< Call stack PCs at lock acquisition. */
+  struct cpu *cpu;          /**< CPU currently holding the lock. */
 };
-extern size_t cache_line_size;
-// Represents the size of a cache line in bytes, used for optimizing spinlock alignment.
-// It is initialized by the detect_cache_line_size() function at runtime.
+
+/** Size in bytes of a processor cache line. */
 extern size_t cache_line_size;
 
-// Ensure cache_line_size is initialized during program startup.
-__attribute__((constructor)) static void initialize_cache_line_size(void) {
-  if (cache_line_size == 0) {
-    detect_cache_line_size();
-#endif // CONFIG_SMP && !defined(SPINLOCK_UNIPROCESSOR)
-}
+/**
+ * Detect the architecture's cache line size at runtime.
+ */
 void detect_cache_line_size(void);
-void initlock(struct spinlock *lk, char *lock_name_ptr);
-// Enable spinlock functionality for symmetric multiprocessing (SMP) systems,
-// unless explicitly configured for a uniprocessor setup.
+
+/**
+ * Initialise a spinlock with a descriptive name.
+ *
+ * \param lk   Spinlock to initialise.
+ * \param name Null-terminated label used for diagnostics.
+ */
+void initlock(struct spinlock *lk, char *name);
+
 #if CONFIG_SMP && !defined(SPINLOCK_UNIPROCESSOR)
-// void initlock(struct spinlock *lk, char *name); // Removed duplicate declaration
+/** Acquire a spinlock, blocking until it becomes available. */
 void acquire(struct spinlock *lk);
+
+/** Release a previously acquired spinlock. */
 void release(struct spinlock *lk);
 #endif
-// Returns the recommended alignment for instances of struct spinlock.
-// Aligning spinlocks to the cache line size helps avoid false sharing,
-// which can significantly improve performance in multi-core systems.
-  // Assume cache_line_size is initialized during program startup.
-  // No need to call detect_cache_line_size here.
+
+/**
+ * Obtain the recommended alignment for \ref spinlock.
+ *
+ * The alignment equals the runtime-detected cache line width to minimise
+ * false sharing across cores.
+ *
+ * \returns Number of bytes to align a spinlock instance.
+ */
+static inline size_t spinlock_align(void)
+{
+  if (!cache_line_size) {
+    detect_cache_line_size();
   }
   return cache_line_size;
 }
-
-#endif // CONFIG_SMP && !defined(SPINLOCK_UNIPROCESSOR)
-

--- a/include/caplib.h
+++ b/include/caplib.h
@@ -26,3 +26,11 @@ EXO_NODISCARD int cap_write_disk(exo_blockcap cap, const void *src,
 EXO_NODISCARD int cap_ipc_echo_demo(void);
 EXO_NODISCARD int cap_inc(uint16_t id);
 EXO_NODISCARD int cap_dec(uint16_t id);
+
+/**
+ * @brief Revoke a capability, invalidating it system-wide.
+ *
+ * @param id Capability identifier.
+ * @return 0 on success, or a negative error code.
+ */
+EXO_NODISCARD int cap_revoke(uint16_t id);

--- a/include/user.h
+++ b/include/user.h
@@ -1,32 +1,345 @@
 #pragma once
 #include "types.h"
 #include "exo.h"
+#include "stat.h"
 
 /* Prevent conflicts with system headers */
 #ifndef PHOENIX_USER_H_DECLS
 #define PHOENIX_USER_H_DECLS
 
+/**
+ * @brief Replace the current process image with a new program.
+ *
+ * @param path Path to the executable.
+ * @param argv Null-terminated argument vector.
+ * @return 0 on success, or -1 on failure.
+ */
 int exec(char *path, char **argv);
+
+/**
+ * @brief Send a signal to a process.
+ *
+ * @param pid Target process identifier.
+ * @param sig Signal number to deliver.
+ * @return 0 on success, or -1 on failure.
+ */
 int sigsend(int pid, int sig);
+
+/**
+ * @brief Check for pending signals.
+ *
+ * @return Pending signal number, or 0 if none are pending.
+ */
 int sigcheck(void);
 
-/* User-space library functions */
+/**
+ * @brief Minimal printf for userland applications.
+ *
+ * @param fd  Destination file descriptor.
+ * @param fmt Format string.
+ * @param ... Additional arguments.
+ */
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wincompatible-library-redeclaration"
 void printf(int fd, const char *fmt, ...);
 #pragma clang diagnostic pop
 
+/**
+ * @brief Allocate dynamic memory.
+ *
+ * @param size Number of bytes to allocate.
+ * @return Pointer to the allocated block, or nullptr on failure.
+ */
 void *malloc(size_t size);
+
+/**
+ * @brief Release dynamic memory.
+ *
+ * @param ptr Pointer previously returned by malloc().
+ */
 void free(void *ptr);
 
-/* System calls not declared elsewhere */
+/**
+ * @brief Register a timer upcall handler.
+ *
+ * @param handler Function invoked on timer events.
+ * @return 0 on success, or -1 on failure.
+ */
 int set_timer_upcall(void (*handler)(void));
+
+/**
+ * @brief Set the available gas (execution budget) for the process.
+ *
+ * @param amount Number of gas units to assign.
+ * @return Previous gas amount.
+ */
 int set_gas(uint64_t amount);
+
+/**
+ * @brief Retrieve the remaining gas for the process.
+ *
+ * @return Remaining gas units.
+ */
 int get_gas(void);
+
+/**
+ * @brief Flush a block capability to the backing store.
+ *
+ * @param cap  Block capability to flush.
+ * @param data Buffer containing the block data.
+ */
 void exo_flush_block(exo_blockcap *cap, void *data);
 
-/* Basic syscalls */
+/**
+ * @brief Increase the data segment by the requested amount.
+ *
+ * @param nbytes Number of bytes to grow.
+ * @return Pointer to the previous program break, or (void *)-1 on failure.
+ */
 void *sbrk(int nbytes);
+
+/**
+ * @brief Write data to a file descriptor.
+ *
+ * @param fd    Destination file descriptor.
+ * @param buf   Buffer containing data to write.
+ * @param count Number of bytes to write.
+ * @return Number of bytes written, or -1 on error.
+ */
 int write(int fd, const void *buf, int count);
+
+/**
+ * @brief Read data from a file descriptor.
+ *
+ * @param fd    Source file descriptor.
+ * @param buf   Destination buffer.
+ * @param count Maximum number of bytes to read.
+ * @return Number of bytes read, or -1 on error.
+ */
+int read(int fd, void *buf, int count);
+
+/**
+ * @brief Open a file.
+ *
+ * @param path File path.
+ * @param mode Opening mode flags.
+ * @param ...  Optional permission argument when creating files.
+ * @return File descriptor on success, or -1 on error.
+ */
+int open(const char *path, int mode, ...);
+
+/**
+ * @brief Close an open file descriptor.
+ *
+ * @param fd File descriptor to close.
+ * @return 0 on success, or -1 on error.
+ */
+int close(int fd);
+
+/**
+ * @brief Create a special or device file.
+ *
+ * @param path  Destination path for the node.
+ * @param type  File type identifier.
+ * @param major Major device number.
+ * @return 0 on success, or -1 on failure.
+ */
+int mknod(const char *path, short type, short major);
+
+/**
+ * @brief Duplicate an existing file descriptor.
+ *
+ * @param fd File descriptor to duplicate.
+ * @return New descriptor referencing the same open file, or -1 on error.
+ */
+int dup(int fd);
+
+/**
+ * @brief Create a new process.
+ *
+ * The child receives a copy of the parent's address space.
+ *
+ * @return 0 in the child, child's PID in the parent, or -1 on error.
+ */
+int fork(void);
+
+/**
+ * @brief Wait for a child process to exit.
+ *
+ * @return PID of the terminated child, or -1 if none remain.
+ */
+int wait(void);
+
+/**
+ * @brief Create a unidirectional data channel.
+ *
+ * @param fd Two-element array receiving the read and write descriptors.
+ * @return 0 on success, or -1 on failure.
+ */
+int pipe(int fd[2]);
+
+/**
+ * @brief Send a termination signal to a process.
+ *
+ * @param pid Target process identifier.
+ * @return 0 on success, or -1 on error.
+ */
+int kill(int pid);
+
+/**
+ * @brief Remove a directory entry.
+ *
+ * @param path Path of the file to unlink.
+ * @return 0 on success, or -1 on failure.
+ */
+int unlink(const char *path);
+
+/**
+ * @brief Create a hard link between two paths.
+ *
+ * @param old Existing file path.
+ * @param newp New link path.
+ * @return 0 on success, or -1 on failure.
+ */
+int link(const char *old, const char *newp);
+
+/**
+ * @brief Retrieve file status information.
+ *
+ * @param fd File descriptor to query.
+ * @param st Output structure for file metadata.
+ * @return 0 on success, or -1 on failure.
+ */
+int fstat(int fd, struct stat *st);
+
+/**
+ * @brief Change the current working directory.
+ *
+ * @param path Path of the new working directory.
+ * @return 0 on success, or -1 on error.
+ */
+int chdir(const char *path);
+
+/**
+ * @brief Obtain the calling process identifier.
+ *
+ * @return The PID of the current process.
+ */
+int getpid(void);
+
+/**
+ * @brief Suspend execution for a number of clock ticks.
+ *
+ * @param ticks Duration to sleep.
+ * @return 0 on success, or -1 on failure.
+ */
+int sleep(int ticks);
+
+/**
+ * @brief Retrieve the system tick count since boot.
+ *
+ * @return Number of ticks since system start.
+ */
+int uptime(void);
+
+/**
+ * @brief Terminate the calling process.
+ */
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wincompatible-library-redeclaration"
+[[noreturn]] void exit(void);
+#pragma clang diagnostic pop
+
+/**
+ * @brief Copy string @p t into buffer @p s.
+ *
+ * Implements a basic C library routine using a simple loop. The
+ * destination buffer must have space for the source string including its
+ * terminating null byte.
+ *
+ * @param s Destination buffer.
+ * @param t Null-terminated source string.
+ * @return Pointer to @p s for convenience.
+ */
+char *strcpy(char *s, const char *t);
+
+/**
+ * @brief Lexicographically compare two strings.
+ *
+ * @param p First string.
+ * @param q Second string.
+ * @return Negative, zero or positive if @p p is respectively less than,
+ *         equal to or greater than @p q.
+ */
+int strcmp(const char *p, const char *q);
+
+/**
+ * @brief Compute the length of a string.
+ *
+ * @param s Null-terminated string.
+ * @return Number of bytes preceding the terminating null.
+ */
+size_t strlen(const char *s);
+
+/**
+ * @brief Fill a memory region with a byte value.
+ *
+ * @param dst Destination buffer.
+ * @param c   Byte value to write.
+ * @param n   Number of bytes to set.
+ * @return Pointer to @p dst.
+ */
+void *memset(void *dst, int c, size_t n);
+
+/**
+ * @brief Locate a character within a string.
+ *
+ * @param s String to scan.
+ * @param c Character to search for.
+ * @return Pointer to the first occurrence or NULL if absent.
+ */
+char *strchr(const char *s, int c);
+
+/**
+ * @brief Read a line from standard input.
+ *
+ * Reads at most @p max-1 bytes from file descriptor zero and terminates
+ * the buffer with a null byte.
+ *
+ * @param buf Destination buffer.
+ * @param max Buffer capacity in bytes.
+ * @return Pointer to @p buf.
+ */
+char *gets(char *buf, size_t max);
+
+/**
+ * @brief Obtain file status information.
+ *
+ * @param n   Path to the file.
+ * @param st  Output structure for file metadata.
+ * @return 0 on success, or -1 on failure.
+ */
+int stat(const char *n, struct stat *st);
+
+/**
+ * @brief Convert a string to an integer.
+ *
+ * Parses a sequence of decimal digits and stops at the first
+ * non-numeric character.
+ *
+ * @param s Input string.
+ * @return Parsed integer value.
+ */
+int atoi(const char *s);
+
+/**
+ * @brief Move a memory region even if the ranges overlap.
+ *
+ * @param vdst Destination buffer.
+ * @param vsrc Source buffer.
+ * @param n    Number of bytes to move.
+ * @return Pointer to @p vdst.
+ */
+void *memmove(void *vdst, const void *vsrc, size_t n);
 
 #endif /* PHOENIX_USER_H_DECLS */

--- a/kernel/lattice_ipc.c
+++ b/kernel/lattice_ipc.c
@@ -8,61 +8,65 @@
 #include "libos/crypto.h"
 #include "cap_security.h"
 #include "kernel_compat.h"
+#include "quaternion_spinlock.h"
 
 /* Standard headers */
 #include <stdint.h>
 #include <stddef.h>
 #include <string.h>
+#include <stdlib.h>
 
 /* Forward declarations for crypto functions */
 extern void simple_sha256(const uint8_t *data, size_t len, uint8_t hash[32]);
-extern int hmac_verify_constant_time(const unsigned char *a, const unsigned char *b, size_t len);
+extern int hmac_verify_constant_time(const unsigned char *a,
+                                     const unsigned char *b, size_t len);
 
 /*------------------------------------------------------------------------------
  * Symmetric XOR stream cipher
  *----------------------------------------------------------------------------*/
 static void xor_crypt(uint8_t *dst, const uint8_t *src, size_t len,
                       const lattice_sig_t *key) {
-    for (size_t i = 0; i < len; ++i) {
-        dst[i] = src[i] ^ key->sig_data[i % LATTICE_SIG_BYTES];
-    }
+  for (size_t i = 0; i < len; ++i) {
+    dst[i] = src[i] ^ key->sig_data[i % LATTICE_SIG_BYTES];
+  }
 }
 
 /*------------------------------------------------------------------------------
  * Post-quantum Kyber-based key exchange via pqcrypto
  *----------------------------------------------------------------------------*/
 static int kyber_pqcrypto_exchange(lattice_channel_t *chan) {
-    uint8_t pk[32], sk[32];
-    if (pqcrypto_kem_keypair(pk, sk) != 0)
-        return -1;
+  uint8_t pk[32], sk[32];
+  if (pqcrypto_kem_keypair(pk, sk) != 0)
+    return -1;
 
-    if (exo_send(chan->cap, pk, sizeof pk) != (int)sizeof pk)
-        return -1;
+  if (exo_send(chan->cap, pk, sizeof pk) != (int)sizeof pk)
+    return -1;
 
-    uint8_t peer_pk[32];
-    if (exo_recv(chan->cap, peer_pk, sizeof peer_pk) != (int)sizeof peer_pk)
-        return -1;
+  uint8_t peer_pk[32];
+  if (exo_recv(chan->cap, peer_pk, sizeof peer_pk) != (int)sizeof peer_pk)
+    return -1;
 
-    uint8_t cipher[32], key1[32];
-    if (pqcrypto_kem_enc(cipher, key1, peer_pk) != 0)
-        return -1;
+  uint8_t cipher[32], key1[32];
+  if (pqcrypto_kem_enc(cipher, key1, peer_pk) != 0)
+    return -1;
 
-    if (exo_send(chan->cap, cipher, sizeof cipher) != (int)sizeof cipher)
-        return -1;
+  if (exo_send(chan->cap, cipher, sizeof cipher) != (int)sizeof cipher)
+    return -1;
 
-    uint8_t peer_cipher[32], key2[32];
-    if (exo_recv(chan->cap, peer_cipher, sizeof peer_cipher) != (int)sizeof peer_cipher)
-        return -1;
+  uint8_t peer_cipher[32], key2[32];
+  if (exo_recv(chan->cap, peer_cipher, sizeof peer_cipher) !=
+      (int)sizeof peer_cipher)
+    return -1;
 
-    if (pqcrypto_kem_dec(key2, peer_cipher, sk) != 0)
-        return -1;
+  if (pqcrypto_kem_dec(key2, peer_cipher, sk) != 0)
+    return -1;
 
-    uint8_t combo[64];
-    memcpy(combo, key1, sizeof key1);
-    memcpy(combo + sizeof key1, key2, sizeof key2);
+  uint8_t combo[64];
+  memcpy(combo, key1, sizeof key1);
+  memcpy(combo + sizeof key1, key2, sizeof key2);
 
-    return libos_kdf_derive(NULL, 0, combo, sizeof combo, "kyber",
-                            chan->key.sig_data, sizeof chan->key.sig_data);
+  return libos_kdf_derive(NULL, 0, combo, sizeof combo, "kyber",
+                          chan->key.sig_data, sizeof chan->key.sig_data);
 }
 
 /*------------------------------------------------------------------------------
@@ -73,150 +77,148 @@ static int kyber_pqcrypto_exchange(lattice_channel_t *chan) {
  * @brief Establish a channel and perform Kyber-based key exchange.
  */
 int lattice_connect(lattice_channel_t *chan, exo_cap dest) {
-    if (!chan)
-        return -1;
+  if (!chan)
+    return -1;
 
-    WITH_QLOCK(&chan->lock) {
-        chan->cap = dest;
-        atomic_store_explicit(&chan->seq, 0, memory_order_relaxed);
-        memset(&chan->key, 0, sizeof chan->key);
-        memset(&chan->token, 0, sizeof chan->token);
-        dag_node_init(&chan->dag, dest);
-    }
+  WITH_QLOCK(&chan->lock) {
+    chan->cap = dest;
+    atomic_store_explicit(&chan->seq, 0, memory_order_relaxed);
+    memset(&chan->key, 0, sizeof chan->key);
+    memset(&chan->token, 0, sizeof chan->token);
+    dag_node_init(&chan->dag, dest);
+  }
 
-    int rc = kyber_pqcrypto_exchange(chan);
-    if (rc == 0) {
-        double coeffs[8];
-        for (size_t i = 0; i < 8; ++i)
-            coeffs[i] = (double)chan->key.sig_data[i] / 255.0;
-        chan->token = octonion_create(coeffs[0], coeffs[1], coeffs[2], coeffs[3],
-                                      coeffs[4], coeffs[5], coeffs[6], coeffs[7]);
-    }
-    return rc;
+  int rc = kyber_pqcrypto_exchange(chan);
+  if (rc == 0) {
+    double coeffs[8];
+    for (size_t i = 0; i < 8; ++i)
+      coeffs[i] = (double)chan->key.sig_data[i] / 255.0;
+    chan->token = octonion_create(coeffs[0], coeffs[1], coeffs[2], coeffs[3],
+                                  coeffs[4], coeffs[5], coeffs[6], coeffs[7]);
+  }
+  return rc;
 }
 
 /**
  * @brief Send a message through an encrypted channel with authentication.
  */
 int lattice_send(lattice_channel_t *chan, const void *buf, size_t len) {
-    if (!chan || !buf || len == 0)
-        return -1;
+  if (!chan || !buf || len == 0)
+    return -1;
 
-    uint8_t *enc = malloc(len + 32); /* Extra space for auth tag */
-    if (!enc)
-        return -1;
+  uint8_t *enc = malloc(len + 32); /* Extra space for auth tag */
+  if (!enc)
+    return -1;
 
-    /* Compute HMAC for authentication */
-    uint8_t auth_tag[32];
-    simple_sha256((const uint8_t *)buf, len, auth_tag);
-    
-    /* Mix in channel key for authentication */
-    for (size_t i = 0; i < 32; i++) {
-        auth_tag[i] ^= chan->key.sig_data[i % LATTICE_SIG_BYTES];
+  /* Compute HMAC for authentication */
+  uint8_t auth_tag[32];
+  simple_sha256((const uint8_t *)buf, len, auth_tag);
+
+  /* Mix in channel key for authentication */
+  for (size_t i = 0; i < 32; i++) {
+    auth_tag[i] ^= chan->key.sig_data[i % LATTICE_SIG_BYTES];
+  }
+
+  /* Encrypt the message */
+  xor_crypt(enc, buf, len, &chan->key);
+
+  /* Append authentication tag */
+  memcpy(enc + len, auth_tag, 32);
+
+  int ret = -1;
+  WITH_QLOCK(&chan->lock) {
+    ret = exo_send(chan->cap, enc, len + 32);
+    if (ret == (int)(len + 32)) {
+      atomic_fetch_add_explicit(&chan->seq, 1, memory_order_relaxed);
+      ret = len; /* Return original message length */
     }
+  }
 
-    /* Encrypt the message */
-    xor_crypt(enc, buf, len, &chan->key);
-    
-    /* Append authentication tag */
-    memcpy(enc + len, auth_tag, 32);
-
-    int ret = -1;
-    WITH_QLOCK(&chan->lock) {
-        ret = exo_send(chan->cap, enc, len + 32);
-        if (ret == (int)(len + 32)) {
-            atomic_fetch_add_explicit(&chan->seq, 1, memory_order_relaxed);
-            ret = len; /* Return original message length */
-        }
-    }
-
-    /* Clear sensitive data */
-    cap_secure_clear(enc, len + 32);
-    cap_secure_clear(auth_tag, sizeof(auth_tag));
-    free(enc);
-    return ret;
+  /* Clear sensitive data */
+  cap_secure_clear(enc, len + 32);
+  cap_secure_clear(auth_tag, sizeof(auth_tag));
+  free(enc);
+  return ret;
 }
 
 /**
  * @brief Receive a message and decrypt it.
  */
 int lattice_recv(lattice_channel_t *chan, void *buf, size_t len) {
-    if (!chan || !buf || len == 0)
-        return -1;
+  if (!chan || !buf || len == 0)
+    return -1;
 
-    uint8_t *enc = malloc(len + 32); /* Space for message + auth tag */
-    if (!enc)
-        return -1;
+  uint8_t *enc = malloc(len + 32); /* Space for message + auth tag */
+  if (!enc)
+    return -1;
 
-    int ret = -1;
-    WITH_QLOCK(&chan->lock) {
-        ret = exo_recv(chan->cap, enc, len + 32);
-        if (ret == (int)(len + 32)) {
-            /* Decrypt the message */
-            xor_crypt(buf, enc, len, &chan->key);
-            
-            /* Verify authentication tag */
-            uint8_t expected_auth[32];
-            simple_sha256((const uint8_t *)buf, len, expected_auth);
-            
-            /* Mix in channel key for authentication */
-            for (size_t i = 0; i < 32; i++) {
-                expected_auth[i] ^= chan->key.sig_data[i % LATTICE_SIG_BYTES];
-            }
-            
-            /* Compare auth tags in constant time */
-            if (hmac_verify_constant_time(expected_auth, enc + len, 32)) {
-                atomic_fetch_add_explicit(&chan->seq, 1, memory_order_relaxed);
-                ret = len; /* Return original message length */
-            } else {
-                /* Authentication failed - clear decrypted data */
-                cap_secure_clear(buf, len);
-                ret = -2; /* Authentication error */
-            }
-            
-            cap_secure_clear(expected_auth, sizeof(expected_auth));
-        }
+  int ret = -1;
+  WITH_QLOCK(&chan->lock) {
+    ret = exo_recv(chan->cap, enc, len + 32);
+    if (ret == (int)(len + 32)) {
+      /* Decrypt the message */
+      xor_crypt(buf, enc, len, &chan->key);
+
+      /* Verify authentication tag */
+      uint8_t expected_auth[32];
+      simple_sha256((const uint8_t *)buf, len, expected_auth);
+
+      /* Mix in channel key for authentication */
+      for (size_t i = 0; i < 32; i++) {
+        expected_auth[i] ^= chan->key.sig_data[i % LATTICE_SIG_BYTES];
+      }
+
+      /* Compare auth tags in constant time */
+      if (hmac_verify_constant_time(expected_auth, enc + len, 32)) {
+        atomic_fetch_add_explicit(&chan->seq, 1, memory_order_relaxed);
+        ret = len; /* Return original message length */
+      } else {
+        /* Authentication failed - clear decrypted data */
+        cap_secure_clear(buf, len);
+        ret = -2; /* Authentication error */
+      }
+
+      cap_secure_clear(expected_auth, sizeof(expected_auth));
     }
+  }
 
-    /* Clear sensitive data */
-    cap_secure_clear(enc, len + 32);
-    free(enc);
-    return ret;
+  /* Clear sensitive data */
+  cap_secure_clear(enc, len + 32);
+  free(enc);
+  return ret;
 }
 
 /**
  * @brief Close the channel and erase its state securely.
  */
 void lattice_close(lattice_channel_t *chan) {
-    if (!chan)
-        return;
+  if (!chan)
+    return;
 
-    WITH_QLOCK(&chan->lock) {
-        chan->cap = (exo_cap){0};
-        atomic_store_explicit(&chan->seq, 0, memory_order_relaxed);
-        
-        /* Securely clear cryptographic material */
-        cap_secure_clear(&chan->key, sizeof chan->key);
-        cap_secure_clear(&chan->token, sizeof chan->token);
-        cap_secure_clear(&chan->pub, sizeof chan->pub);
-        cap_secure_clear(&chan->priv, sizeof chan->priv);
-        
-        memset(&chan->dag, 0, sizeof chan->dag);
-    }
+  WITH_QLOCK(&chan->lock) {
+    chan->cap = (exo_cap){0};
+    atomic_store_explicit(&chan->seq, 0, memory_order_relaxed);
+
+    /* Securely clear cryptographic material */
+    cap_secure_clear(&chan->key, sizeof chan->key);
+    cap_secure_clear(&chan->token, sizeof chan->token);
+    cap_secure_clear(&chan->pub, sizeof chan->pub);
+    cap_secure_clear(&chan->priv, sizeof chan->priv);
+
+    memset(&chan->dag, 0, sizeof chan->dag);
+  }
 }
 
 /**
  * @brief Yield control to the peer endpoint associated with the channel.
  */
 int lattice_yield_to(const lattice_channel_t *chan) {
-    if (!chan)
-        return -1;
+  if (!chan)
+    return -1;
 
-    exo_cap dest;
-    WITH_QLOCK((quaternion_spinlock_t *)&chan->lock) {
-        dest = chan->cap;
-    }
-    return cap_yield_to_cap(dest);
+  exo_cap dest;
+  WITH_QLOCK((quaternion_spinlock_t *)&chan->lock) { dest = chan->cap; }
+  return cap_yield_to_cap(dest);
 }
 
 /**
@@ -224,16 +226,16 @@ int lattice_yield_to(const lattice_channel_t *chan) {
  */
 int lattice_channel_add_dep(lattice_channel_t *parent,
                             lattice_channel_t *child) {
-    if (!parent || !child)
-        return -1;
-    return dag_add_edge(&parent->dag, &child->dag);
+  if (!parent || !child)
+    return -1;
+  return dag_add_edge(&parent->dag, &child->dag);
 }
 
 /**
  * @brief Submit a lattice channel’s DAG node for scheduling.
  */
 int lattice_channel_submit(lattice_channel_t *chan) {
-    if (!chan)
-        return -1;
-    return dag_sched_submit(&chan->dag);
+  if (!chan)
+    return -1;
+  return dag_sched_submit(&chan->dag);
 }

--- a/libos/ulib.h
+++ b/libos/ulib.h
@@ -1,0 +1,6 @@
+#pragma once
+#include "user.h"
+/**
+ * @file ulib.h
+ * @brief Thin wrapper exposing user-level allocation routines to the libOS.
+ */

--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -104,13 +104,13 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/x86/modern")
 endif()
 
 # ARM Support
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/arm")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "arm" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/arm")
     file(GLOB ARM_SOURCES arm/*.c)
     if(ARM_SOURCES)
         phoenix_add_library(phoenix-arch-arm
             STATIC
             SOURCES ${ARM_SOURCES}
-            INCLUDES 
+            INCLUDES
                 ${CMAKE_CURRENT_SOURCE_DIR}/arm
                 ${CMAKE_SOURCE_DIR}/include
             DEPENDENCIES phoenix-simd
@@ -119,13 +119,13 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/arm")
 endif()
 
 # AArch64 Support
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aarch64")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aarch64")
     file(GLOB AARCH64_SOURCES aarch64/*.c)
     if(AARCH64_SOURCES)
         phoenix_add_library(phoenix-arch-aarch64
             STATIC
             SOURCES ${AARCH64_SOURCES}
-            INCLUDES 
+            INCLUDES
                 ${CMAKE_CURRENT_SOURCE_DIR}/aarch64
                 ${CMAKE_SOURCE_DIR}/include
             DEPENDENCIES phoenix-simd
@@ -134,13 +134,13 @@ if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/aarch64")
 endif()
 
 # PowerPC Support
-if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ppc")
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "powerpc|ppc" AND EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/ppc")
     file(GLOB PPC_SOURCES ppc/*.c)
     if(PPC_SOURCES)
         phoenix_add_library(phoenix-arch-ppc
             STATIC
             SOURCES ${PPC_SOURCES}
-            INCLUDES 
+            INCLUDES
                 ${CMAKE_CURRENT_SOURCE_DIR}/ppc
                 ${CMAKE_SOURCE_DIR}/include
             DEPENDENCIES phoenix-simd

--- a/user/CMakeLists.txt
+++ b/user/CMakeLists.txt
@@ -117,8 +117,12 @@ endif()
 # ═════════════════════════════════════════════════════════════════════
 
 # Core user applications
+#
+# The microcontroller-specific "blink" demo relies on MCU headers
+# that are only available when the MCU build option is enabled.  Building it
+# unconditionally causes missing-header failures on hosted builds.  We therefore
+# keep it separate and inject it only when the MCU option is active.
 set(USER_APPS
-    blink
     cat
     echo
     grep
@@ -132,6 +136,11 @@ set(USER_APPS
     wc
     zombie
 )
+
+# Conditionally include MCU demos
+if(MCU)
+    list(INSERT USER_APPS 0 blink)
+endif()
 
 # Build each user application
 foreach(app ${USER_APPS})

--- a/user/caplib.c
+++ b/user/caplib.c
@@ -44,8 +44,8 @@ EXO_NODISCARD int cap_write_disk(exo_blockcap cap, const void *src,
   return exo_write_disk(cap, src, off, n);
 }
 
-extern int cap_revoke_syscall(void);
-int cap_revoke(void) { return cap_revoke_syscall(); }
+extern int cap_revoke_syscall(uint16_t id);
+int cap_revoke(uint16_t id) { return cap_revoke_syscall(id); }
 
 EXO_NODISCARD int cap_send(exo_cap dest, const void *buf, uint64_t len) {
   return exo_send(dest, buf, len);
@@ -64,19 +64,19 @@ EXO_NODISCARD int cap_ipc_echo_demo(void) {
   const char *msg = "ping";
   char buf[5];
   exo_cap cap = {0, 0};
-  
+
   int result = cap_send(cap, msg, 4);
   if (result != 0) {
     printf(2, "caplib echo: send failed\n");
     return result;
   }
-  
+
   result = cap_recv(cap, buf, 4);
   if (result != 0) {
     printf(2, "caplib echo: recv failed\n");
     return result;
   }
-  
+
   buf[4] = '\0';
   printf(1, "caplib echo: %s\n", buf);
   return 0;


### PR DESCRIPTION
## Summary
- Declare user-space system call wrappers and basic libc routines with detailed C23 prototypes
- Include quaternion spinlock and `<stdlib.h>` in lattice IPC to provide locking macro and memory helpers

## Testing
- `shellcheck setup.sh`
- `pre-commit run --files include/user.h kernel/lattice_ipc.c` *(fails: prompts for GitHub credentials)*
- `cmake --build . -- -j$(nproc)` *(fails: unknown type name `pde_t` and missing kernel headers)*
- `pytest` *(20 failed, 20 passed, 3 skipped, 9 xfailed, 1 xpassed; multiple subprocess failures)
- `doxygen docs/Doxyfile` *(warnings: missing `stdint.h` and high graph node counts)*
- `make -C docs/sphinx` *(build succeeded with 9 warnings after installing extensions)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c2562c74833194159793eaff41cb