### PR TITLE
Add safety checks and optimizer tests for Aether NN

### DIFF
--- a/tests/c17/unit/test_aether_nn.c
+++ b/tests/c17/unit/test_aether_nn.c
@@ -36,4 +36,72 @@ TEST(aether_nn_basic) {
   TEST_ASSERT(yhat <= 1.0f);
 }
 
-TEST_MAIN("aether_nn", test_aether_nn_basic);
+TEST(aether_nn_optimizers) {
+  enum { ARENA_BYTES = 64 * 1024 };
+  unsigned char buf[ARENA_BYTES];
+  ann_Arena arena;
+  ann_arena_init(&arena, buf, ARENA_BYTES);
+  ann_XRand rng = {.s = 2};
+
+  /* Momentum optimizer initialisation and edge cases */
+  ann_Dense Lm = ann_dense_new(&arena, 1, 1, &rng);
+  ann_Optim mom = {
+      .kind = ANN_OPT_MOMENTUM,
+      .lr = 0.01f,
+      .l2 = 0.0f,
+      .mu = 0.9f,
+      .t = 0,
+  };
+  ann_dense_opt_prepare(&arena, &Lm, &mom);
+  TEST_ASSERT_NOT_NULL(Lm.momW);
+  TEST_ASSERT_NOT_NULL(Lm.momB);
+  TEST_ASSERT(fabsf(Lm.momW[0]) < 1e-6f);
+  TEST_ASSERT(fabsf(Lm.momB[0]) < 1e-6f);
+
+  mom.lr = 0.0f;
+  ann_Tensor x = ann_tensor_new(&arena, 1);
+  x.data[0] = 1.0f;
+  ann_f32 w_before = Lm.W[0];
+  ann_dense_train_logistic(&Lm, x, 1.0f, &mom);
+  TEST_ASSERT(fabsf(Lm.W[0] - w_before) < 1e-6f);
+
+  mom.lr = 0.1f;
+  x.data[0] = 1e6f;
+  ann_dense_train_logistic(&Lm, x, 0.0f, &mom);
+  TEST_ASSERT(isfinite(Lm.W[0]));
+
+  /* Adam optimizer initialisation and edge cases */
+  ann_Dense La = ann_dense_new(&arena, 1, 1, &rng);
+  ann_Optim adam = {
+      .kind = ANN_OPT_ADAM,
+      .lr = 0.001f,
+      .l2 = 0.0f,
+      .beta1 = 0.9f,
+      .beta2 = 0.999f,
+      .eps = 1e-8f,
+      .t = 0,
+  };
+  ann_dense_opt_prepare(&arena, &La, &adam);
+  TEST_ASSERT_NOT_NULL(La.mW);
+  TEST_ASSERT_NOT_NULL(La.vW);
+  TEST_ASSERT_NOT_NULL(La.mB);
+  TEST_ASSERT_NOT_NULL(La.vB);
+  TEST_ASSERT(fabsf(La.mW[0]) < 1e-6f);
+  TEST_ASSERT(fabsf(La.vW[0]) < 1e-6f);
+  TEST_ASSERT(fabsf(La.mB[0]) < 1e-6f);
+  TEST_ASSERT(fabsf(La.vB[0]) < 1e-6f);
+
+  adam.lr = 0.0f;
+  ann_Tensor xa = ann_tensor_new(&arena, 1);
+  xa.data[0] = 1.0f;
+  w_before = La.W[0];
+  ann_dense_train_logistic(&La, xa, 1.0f, &adam);
+  TEST_ASSERT(fabsf(La.W[0] - w_before) < 1e-6f);
+
+  adam.lr = 0.01f;
+  xa.data[0] = 1e6f;
+  ann_dense_train_logistic(&La, xa, 0.0f, &adam);
+  TEST_ASSERT(isfinite(La.W[0]));
+}
+
+TEST_MAIN("aether_nn", test_aether_nn_basic, test_aether_nn_optimizers);


### PR DESCRIPTION
## Summary
- Guard tensor copies with size checks and safer bounds handling
- Handle zero-class softmax and allocation failures in training
- Add unit tests exercising momentum and Adam optimizers

## Testing
- `cc -std=c17 -Wall -Werror -I../tests/c17 -I../include -I../kernel -I../libos ../tests/c17/test_framework.c ../tests/c17/unit/test_aether_nn.c ../libos/aether_nn.c -lm -o test_aether_nn && ./test_aether_nn`

------
https://chatgpt.com/codex/tasks/task_e_68c0c77c3aa88331902177c923d15c61